### PR TITLE
GHA job to check newsfragments.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,18 @@ jobs:
         run: |
           /env/bin/python scripts/check-event-schema-examples.py
 
+  check-newsfragments:
+    name: "🔎 Check that new newsfragments are valid"
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - run: scripts/check-newsfragments
+        env:
+          PULL_REQUEST_NUMBER: ${{ github.event.number }}
+        
   calculate-baseurl:
     name: "⚙️ Calculate baseURL for later jobs"
     runs-on: ubuntu-latest

--- a/scripts/check-newsfragments
+++ b/scripts/check-newsfragments
@@ -7,7 +7,6 @@ pr="$PULL_REQUEST_NUMBER"
 
 echo -e "+++ \033[32mChecking newsfragments for PR #$pr\033[m"
 
-set -e
 
 failed=0
 matched=0
@@ -28,7 +27,6 @@ find changelogs -regex '.*/[0-9]+\.[^/]+$' | while read f; do
         [[ -n "$pr" && "$basename" == "$pr".* ]] && matched=1
     fi
 done
-
 
 if [[ -n "$pr" && "$matched" -eq 0 ]]; then
     echo -e "\e[31mERROR: Did not find a news fragment with the right number: expected changelogs/*/newsfragments/$pr.*\e[39m" >&2

--- a/scripts/check-newsfragments
+++ b/scripts/check-newsfragments
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# A script which checks that an appropriate news file has been added on this
+# branch.
+
+pr="$PULL_REQUEST_NUMBER"
+
+echo -e "+++ \033[32mChecking newsfragments for PR #$pr\033[m"
+
+set -e
+
+failed=0
+matched=0
+
+# assume that anything in the changelogs directory which starts with a number
+# is intended as a newsfile.
+find changelogs -regex '.*/[0-9]+\.[^/]+$' | while read f; do
+    basename=$(basename $f)
+    dirname=$(dirname $f)
+
+    # check that there is nothing that looks like a newsfile outside one of the
+    # expected directories.
+    if [[ "$dirname" != changelogs/*/newsfragments ]]; then
+        echo -e "\e[31mERROR: newsfragment $f appears to be in the wrong directory: should be in changelogs/*/newsfragments\e[39m" >&2
+        failed=1
+    else
+        # see if this newsfile corresponds to the right PR
+        [[ -n "$pr" && "$basename" == "$pr".* ]] && matched=1
+    fi
+done
+
+
+if [[ -n "$pr" && "$matched" -eq 0 ]]; then
+    echo -e "\e[31mERROR: Did not find a news fragment with the right number: expected changelogs/*/newsfragments/$pr.*\e[39m" >&2
+    failed=1
+fi
+
+exit $failed


### PR DESCRIPTION
Having just found another *three* newsfragments in the wrong places, I cracked and wrote a CI job to check.

Ironically, this PR is failing CI, because it doesn't have a changelog. That doesn't happen very often, so I'm inclined to ignore it, but I'm open to suggestions for ways to flag/detect PRs that don't need a changelog.