### PR TITLE
fix: spaces hierarchy paramater types

### DIFF
--- a/changelogs/client_server/newsfragments/1097.clarification
+++ b/changelogs/client_server/newsfragments/1097.clarification
@@ -1,1 +1,1 @@
-Adjust the data types of the Spaces Hierarchy query parameters.
+Fix various typos throughout the specification.

--- a/changelogs/client_server/newsfragments/1097.clarification
+++ b/changelogs/client_server/newsfragments/1097.clarification
@@ -1,0 +1,1 @@
+Adjust the data types of the Spaces Hierarchy query parameters.

--- a/data/api/client-server/space_hierarchy.yaml
+++ b/data/api/client-server/space_hierarchy.yaml
@@ -58,7 +58,7 @@ paths:
             contents.
           x-example: true
         - in: query
-          type: number
+          type: integer
           name: limit
           description: |-
             Optional limit for the maximum number of rooms to include per response. Must be an integer
@@ -67,7 +67,7 @@ paths:
             Servers should apply a default value, and impose a maximum value to avoid resource exhaustion.
           x-example: 20
         - in: query
-          type: number
+          type: integer
           name: max_depth
           description: |-
             Optional limit for how far to go into the space. Must be a non-negative integer.


### PR DESCRIPTION
- changed `limit` parameter type to integer
- changed `query` parameter type to integer

A floating number does not make any sense here. Also, at least Synapse
does not allow floating point numbers in here.

Signed-off-by: TheOneWithTheBraid <the-one@with-the-braid.cf>

<!-- Replace -->
Preview: https://pr1097--matrix-spec-previews.netlify.app
<!-- Replace -->
