### PR TITLE
Fix typo in relations endpoint description

### DIFF
--- a/changelogs/client_server/newsfragments/1114.clarification
+++ b/changelogs/client_server/newsfragments/1114.clarification
@@ -1,0 +1,1 @@
+Fix various typos throughout the specification.

--- a/data/api/client-server/relations.yaml
+++ b/data/api/client-server/relations.yaml
@@ -286,7 +286,7 @@ paths:
       summary: Get the child events for a given parent event, with a given `relType` and `eventType`.
       description: |-
         Retrieve all of the child events for a given parent event which relate to the parent
-        using the given `relType` and have the given `eventType`.
+        using the given `relType` and having the given `eventType`.
 
         Note that when paginating the `from` token should be "after" the `to` token in
         terms of topological ordering, because it is only possible to paginate "backwards"


### PR DESCRIPTION
English is not my native language but I'm pretty sure it's grammatically incorrect otherwise.