### PR TITLE
Some clarifications and style fixes in E2EE-related areas

### DIFF
--- a/changelogs/client_server/newsfragments/1088.clarification
+++ b/changelogs/client_server/newsfragments/1088.clarification
@@ -1,0 +1,1 @@
+Clarifications regarding Megolm session formats and E2EE-related stylistic fixes.

--- a/content/client-server-api/modules/end_to_end_encryption.md
+++ b/content/client-server-api/modules/end_to_end_encryption.md
@@ -1260,7 +1260,7 @@ the following format:
 | Parameter  | Type       | Description                                                                                      |
 | -----------| -----------|--------------------------------------------------------------------------------------------------|
 | public_key | string     | **Required.** The curve25519 public key used to encrypt the backups, encoded in unpadded base64. |
-| signatures | Signatures | Optional. Signatures of the ``auth_data``, as Signed JSON                                        |
+| signatures | Signatures | Optional. Signatures of the ``auth_data``, as Signed JSON.                                       |
 
 The `session_data` field in the backups is constructed as follows:
 
@@ -1269,7 +1269,7 @@ The `session_data` field in the backups is constructed as follows:
 
 | Parameter                       | Type              | Description                                                                                                                                                                 |
 | --------------------------------|-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| algorithm                       | string            | **Required.** The end-to-end message encryption algorithm that the key is for.  Must be `m.megolm.v1.aes-sha2`.                                                             |
