### PR TITLE
Arrange a few titles

### DIFF
--- a/changelogs/client_server/newsfragments/1126.clarification
+++ b/changelogs/client_server/newsfragments/1126.clarification
@@ -1,0 +1,1 @@
+Fix various typos throughout the specification.

--- a/data/api/client-server/definitions/public_rooms_response.yaml
+++ b/data/api/client-server/definitions/public_rooms_response.yaml
@@ -17,7 +17,6 @@ description: A list of the rooms on the server.
 required: ["chunk"]
 properties:
   chunk:
-    title: "PublicRoomsChunks"
     type: array
     description: |-
       A paginated chunk of public rooms.
@@ -25,6 +24,7 @@ properties:
       allOf:
         - $ref: "public_rooms_chunk.yaml"
         - type: object
+          title: PublicRoomsChunk
           properties:
             # Override description of join_rule
             join_rule:

--- a/data/api/client-server/space_hierarchy.yaml
+++ b/data/api/client-server/space_hierarchy.yaml
@@ -127,6 +127,7 @@ paths:
                   allOf:
                     - $ref: "definitions/public_rooms_chunk.yaml"
                     - type: object
+                      title: ChildRoomsChunk
                       properties:
                         room_type:
                           type: string
@@ -143,6 +144,7 @@ paths:
                             allOf:
                               - $ref: "../../event-schemas/schema/core-event-schema/stripped_state.yaml"
                               - type: object
+                                title: StrippedChildStateEvent
                                 properties:
                                   origin_server_ts:
                                     type: number


### PR DESCRIPTION
Before this change, PublicRoomsChunk in the spec text could be found in [two](https://spec.matrix.org/v1.2/client-server-api/#get_matrixclientv3publicrooms) [places](https://spec.matrix.org/v1.2/client-server-api/#get_matrixclientv1roomsroomidhierarchy) (actually [three](https://spec.matrix.org/v1.2/client-server-api/#post_matrixclientv3publicrooms) but this one is identical to the first one), defining two (_mostly_ identical but) different
schemas. Ctrl-F'ing through the spec may confuse you with the "wrong" definition. This commit gives distinct schemas distinct names; aside from PublicRoomChunk, the same story happens with the derivative of stripped_state.yaml used in space_hierarchy.yaml (it's not exactly StrippedStateEvent either).
As for the removal of `PublicRoomsChunks` (plural) - this title is unnecessary because the tooling would place rather self-explanatory `[PublicRoomsChunk]` without it, whereas the plural title ends up with no definition in the spec text.

Signed-off-by: Alexey Rusakov \<Kitsune-Ral@users.sf.net\>

<!-- Replace -->
Preview: https://pr1126--matrix-spec-previews.netlify.app
<!-- Replace -->
