### PR TITLE
Correct title location in login flow definition

### DIFF
--- a/changelogs/client_server/newsfragments/1003.clarification
+++ b/changelogs/client_server/newsfragments/1003.clarification
@@ -1,0 +1,1 @@
+Adjust the OpenAPI specification so that the type `Flow information` is explicitly defined when the CS spec is rendered.

--- a/data/api/client-server/definitions/auth_response.yaml
+++ b/data/api/client-server/definitions/auth_response.yaml
@@ -18,10 +18,10 @@ type: object
 properties:
   flows:
     description: A list of the login flows supported by the server for this API.
-    title: Flow information
     type: array
     items:
       type: object
+      title: Flow information
       properties:
         stages:
           description: |-


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-spec/issues/1000.

Before: ![](https://user-images.githubusercontent.com/8614563/159905006-899b1d0e-e796-4129-a625-a730675b6ac0.png)

After: ![Screenshot from 2022-03-25 15-21-27](https://user-images.githubusercontent.com/8614563/160149904-55f12c1d-eb28-4bd8-9c38-3193524086af.png)

Note that `flows` is now defined as a `[Flow information]` list, rather than a `Flow information` itself. I think this is clearer (and besides, I wasn't convinced that the hugo templating machinery handles a type alias for an array correctly.)
