### PR TITLE
Clarify that valid_until_ts is in milliseconds, like other timestamps used in Matrix

### DIFF
--- a/changelogs/server_server/newsfragments/1055.clarification
+++ b/changelogs/server_server/newsfragments/1055.clarification
@@ -1,0 +1,1 @@
+Clarify that valid_until_ts is in milliseconds, like other timestamps used in Matrix

--- a/data/api/server-server/definitions/keys.yaml
+++ b/data/api/server-server/definitions/keys.yaml
@@ -88,9 +88,10 @@ properties:
     type: integer
     format: int64
     description: |-
-      POSIX timestamp when the list of valid keys should be refreshed. This field MUST
-      be ignored in room versions 1, 2, 3, and 4. Keys used beyond this timestamp MUST
-      be considered invalid, depending on the [room version specification](/rooms).
+      POSIX timestamp in milliseconds when the list of valid keys should be refreshed.
+      This field MUST be ignored in room versions 1, 2, 3, and 4. Keys used beyond this
+      timestamp MUST be considered invalid, depending on the
+      [room version specification](/rooms).
 
       Servers MUST use the lesser of this field and 7 days into the future when
       determining if a key is valid. This is to avoid a situation where an attacker


### PR DESCRIPTION
Signed-off-by: Valentin Lorentz <progval+git@progval.net>