### PR TITLE
Fix origin server name in S2S Request Authentication example.

### DIFF
--- a/changelogs/server_server/newsfragments/1038.clarification
+++ b/changelogs/server_server/newsfragments/1038.clarification
@@ -1,0 +1,1 @@
+Fix origin server name in S2S Request Authentication example.

--- a/content/server-server-api.md
+++ b/content/server-server-api.md
@@ -255,7 +255,7 @@ condition applies throughout the request signing process.
 Step 2 add Authorization header:
 
     GET /target HTTP/1.1
-    Authorization: X-Matrix origin=origin.example.com,key="ed25519:key1",sig="ABCDEF..."
+    Authorization: X-Matrix origin=origin.hs.example.com,key="ed25519:key1",sig="ABCDEF..."
     Content-Type: application/json
 
     <JSON-encoded request body>


### PR DESCRIPTION
The JSON payload listed a different origin HS name from the one mentioned in the Authorization header.

<!-- Replace -->
Preview: https://pr1038--matrix-spec-previews.netlify.app
<!-- Replace -->
