### PR TITLE
Clarify that /invite will respond with 200 if the user is already invited to the room

### DIFF
--- a/changelogs/client_server/newsfragments/1084.clarification
+++ b/changelogs/client_server/newsfragments/1084.clarification
@@ -1,1 +1,1 @@
-Mention that the /rooms/$roomId/invite endpoint will return a 200 response if the user is already invited to the room.
+Mention that the `/rooms/{roomId}/invite` endpoint will return a 200 response if the user is already invited to the room.

--- a/changelogs/client_server/newsfragments/1084.clarification
+++ b/changelogs/client_server/newsfragments/1084.clarification
@@ -1,0 +1,1 @@
+Mention that the /rooms/$roomId/invite endpoint will return a 200 response if the user is already invited to the room.

--- a/data/api/client-server/inviting.yaml
+++ b/data/api/client-server/inviting.yaml
@@ -80,7 +80,7 @@ paths:
             required: ["user_id"]
       responses:
         200:
-          description: The user has been invited to join the room.
+          description: The user has been invited to join the room, or was already invited to the room.
           examples:
             application/json: {
               }


### PR DESCRIPTION
Potentially fixes #1083 

I *believe* this might fall within the scope of minor text clarification rather than requiring a full MSC, as it's a behavior that has been in action for a long time (for Synapse at least, and possibly other implementations?). This doesn't seek to correct the response.

<!-- Replace -->
Preview: https://pr1084--matrix-spec-previews.netlify.app
<!-- Replace -->
