### PR TITLE
Use type: integer, format: int64 for timestamps

### DIFF
--- a/changelogs/client_server/newsfragments/1129.clarification
+++ b/changelogs/client_server/newsfragments/1129.clarification
@@ -1,0 +1,1 @@
+Fix various typos throughout the specification.

--- a/data/api/client-server/notifications.yaml
+++ b/data/api/client-server/notifications.yaml
@@ -126,6 +126,7 @@ paths:
                       description: The ID of the room in which the event was posted.
                     ts:
                       type: integer
+                      format: int64
                       description: |-
                         The unix timestamp at which the event notification was sent,
                         in milliseconds.

--- a/data/api/client-server/space_hierarchy.yaml
+++ b/data/api/client-server/space_hierarchy.yaml
@@ -147,7 +147,7 @@ paths:
                                 title: StrippedChildStateEvent
                                 properties:
                                   origin_server_ts:
-                                    type: number
+                                    type: integer
                                     format: int64
                                     description: The `origin_server_ts` for the event.
                                 required: [origin_server_ts]

--- a/data/api/identity/v2_associations.yaml
+++ b/data/api/identity/v2_associations.yaml
@@ -68,6 +68,7 @@ paths:
                 description: The address of the 3pid being looked up.
               validated_at:
                 type: integer
+                format: int64
                 description: |-
                   Timestamp, in milliseconds, indicating the time that the 3pid
                   was validated.
@@ -174,12 +175,15 @@ paths:
                 description: The Matrix user ID associated with the 3pid.
               not_before:
                 type: integer
+                format: int64
                 description: A unix timestamp before which the association is not known to be valid.
               not_after:
                 type: integer
+                format: int64
                 description: A unix timestamp after which the association is not known to be valid.
               ts:
                 type: integer
+                format: int64
                 description: The unix timestamp at which the association was verified.
               signatures:
                 type: object

--- a/data/api/push-gateway/push_notifier.yaml
+++ b/data/api/push-gateway/push_notifier.yaml
@@ -184,6 +184,7 @@ paths:
                           description: The `pushkey` given when the pusher was created.
                         pushkey_ts:
                           type: integer
+                          format: int64
                           description: |-
                             The unix timestamp (in seconds) when the
                             pushkey was last updated.

--- a/data/api/server-server/space_hierarchy.yaml
+++ b/data/api/server-server/space_hierarchy.yaml
@@ -154,7 +154,7 @@ paths:
                             - type: object
                               properties:
                                 origin_server_ts:
-                                  type: number
+                                  type: integer
                                   format: int64
                                   description: The `origin_server_ts` for the event.
                               required: [origin_server_ts]

--- a/data/event-schemas/schema/m.receipt.yaml
+++ b/data/event-schemas/schema/m.receipt.yaml
@@ -27,7 +27,8 @@
                                     "x-pattern": "$USER_ID",
                                     "properties": {
                                         "ts": {
-                                            "type": "number",
+                                            "type": "integer",
+                                            "format": "int64",
                                             "description": "The timestamp the receipt was sent at."
                                         }
                                     }


### PR DESCRIPTION
This fixes all cases listed in #749 (and a few more), including `m.receipt` JSON Schema since we apparently have all the necessary pieces to process `format:` in JSON Schema (see [the definition of same `m.receipt` for Federation API](https://github.com/matrix-org/matrix-spec/blob/6adacd18c107cb01c9486a2e592b4ea16fa28c7d/data/api/server-server/definitions/event-schemas/m.receipt.yaml)).

Signed-off-by: Alexey Rusakov <Kitsune-Ral@users.sf.net>