### PR TITLE
Style tweak for API rendering

### DIFF
--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -259,10 +259,13 @@ footer {
   margin: 1rem 0 3rem 0;
 
   details {
-
     summary {
       padding: .5rem 0;
       list-style-position: outside;
+
+      p {
+        max-width: 80%;
+      }
     }
   }
 
@@ -303,10 +306,6 @@ footer {
   hr {
     border-bottom: 2px solid $dark;
     margin-bottom: 1.5rem;
-  }
-
-  p {
-    max-width: 80%;
   }
 
   p code, table code {


### PR DESCRIPTION
Tighter bound on the `max-width` property for paragraphs inside rendered APIs. AFAICT it's only meant to apply to the summary.

Sometimes we end up with a `<p>` in the descriptions of parameters or response fields, and capping it to 80% of the table cell looks inconsitent (and is unnecessarily narrow).