### PR TITLE
Update the 'unstable' copy of the site every night at 2am UTC

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,10 @@ on:
       - v*
   pull_request:
   workflow_dispatch:
+  schedule:
+    # Run this workflow every day at 2am. This helps keep the page of
+    # current spec proposals up-to-date.
+    - cron: '0 2 * * *'
 
 jobs:
   validate-openapi:

--- a/scripts/proposals.js
+++ b/scripts/proposals.js
@@ -98,7 +98,7 @@ async function getIssues() {
     return null;
   }
 
-  let pageLink = "https://api.github.com/repos/matrix-org/matrix-doc/issues?state=all&labels=proposal&per_page=100";
+  let pageLink = "https://api.github.com/repos/matrix-org/matrix-spec-proposals/issues?state=all&labels=proposal&per_page=100";
   while (pageLink) {
     const response = await fetch(pageLink);
     const issuesForPage = await response.json();


### PR DESCRIPTION
We used to have a buildkite job that run rebuild matrix.org, and thus the old matrix.org/spec site, nightly. That was lost in the move to the new spec site.

This is mostly fine, as new changes to the site will be built and deployed whenever a spec PR is merged. However, when there is a lull in changes, pages such as https://spec.matrix.org/unstable/proposals/ can become out of date quite quickly.

This PR simply schedules the 'main' workflow to run every night at 2am UTC, mostly so that the proposals page can stay relatively up to date. I also fixed an instance of the old name for the github.com/matrix-org/matrix-spec-proposals repo (the script was still working with the old name however, due to github redirects).