### PR TITLE
Fix `x-changedInMatrixVersion` for API parameters

### DIFF
--- a/layouts/partials/openapi/render-parameters.html
+++ b/layouts/partials/openapi/render-parameters.html
@@ -18,10 +18,10 @@
 
 {{ with $parameters_of_type }}
 
-    {{/* convert parameters into the format that render-object-table expects to see */}}
+    {{/* build a dict mapping from name->parameter, which render-object-table expects */}}
     {{ $param_dict := dict }}
     {{ range $parameter := . }}
-        {{ $param_dict = merge $param_dict (dict $parameter.name (dict "type" $parameter.type "description" $parameter.description "required" $parameter.required "enum" $parameter.enum)  )}}
+        {{ $param_dict = merge $param_dict (dict $parameter.name $parameter )}}
     {{ end }}
 
     {{/* and render the parameters */}}


### PR DESCRIPTION
#1002 adds an `x-changedInMatrixVersion` dict for a query param, but it's not currently working. Turns out we're not passing the full dict through to the right template.