### PR TITLE
Switch `%CLIENT_MAJOR_VERSION%` in /login endpoint for current /login version

### DIFF
--- a/content/application-service-api.md
+++ b/content/application-service-api.md
@@ -342,7 +342,7 @@ log in without needing the user's password. This is achieved by including the
 
 {{% added-in v="1.2" %}}
 
-    POST /_matrix/client/%CLIENT_MAJOR_VERSION%/login
+    POST /_matrix/client/v3/login
     Authorization: Bearer YourApplicationServiceTokenHere
 
     Content:


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-spec/issues/799

This was left over from the days of all CS API endpoints sharing the same major spec release version. `/login` now has its own endpoint version.

<!-- Replace -->
Preview: https://pr980--matrix-spec-previews.netlify.app
<!-- Replace -->
