### PR TITLE
Use A(E) and B(E) for state after/before events

### DIFF
--- a/changelogs/room_versions/newsfragments/1040.clarification
+++ b/changelogs/room_versions/newsfragments/1040.clarification
@@ -1,0 +1,1 @@
+Adjust state resolution notation to be easier to read in a browser.

--- a/content/rooms/fragments/v2-state-res.md
+++ b/content/rooms/fragments/v2-state-res.md
@@ -2,17 +2,17 @@
 toc_hide: true
 ---
 
-The room state *S*′(*E*) after an event *E* is defined in terms of the
-room state *S*(*E*) before *E*, and depends on whether *E* is a state
+The room state *A*(*E*) after an event *E* is defined in terms of the
+room state *B*(*E*) before *E*, and depends on whether *E* is a state
 event or a message event:
 
--   If *E* is a message event, then *S*′(*E*) = *S*(*E*).
--   If *E* is a state event, then *S*′(*E*) is *S*(*E*), except that its
+-   If *E* is a message event, then *A*(*E*) = *B*(*E*).
+-   If *E* is a state event, then *A*(*E*) is *B*(*E*), except that its
     entry corresponding to *E*'s `event_type` and `state_key` is
     replaced by *E*'s `event_id`.
 
-The room state *S*(*E*) before *E* is the *resolution* of the set of
-states {*S*′(*E*<sub>1</sub>), *S*′(*E*<sub>2</sub>), …} consisting of
+The room state *B*(*E*) before *E* is the *resolution* of the set of
+states {*A*(*E*<sub>1</sub>), *A*(*E*<sub>2</sub>), …} consisting of
 the states after each of *E*'s `prev_event`s
 {*E*<sub>1</sub>, *E*<sub>2</sub>, …}, where the resolution of a set of
 states is given in the algorithm below.

--- a/content/rooms/v1.md
+++ b/content/rooms/v1.md
@@ -66,17 +66,17 @@ This is fixed in the state resolution algorithm introduced in room
 version 2.
 {{% /boxes/warning %}}
 
-The room state *S*′(*E*) after an event *E* is defined in terms of the
-room state *S*(*E*) before *E*, and depends on whether *E* is a state
+The room state *A*(*E*) after an event *E* is defined in terms of the
+room state *B*(*E*) before *E*, and depends on whether *E* is a state
 event or a message event:
 
--   If *E* is a message event, then *S*′(*E*) = *S*(*E*).
--   If *E* is a state event, then *S*′(*E*) is *S*(*E*), except that its
+-   If *E* is a message event, then *A*(*E*) = *B*(*E*).
+-   If *E* is a state event, then *A*(*E*) is *B*(*E*), except that its
     entry corresponding to *E*'s `event_type` and `state_key` is
     replaced by *E*'s `event_id`.
 
-The room state *S*(*E*) before *E* is the *resolution* of the set of
-states {*S*′(*E*′), *S*′(*E*″), …} consisting of the states after each
+The room state *B*(*E*) before *E* is the *resolution* of the set of
+states {*A*(*E*′), *A*(*E*″), …} consisting of the states after each
 of *E*'s `prev_event`s {*E*′, *E*″, …}.
 
 The *resolution* of a set of states is defined as follows. The resolved


### PR DESCRIPTION
A suggestion to mitigate #774.

<!-- Replace -->
Preview: https://pr1040--matrix-spec-previews.netlify.app
<!-- Replace -->
