### PR TITLE
auth_data.yaml: formally allow it to be non-object

### DIFF
--- a/changelogs/client_server/newsfragments/1115.clarification
+++ b/changelogs/client_server/newsfragments/1115.clarification
@@ -1,0 +1,1 @@
+Fix various typos throughout the specification.

--- a/data/api/client-server/definitions/auth_data.yaml
+++ b/data/api/client-server/definitions/auth_data.yaml
@@ -28,7 +28,6 @@ properties:
     type: string
 additionalProperties:
   description: Keys dependent on the login type
-  type: object
 example:
   type: "example.type.foo"
   session: "xxxxx"


### PR DESCRIPTION
Closes #716.

Signed-off-by: Alexey Rusakov <Kitsune-Ral@users.sf.net>

<!-- Replace -->
Preview: https://pr1115--matrix-spec-previews.netlify.app
<!-- Replace -->
