### PR TITLE
Fix a few more instances of matrix-doc being used; Fix changelog support for repo split

### DIFF
--- a/changelogs/client_server/newsfragments/1002.feature
+++ b/changelogs/client_server/newsfragments/1002.feature
@@ -1,1 +1,1 @@
-Make `from` optional on `GET /_matrix/client/v3/messages` to allow requesting events from the start or end of the room history, as per [MSC3567](https://github.com/matrix-org/matrix-doc/pull/3567).
+Make `from` optional on `GET /_matrix/client/v3/messages` to allow requesting events from the start or end of the room history, as per [MSC3567](https://github.com/matrix-org/matrix-spec-proposals/pull/3567).

--- a/changelogs/client_server/newsfragments/1051.clarification
+++ b/changelogs/client_server/newsfragments/1051.clarification
@@ -1,0 +1,1 @@
+Fix various typos throughout the specification.

--- a/content/client-server-api/_index.md
+++ b/content/client-server-api/_index.md
@@ -1490,7 +1490,7 @@ before using the contents verbatim.
 **It is not safe to assume that an event body will have all the expected
 fields of the expected types.**
 
-See [MSC2801](https://github.com/matrix-org/matrix-doc/pull/2801) for more
+See [MSC2801](https://github.com/matrix-org/matrix-spec-proposals/pull/2801) for more
 detail on why this assumption is unsafe.
 {{% /boxes/warning %}}
 

--- a/content/client-server-api/modules/instant_messaging.md
+++ b/content/client-server-api/modules/instant_messaging.md
@@ -102,7 +102,7 @@ the tag entirely.
 {{% boxes/note %}}
 A future iteration of the specification will support more powerful and
 extensible message formatting options, such as the proposal
-[MSC1767](https://github.com/matrix-org/matrix-doc/pull/1767).
+[MSC1767](https://github.com/matrix-org/matrix-spec-proposals/pull/1767).
 {{% /boxes/note %}}
 
 {{% msgtypes %}}

--- a/content/client-server-api/modules/moderation_policies.md
+++ b/content/client-server-api/modules/moderation_policies.md
@@ -53,7 +53,7 @@ follows:
 -   Is a `room` rule...
     -   Applied to a user: The user should leave the room and not join
         it
-        ([MSC2270](https://github.com/matrix-org/matrix-doc/pull/2270)-style
+        ([MSC2270](https://github.com/matrix-org/matrix-spec-proposals/pull/2270)-style
         ignore).
     -   Applied to a room: No-op because a room cannot ban itself.
     -   Applied to a server: The server should prevent users from
@@ -120,6 +120,6 @@ Depending on how implementations handle subscriptions, user IDs may be
 linked to policy lists and therefore expose the views of that user. For
 example, a client implementation which joins the user to the policy room
 would expose the user's ID to observers of the policy room. In future,
-[MSC1228](https://github.com/matrix-org/matrix-doc/pulls/1228) and
-[MSC1777](https://github.com/matrix-org/matrix-doc/pulls/1777) (or
+[MSC1228](https://github.com/matrix-org/matrix-spec-proposals/pulls/1228) and
+[MSC1777](https://github.com/matrix-org/matrix-spec-proposals/pulls/1777) (or
 similar) could help solve this concern.

--- a/layouts/shortcodes/changelog/changelog-changes.html
+++ b/layouts/shortcodes/changelog/changelog-changes.html
@@ -25,7 +25,7 @@
 
 {{ if ne $status "unstable" }}
 <table class="release-info">
-<tr><th>Git commit</th><td><a href="https://github.com/matrix-org/matrix-doc/tree/{{ $release_tag }}">https://github.com/matrix-org/matrix-doc/tree/{{ $release_tag }}</a></td>
+<tr><th>Git commit</th><td><a href="https://github.com/matrix-org/matrix-spec/tree/{{ $release_tag }}">https://github.com/matrix-org/matrix-spec/tree/{{ $release_tag }}</a></td>
 <tr><th>Release date</th><td>{{ .Site.Params.version.release_date }}</td>
 </table>
 {{ end }}
@@ -79,7 +79,12 @@
 <li>{{.name | safeHTML}}
 <p><ul>
         {{ range $changes_of_type }}
+<!-- TODO: TravisR: Remove after v1.3 release and just use matrix-spec links -->
+{{ if gt .ticket 3000 }}
 <li><a href="https://github.com/matrix-org/matrix-doc/issues/{{.ticket}}"><strong>{{ .ticket }}: </strong></a>{{ .description | markdownify }}</li>
+{{ else }}
+<li><a href="https://github.com/matrix-org/matrix-spec/issues/{{.ticket}}"><strong>{{ .ticket }}: </strong></a>{{ .description | markdownify }}</li>
+{{ end }}
         {{ end }}
 </ul></p>
 </li>


### PR DESCRIPTION
[We split the repo](https://github.com/matrix-org/matrix-spec/issues/927) and that caused a re-numbering of contributions. Some strings were also missed in previous passes of matrix-doc string searching, which has been incorporated here.

After v1.3, we can remove the if-statement added by this change because it shouldn't be needed anymore. I've set a reminder.

<!-- Replace -->
Preview: https://pr1051--matrix-spec-previews.netlify.app
<!-- Replace -->
