### PR TITLE
Re-add paragraph about how some state keys are reserved

### DIFF
--- a/changelogs/client_server/newsfragments/1100.clarification
+++ b/changelogs/client_server/newsfragments/1100.clarification
@@ -1,0 +1,1 @@
+Clarify that state keys starting with `@` are in fact reserved. Regressed from [#3658](https://github.com/matrix-org/matrix-spec-proposals/pull/3658).

--- a/data/api/client-server/definitions/client_event_without_room_id.yaml
+++ b/data/api/client-server/definitions/client_event_without_room_id.yaml
@@ -38,6 +38,10 @@ properties:
       Present if, and only if, this event is a *state* event. The key making
       this piece of state unique in the room. Note that it is often an empty
       string.
+
+      State keys starting with an `@` are reserved for referencing user IDs, such
+      as room members. With the exception of a few events, state events set with a
+      given user's ID as the state key MUST only be set by that user.
     type: string
     example: '@user:example.org'
   sender:


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-spec/issues/1013

This is a direct copy/paste from the sync state event definition, which we should probably de-duplicate eventually.

<!-- Replace -->
Preview: https://pr1100--matrix-spec-previews.netlify.app
<!-- Replace -->
