### PR TITLE
Conflicted state set is a set of events

### DIFF
--- a/content/rooms/fragments/v2-state-res.md
+++ b/content/rooms/fragments/v2-state-res.md
@@ -36,10 +36,10 @@ The key-value pairs (*K*, *V*) across all state maps *S<sub>i</sub>* can be
 divided into two collections.
 If a given key *K* is present in every *S<sub>i</sub>* with the same value *V* 
 in each state map, then the pair (*K*, *V*) belongs to the *unconflicted state map*.
-Otherwise (*K*, *V*) belongs to the *conflicted state set*.
+Otherwise, *V* belongs to the *conflicted state set*.
 
 Note that the unconflicted state map only has one event for each key *K*,
-whereas the conflicted state set may associate multiple events to the same key.
+whereas the conflicted state set may contain multiple events with the same key.
 
 **Auth chain.**
 The *auth chain* of an event *E* is the set containing all of *E*'s auth events,


### PR DESCRIPTION
In #1042 I incorrectly wrote that the conflicted state set is a set of
pairs (K, V). We later take the union of the conflicted state set and
the auth difference. The latter is a set of events (V) only.

Fix this by making the conflicted state set a set of events rather than
a set of pairs. That is, the conflicted state set is a a `Set[Event]`
instead of a `Set[((type, state key), event)]`.