### PR TITLE
Replace deprecated Page.Dir with Page.File.Dir

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -107,7 +107,7 @@ jobs:
       - name: "➕ Setup Hugo"
         uses: peaceiris/actions-hugo@c03b5dbed22245418539b65eb9a3b1d5fdd9a0a6
         with:
-          hugo-version: '0.85.0'
+          hugo-version: '0.93.3'
           extended: true
       - name: "📥 Source checkout"
         uses: actions/checkout@v2
@@ -153,7 +153,7 @@ jobs:
       - name: "➕ Setup Hugo"
         uses: peaceiris/actions-hugo@c03b5dbed22245418539b65eb9a3b1d5fdd9a0a6
         with:
-          hugo-version: '0.85.0'
+          hugo-version: '0.93.3'
           extended: true
       - name: "📥 Source checkout"
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ place after an MSC has been accepted, not as part of a proposal itself.
 
 1. Install the extended version (often the OS default) of Hugo:
    <https://gohugo.io/getting-started/installing>. Note that at least Hugo
-   v0.74 is required.
+   v0.93.0 is required.
 
    Alternatively, use the Docker image at
    https://hub.docker.com/r/klakegg/hugo/. (The "extended edition" is required

--- a/layouts/shortcodes/cs-module.html
+++ b/layouts/shortcodes/cs-module.html
@@ -9,5 +9,5 @@
 
 {{ $name := .Params.name }}
 
-{{ $page := .Site.GetPage (path.Join .Page.Dir "modules" (printf "%s%s" $name ".md"))}}
+{{ $page := .Site.GetPage (path.Join .Page.File.Dir "modules" (printf "%s%s" $name ".md"))}}
 {{ $page.Content }}

--- a/layouts/shortcodes/rver-fragment.html
+++ b/layouts/shortcodes/rver-fragment.html
@@ -17,7 +17,7 @@
 {{ $name := .Params.name }}
 {{ $withVersioning := .Params.withVersioning }}
 
-{{ $page := .Site.GetPage (path.Join .Page.Dir "fragments" (printf "%s%s" $name ".md"))}}
+{{ $page := .Site.GetPage (path.Join .Page.File.Dir "fragments" (printf "%s%s" $name ".md"))}}
 {{ $content := $page.Content }}
 {{ if not $withVersioning }}
     {{ $content = (replace $content "[New in this version]" "") }}


### PR DESCRIPTION
Fixes #986 (which has a bit more context).

`Page.Dir` has been deprecated for a while, calling them raised an error in [hugo v0.92.0](https://github.com/gohugoio/hugo/releases/tag/v0.92.0), before it was finally removed in [hugo v0.93.0](https://github.com/gohugoio/hugo/releases/tag/v0.93.0).

This commit replaces instances of `Page.Dir` with [`Page.File.Dir`](https://gohugo.io/variables/files/).

<!-- Replace -->
Preview: https://pr988--matrix-spec-previews.netlify.app
<!-- Replace -->
