### PR TITLE
room_type is not a required parameter in practice

### DIFF
--- a/changelogs/client_server/newsfragments/1110.clarification
+++ b/changelogs/client_server/newsfragments/1110.clarification
@@ -1,0 +1,1 @@
+Fix various typos throughout the specification.

--- a/changelogs/server_server/newsfragments/1100.clarification
+++ b/changelogs/server_server/newsfragments/1100.clarification
@@ -1,1 +1,0 @@
-Clarify that state keys starting with `@` are in fact reserved. Regressed from [#3658](https://github.com/matrix-org/matrix-spec-proposals/pull/3658).

--- a/changelogs/server_server/newsfragments/1100.clarification
+++ b/changelogs/server_server/newsfragments/1100.clarification
@@ -1,0 +1,1 @@
+Clarify that state keys starting with `@` are in fact reserved. Regressed from [#3658](https://github.com/matrix-org/matrix-spec-proposals/pull/3658).

--- a/changelogs/server_server/newsfragments/1110.clarification
+++ b/changelogs/server_server/newsfragments/1110.clarification
@@ -1,0 +1,1 @@
+Fix various typos throughout the specification.

--- a/data/api/client-server/space_hierarchy.yaml
+++ b/data/api/client-server/space_hierarchy.yaml
@@ -149,7 +149,7 @@ paths:
                                     format: int64
                                     description: The `origin_server_ts` for the event.
                                 required: [origin_server_ts]
-                      required: [room_type, children_state]
+                      required: [children_state]
               next_batch:
                 type: string
                 description: |-

--- a/data/api/server-server/space_hierarchy.yaml
+++ b/data/api/server-server/space_hierarchy.yaml
@@ -158,7 +158,7 @@ paths:
                                   format: int64
                                   description: The `origin_server_ts` for the event.
                               required: [origin_server_ts]
-                    required: [room_type, allowed_room_ids, children_state]
+                    required: [children_state]
               children:
                 type: array
                 description: |-


### PR DESCRIPTION
In practice servers seem to mirror what the room create event does and
leave out the room_type when unset.

I don't think the intention of the spec was to have the room type required
on normal rooms and the text seems to match that too.

Signed-off-by: Nicolas Werner <n.werner@famedly.com>







<!-- Replace -->
Preview: https://pr1110--matrix-spec-previews.netlify.app
<!-- Replace -->
