### PR TITLE
`refresh_token` is omitted if `inhibit_login` is true

### DIFF
--- a/changelogs/client_server/newsfragments/1113.clarification
+++ b/changelogs/client_server/newsfragments/1113.clarification
@@ -1,1 +1,0 @@
-Fix various typos throughout the specification.

--- a/changelogs/client_server/newsfragments/1113.clarification
+++ b/changelogs/client_server/newsfragments/1113.clarification
@@ -1,0 +1,1 @@
+Fix various typos throughout the specification.

--- a/changelogs/client_server/newsfragments/1113.feature
+++ b/changelogs/client_server/newsfragments/1113.feature
@@ -1,0 +1,1 @@
+Add refresh tokens, per [MSC2918](https://github.com/matrix-org/matrix-spec-proposals/pull/2918).

--- a/data/api/client-server/registration.yaml
+++ b/data/api/client-server/registration.yaml
@@ -165,7 +165,7 @@ paths:
                   obtain a new access token when it expires by calling the
                   `/refresh` endpoint.
 
-                  Omitted if the `inhibit_login` option is false.
+                  Omitted if the `inhibit_login` option is true.
                 x-addedInMatrixVersion: "1.3"
               expires_in_ms:
                 type: integer
@@ -177,7 +177,7 @@ paths:
                   to obtain a new access token. If not given, the client can
                   assume that the access token will not expire.
 
-                  Omitted if the `inhibit_login` option is false.
+                  Omitted if the `inhibit_login` option is true.
                 x-addedInMatrixVersion: "1.3"
               home_server:
                 type: string


### PR DESCRIPTION
I think there's been a mixup when writing the spec PR, and it's actually meant to be this, according to the MSC and Synapse's implementation.

<!-- Replace -->
Preview: https://pr1113--matrix-spec-previews.netlify.app
<!-- Replace -->
