### PR TITLE
Italicise primes and brackets in state res desc

### DIFF
--- a/changelogs/room_versions/newsfragments/1043.clarification
+++ b/changelogs/room_versions/newsfragments/1043.clarification
@@ -1,0 +1,1 @@
+Adjust mathematical notation used in the description of state resolution to render better in browsers.

--- a/content/rooms/fragments/v2-state-res.md
+++ b/content/rooms/fragments/v2-state-res.md
@@ -2,20 +2,19 @@
 toc_hide: true
 ---
 
-The room state *S*′(*E*) after an event *E* is defined in terms of the
-room state *S*(*E*) before *E*, and depends on whether *E* is a state
+The room state *S′(E)* after an event *E* is defined in terms of the
+room state *S(E)* before *E*, and depends on whether *E* is a state
 event or a message event:
 
--   If *E* is a message event, then *S*′(*E*) = *S*(*E*).
--   If *E* is a state event, then *S*′(*E*) is *S*(*E*), except that its
-    entry corresponding to *E*'s `event_type` and `state_key` is
-    replaced by *E*'s `event_id`.
+-   If *E* is a message event, then *S′(E)* = *S(E)*.
+-   If *E* is a state event, then *S′(E)* is *S(E)*, except that its
+    entry corresponding to the `event_type` and `state_key` of *E* is
+    replaced by the `event_id` of *E*.
 
-The room state *S*(*E*) before *E* is the *resolution* of the set of
-states {*S*′(*E*<sub>1</sub>), *S*′(*E*<sub>2</sub>), …} consisting of
-the states after each of *E*'s `prev_event`s
-{*E*<sub>1</sub>, *E*<sub>2</sub>, …}, where the resolution of a set of
-states is given in the algorithm below.
+The room state *S(E)* before *E* is the *resolution* of the set of
+states {*S′(E*<sub>1</sub>*)*, *S′(E*<sub>2</sub>*)*, …}
+after the `prev_event`s {*E*<sub>1</sub>, *E*<sub>2</sub>, …} of *E*.
+The resolution of a set of states is given in the algorithm below.
 
 #### Definitions
 

--- a/content/rooms/v1.md
+++ b/content/rooms/v1.md
@@ -66,18 +66,18 @@ This is fixed in the state resolution algorithm introduced in room
 version 2.
 {{% /boxes/warning %}}
 
-The room state *S*′(*E*) after an event *E* is defined in terms of the
+The room state *S′*(*E*) after an event *E* is defined in terms of the
 room state *S*(*E*) before *E*, and depends on whether *E* is a state
 event or a message event:
 
--   If *E* is a message event, then *S*′(*E*) = *S*(*E*).
--   If *E* is a state event, then *S*′(*E*) is *S*(*E*), except that its
-    entry corresponding to *E*'s `event_type` and `state_key` is
-    replaced by *E*'s `event_id`.
+-   If *E* is a message event, then *S′(E)* = *S(E)*.
+-   If *E* is a state event, then *S′(E)* is *S(E)*, except that its
+    entry corresponding to the `event_type` and `state_key` of *E* is
+    replaced by the `event_id` of *E*.
 
-The room state *S*(*E*) before *E* is the *resolution* of the set of
-states {*S*′(*E*′), *S*′(*E*″), …} consisting of the states after each
-of *E*'s `prev_event`s {*E*′, *E*″, …}.
+The room state *S(E)* before *E* is the *resolution* of the set of
+states {*S′(E′)*, *S′(E″)*, …} after the `prev_events` {*E′*, *E″*, …}.
+of *E*.
 
 The *resolution* of a set of states is defined as follows. The resolved
 state is built up in a number of passes; here we use *R* to refer to the


### PR DESCRIPTION
I don't like it but it seems to make things look decent in Firefox.
This is probably good enough---we're not Knuth, after all.

To the reviewer: please check that this looks like an improvement for a Chromium-based browser too.

Additionally I have avoided the use of `*E*'s` as in "E's prev_events"
since the apostrophe looks poor here.

Resolves #774.
An alternative to #1040.

<!-- Replace -->
Preview: https://pr1043--matrix-spec-previews.netlify.app
<!-- Replace -->
