### PR TITLE
Remove broken "token-based" link

### DIFF
--- a/changelogs/client_server/newsfragments/1081.clarification
+++ b/changelogs/client_server/newsfragments/1081.clarification
@@ -1,0 +1,1 @@
+Fix various typos throughout the specification.

--- a/content/client-server-api/_index.md
+++ b/content/client-server-api/_index.md
@@ -1056,8 +1056,8 @@ as follows:
 }
 ```
 
-As with [token-based]() interactive login, the `token` must encode the
-user ID. In the case that the token is not valid, the homeserver must
+The `token` must encode the user ID, since there is no other identifying
+data in the request. In the case that the token is not valid, the homeserver must
 respond with `403 Forbidden` and an error code of `M_FORBIDDEN`.
 
 If the homeserver advertises `m.login.sso` as a viable flow, and the


### PR DESCRIPTION
This used to link to a section in the UIA docs (https://matrix.org/docs/spec/client_server/r0.6.1#token-based), 
but that was removed in 7c6636a5.

<!-- Replace -->
Preview: https://pr1081--matrix-spec-previews.netlify.app
<!-- Replace -->
