### PR TITLE
PDU check 5 should consult state before an event

### DIFF
--- a/changelogs/server_server/newsfragments/1070.clarification
+++ b/changelogs/server_server/newsfragments/1070.clarification
@@ -1,0 +1,1 @@
+Clarify that checks on PDUs should refer to the state _before_ an event.

--- a/content/server-server-api.md
+++ b/content/server-server-api.md
@@ -364,7 +364,7 @@ server must ensure that the event:
     further.
 4.  Passes authorization rules based on the event's auth events,
     otherwise it is rejected.
-5.  Passes authorization rules based on the state at the event,
+5.  Passes authorization rules based on the state before the event,
     otherwise it is rejected.
 6.  Passes authorization rules based on the current state of the room,
     otherwise it is "soft failed".


### PR DESCRIPTION
See #1069 for my rationale.

Fixes #1069.

<!-- Replace -->
Preview: https://pr1070--matrix-spec-previews.netlify.app
<!-- Replace -->