+| algorithm                       | string            | **Required.** The end-to-end message encryption algorithm that the key is for. Must be `m.megolm.v1.aes-sha2`.                                                             |
 | forwarding_curve25519_key_chain | [string]          | **Required.** Chain of Curve25519 keys through which this session was forwarded, via [m.forwarded_room_key](#mforwarded_room_key) events.                                   |
 | sender_key                      | string            | **Required.** Unpadded base64-encoded device Curve25519 key.                                                                                                                |
 | sender_claimed_keys             | {string: string}  | **Required.** A map from the algorithm name (`ed25519`) to the corresponding device key of the sending device.                                                              |
@@ -1346,8 +1346,8 @@ objects described as follows:
 
 `SessionData`
 
-| Parameter                         | Type             | Description                                                                                                                           |
-|-----------------------------------|------------------|---------------------------------------------------------------------------------------------------------------------------------------|
+| Parameter                         | Type             | Description                                                                                                                               |
+|-----------------------------------|------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
 | algorithm                         | string           | **Required.** The encryption algorithm that the session uses. Must be `m.megolm.v1.aes-sha2`.                                             |
 | forwarding_curve25519_key_chain   | [string]         | **Required.** Chain of Curve25519 keys through which this session was forwarded, via [m.forwarded_room_key](#mforwarded_room_key) events. |
 | room_id                           | string           | **Required.** The room where the session is used.                                                                                         |

--- a/content/client-server-api/modules/end_to_end_encryption.md
+++ b/content/client-server-api/modules/end_to_end_encryption.md
@@ -1372,7 +1372,7 @@ Example:
         "room_id": "!Cuyf34gef24t:localhost",
         "sender_key": "RF3s+E7RkTQTGF2d8Deol0FkQvgII2aJDf3/Jp5mxVU",
         "sender_claimed_keys": {
-            "ed25519": "<device ed25519 identity key>",
+            "ed25519": "<device ed25519 key>",
         },
         "session_id": "X3lUlvLELLYxeTx4yOVu6UDpasGEVO0Jbu+QFnm0cKQ",
         "session_key": "AgAAAADxKHa9uFxcXzwYoNueL5Xqi69IkD4sni8Llf..."

--- a/content/client-server-api/modules/end_to_end_encryption.md
+++ b/content/client-server-api/modules/end_to_end_encryption.md
@@ -1257,10 +1257,10 @@ the following format:
 
 `AuthData`
 
-| Parameter  | Type       | Description                                                                                      |
-| -----------| -----------|--------------------------------------------------------------------------------------------------|
-| public_key | string     | **Required.** The curve25519 public key used to encrypt the backups, encoded in unpadded base64. |
-| signatures | Signatures | Optional. Signatures of the ``auth_data``, as Signed JSON.                                       |
+| Parameter  | Type       | Description                                                                                                           |
+| -----------| -----------|-----------------------------------------------------------------------------------------------------------------------|
+| public_key | string     | **Required.** The curve25519 public key used to encrypt the backups, encoded in unpadded base64.                      |
+| signatures | Signatures | *Optional.* Signatures of the ``auth_data``. The signature is calculated using the process described at Signing JSON. |
 
 The `session_data` field in the backups is constructed as follows:
 

--- a/content/client-server-api/modules/end_to_end_encryption.md
+++ b/content/client-server-api/modules/end_to_end_encryption.md
@@ -1498,9 +1498,9 @@ should use the session from which it last received and successfully
 decrypted a message. For these purposes, a session that has not received
 any messages should use its creation time as the time that it last
 received a message. A client may expire old sessions by defining a
-maximum number of olm sessions that it will maintain for each device,
+maximum number of Olm sessions that it will maintain for each device,
 and expiring sessions on a Least Recently Used basis. The maximum number
-of olm sessions maintained per device should be at least 4.
+of Olm sessions maintained per device should be at least 4.
 
 ###### Recovering from undecryptable messages
 
@@ -1698,12 +1698,12 @@ requests](#key-requests), the device from which the key is being
 requested may want to tell the requester that it is purposely not
 sharing the key.
 
-If Alice withholds a megolm session from Bob for some messages in a
+If Alice withholds a Megolm session from Bob for some messages in a
 room, and then later on decides to allow Bob to decrypt later messages,
-she can send Bob the megolm session, ratcheted up to the point at which
+she can send Bob the Megolm session, ratcheted up to the point at which
 she allows Bob to decrypt the messages. If Bob logs into a new device
 and uses key sharing to obtain the decryption keys, the new device will
-be sent the megolm sessions that have been ratcheted up. Bob's old
+be sent the Megolm sessions that have been ratcheted up. Bob's old
 device can include the reason that the session was initially not shared
 by including a `withheld` property in the `m.forwarded_room_key` message
 that is an object with the `code` and `reason` properties from the

--- a/content/client-server-api/modules/end_to_end_encryption.md
+++ b/content/client-server-api/modules/end_to_end_encryption.md
@@ -1348,13 +1348,13 @@ objects described as follows:
 
 | Parameter                         | Type             | Description                                                                                                                           |
 |-----------------------------------|------------------|---------------------------------------------------------------------------------------------------------------------------------------|
-| algorithm                         | string           | Required. The encryption algorithm that the session uses. Must be `m.megolm.v1.aes-sha2`.                                             |
-| forwarding_curve25519_key_chain   | [string]         | Required. Chain of Curve25519 keys through which this session was forwarded, via [m.forwarded_room_key](#mforwarded_room_key) events. |
-| room_id                           | string           | Required. The room where the session is used.                                                                                         |
-| sender_key                        | string           | Required. The Curve25519 key of the device which initiated the session originally.                                                    |
-| sender_claimed_keys               | {string: string} | Required. The Ed25519 key of the device which initiated the session originally.                                                       |
-| session_id                        | string           | Required. The ID of the session.                                                                                                      |
-| session_key                       | string           | Required. The key for the session.                                                                                                    |
+| algorithm                         | string           | **Required.** The encryption algorithm that the session uses. Must be `m.megolm.v1.aes-sha2`.                                             |
+| forwarding_curve25519_key_chain   | [string]         | **Required.** Chain of Curve25519 keys through which this session was forwarded, via [m.forwarded_room_key](#mforwarded_room_key) events. |
+| room_id                           | string           | **Required.** The room where the session is used.                                                                                         |
+| sender_key                        | string           | **Required.** The Curve25519 key of the device which initiated the session originally.                                                    |
+| sender_claimed_keys               | {string: string} | **Required.** The Ed25519 key of the device which initiated the session originally.                                                       |
+| session_id                        | string           | **Required.** The ID of the session.                                                                                                      |
+| session_key                       | string           | **Required.** The key for the session.                                                                                                    |
 
 This is similar to the format before encryption used for the session
 keys in [Server-side key backups](#server-side-key-backups) but adds the

--- a/content/client-server-api/modules/end_to_end_encryption.md
+++ b/content/client-server-api/modules/end_to_end_encryption.md
@@ -1273,7 +1273,7 @@ The `session_data` field in the backups is constructed as follows:
 | forwarding_curve25519_key_chain | [string]          | **Required.** Chain of Curve25519 keys through which this session was forwarded, via [m.forwarded_room_key](#mforwarded_room_key) events.                                   |
 | sender_key                      | string            | **Required.** Unpadded base64-encoded device Curve25519 key.                                                                                                                |
 | sender_claimed_keys             | {string: string}  | **Required.** A map from the algorithm name (`ed25519`) to the corresponding device key of the sending device.                                                              |
-| session_key                     | string            | **Required.** Unpadded base64-encoded session key in [session-sharing format](https://gitlab.matrix.org/matrix-org/olm/blob/master/docs/megolm.md#session-sharing-format).  |
+| session_key                     | string            | **Required.** Unpadded base64-encoded session key in [session export format](https://gitlab.matrix.org/matrix-org/olm/blob/master/docs/megolm.md#session-export-format).  |
 
 2.  Generate an ephemeral curve25519 key, and perform an ECDH with the
     ephemeral key and the backup's public key to generate a shared

--- a/content/client-server-api/modules/end_to_end_encryption.md
+++ b/content/client-server-api/modules/end_to_end_encryption.md
@@ -1271,8 +1271,8 @@ The `session_data` field in the backups is constructed as follows:
 | --------------------------------|-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | algorithm                       | string            | **Required.** The end-to-end message encryption algorithm that the key is for.  Must be `m.megolm.v1.aes-sha2`.                                                             |
 | forwarding_curve25519_key_chain | [string]          | **Required.** Chain of Curve25519 keys through which this session was forwarded, via [m.forwarded_room_key](#mforwarded_room_key) events.                                   |
-| sender_key                      | string            | **Required.** Unpadded base64-encoded device curve25519 key.                                                                                                                |
-| sender_claimed_keys             | {string: string}  | **Required.** A map from algorithm name (`ed25519`) to the identity key for the sending device.                                                                             |
+| sender_key                      | string            | **Required.** Unpadded base64-encoded device Curve25519 key.                                                                                                                |
+| sender_claimed_keys             | {string: string}  | **Required.** A map from the algorithm name (`ed25519`) to the corresponding device key of the sending device.                                                              |
 | session_key                     | string            | **Required.** Unpadded base64-encoded session key in [session-sharing format](https://gitlab.matrix.org/matrix-org/olm/blob/master/docs/megolm.md#session-sharing-format).  |
 
 2.  Generate an ephemeral curve25519 key, and perform an ECDH with the
@@ -1353,8 +1353,8 @@ objects described as follows:
 | room_id                           | string           | **Required.** The room where the session is used.                                                                                         |
 | sender_key                        | string           | **Required.** The Curve25519 key of the device which initiated the session originally.                                                    |
 | sender_claimed_keys               | {string: string} | **Required.** The Ed25519 key of the device which initiated the session originally.                                                       |
-| session_id                        | string           | **Required.** The ID of the session.                                                                                                      |
-| session_key                       | string           | **Required.** The key for the session.                                                                                                    |
+| session_id                        | string           | **Required.** The Megolm session ID.                                                                                                      |
+| session_key                       | string           | **Required.** The Megolm session key in the [session export format](https://gitlab.matrix.org/matrix-org/olm/blob/master/docs/megolm.md#session-export-format).|
 
 This is similar to the format before encryption used for the session
 keys in [Server-side key backups](#server-side-key-backups) but adds the

--- a/content/client-server-api/modules/end_to_end_encryption.md
+++ b/content/client-server-api/modules/end_to_end_encryption.md
@@ -1258,7 +1258,7 @@ the following format:
 `AuthData`
 
 | Parameter  | Type       | Description                                                                                                           |
-| -----------| -----------|-----------------------------------------------------------------------------------------------------------------------|
+| -----------| -----------|---------------------------------------------------------------------------------------------------------------------- |
 | public_key | string     | **Required.** The curve25519 public key used to encrypt the backups, encoded in unpadded base64.                      |
 | signatures | Signatures | *Optional.* Signatures of the ``auth_data``. The signature is calculated using the process described at Signing JSON. |
 

--- a/content/client-server-api/modules/secrets.md
+++ b/content/client-server-api/modules/secrets.md
@@ -279,7 +279,7 @@ To request a secret from other devices, a client sends an
 `m.secret.requests` device event with `action` set to `request` and
 `name` set to the identifier of the secret. A device that wishes to
 share the secret will reply with an `m.secret.send` event, encrypted
-using olm. When the original client obtains the secret, it sends an
+using Olm. When the original client obtains the secret, it sends an
 `m.secret.request` event with `action` set to `request_cancellation` to
 all devices other than the one that it received the secret from. Clients
 should ignore `m.secret.send` events received from devices that it did
@@ -287,7 +287,7 @@ not send an `m.secret.request` event to.
 
 Clients must ensure that they only share secrets with other devices that
 are allowed to see them. For example, clients should only share secrets
-with the user’s own devices that are verified and may prompt the user to
+with the user's own devices that are verified and may prompt the user to
 confirm sharing the secret.
 
 ##### Event definitions

--- a/data/api/client-server/key_backup.yaml
+++ b/data/api/client-server/key_backup.yaml
@@ -398,7 +398,7 @@ paths:
         - in: path
           type: string
           name: sessionId
-          description: The ID of the megolm session that the key is for.
+          description: The ID of the Megolm session that the key is for.
           required: true
           x-example: "sessionid"
         - in: body
@@ -470,7 +470,7 @@ paths:
         - in: path
           type: string
           name: sessionId
-          description: The ID of the megolm session whose key is requested.
+          description: The ID of the Megolm session whose key is requested.
           required: true
           x-example: "sessionid"
       responses:
@@ -517,7 +517,7 @@ paths:
         - in: path
           type: string
           name: sessionId
-          description: The ID of the megolm session whose key is to be deleted.
+          description: The ID of the Megolm session whose key is to be deleted.
           required: true
           x-example: "sessionid"
       responses:

--- a/data/event-schemas/schema/m.forwarded_room_key.yaml
+++ b/data/event-schemas/schema/m.forwarded_room_key.yaml
@@ -22,10 +22,11 @@ properties:
           The Curve25519 key of the device which initiated the session originally.
       session_id:
         type: string
-        description: The ID of the session that the key is for.
+        description: The ID of the Megolm session that the key is for.
       session_key:
         type: string
-        description: The key to be exchanged.
+        description: The Megolm key to be exchanged, in [session export
+          format](https://gitlab.matrix.org/matrix-org/olm/blob/master/docs/megolm.md#session-export-format).
       sender_claimed_ed25519_key:
         type: string
         description: |-

--- a/data/event-schemas/schema/m.room.encrypted.yaml
+++ b/data/event-schemas/schema/m.room.encrypted.yaml
@@ -4,8 +4,9 @@ allOf:
 
 description: |-
   This event type is used when sending encrypted events. It can be used either
-  within a room (in which case it will have all of the [Room Event fields](/client-server-api/#room-event-fields)), or
-  as a [to-device](/client-server-api/#send-to-device-messaging) event.
+  within a room (in which case it will have all of the [Room Event
+  fields](/client-server-api/#room-event-format)), or as
+  a [to-device](/client-server-api/#send-to-device-messaging) event.
 
 properties:
   content:

--- a/data/event-schemas/schema/m.room_key.withheld.yaml
+++ b/data/event-schemas/schema/m.room_key.withheld.yaml
@@ -16,20 +16,20 @@ description: |-
     was not in the room when the original message was sent.
   * `m.unavailable`: sent in reply to a key request if the device that the
     key is requested from does not have the requested key.
-  * `m.no_olm`: an olm session could not be established.
+  * `m.no_olm`: an Olm session could not be established.
 
   In most cases, this event refers to a specific room key. The one exception to
-  this is when the sender is unable to establish an olm session with the
+  this is when the sender is unable to establish an Olm session with the
   recipient. When this happens, multiple sessions will be affected.  In order
   to avoid filling the recipient\'s device mailbox, the sender should only send
   one `m.room_key.withheld` message with no `room_id` nor `session_id`
-  set.  If the sender retries and fails to create an olm session again in the
+  set.  If the sender retries and fails to create an Olm session again in the
   future, it should not send another `m.room_key.withheld` message with a
-  `code` of `m.no_olm`, unless another olm session was previously
+  `code` of `m.no_olm`, unless another Olm session was previously
   established successfully.  In response to receiving an
   `m.room_key.withheld` message with a `code` of `m.no_olm`, the
-  recipient may start an olm session with the sender and send an `m.dummy`
-  message to notify the sender of the new olm session.  The recipient may
+  recipient may start an Olm session with the sender and send an `m.dummy`
+  message to notify the sender of the new Olm session.  The recipient may
   assume that this `m.room_key.withheld` message applies to all encrypted
   room messages sent before it receives the message.
 properties:

--- a/data/event-schemas/schema/m.room_key.yaml
+++ b/data/event-schemas/schema/m.room_key.yaml
@@ -21,7 +21,8 @@ properties:
         description: The ID of the session that the key is for.
       session_key:
         type: string
-        description: The key to be exchanged.
+        description: The Megolm key to be exchanged, in [session sharing
+          format](https://gitlab.matrix.org/matrix-org/olm/blob/master/docs/megolm.md#session-sharing-format).
     required:
       - algorithm
       - room_id


### PR DESCRIPTION
Changes include:

- Link to correct Megolm session sharing formats:
  - `m.room_key` -> session sharing format
  - `m.forwarded_room_key` -> session export format
  - Server-side Megolm session backups -> session export format
  - Megolm session file exports -> session export format

- Remove some points of ambiguity regarding terminology.
- Adding links to other parts of the spec.
- Stylistic fixes (rewording for consistency, capitalization, etc).
- Fix for #1080.

<!-- Replace -->
Preview: https://pr1088--matrix-spec-previews.netlify.app
<!-- Replace -->
