### PR TITLE
Add missing object type to openapi client event

### DIFF
--- a/data/api/client-server/definitions/client_event.yaml
+++ b/data/api/client-server/definitions/client_event.yaml
@@ -19,7 +19,8 @@ description: |-
 type: object
 allOf:
   - $ref: "client_event_without_room_id.yaml"
-  - properties:
+  - type: object
+    properties:
       room_id:
         description: The ID of the room associated with this event.
         type: string


### PR DESCRIPTION
Signed-off-by: Nicolas Werner <n.werner@famedly.com>

Not sure if this needs a news fragment, since this is fairly trivial and just changes one line in the openapi stuff. This is also how it is done everywhere else in the openapi spec, so I assume it just was missed.