### PR TITLE
Quick hacky version dropdown

### DIFF
--- a/changelogs/room_versions/newsfragments/1131.feature
+++ b/changelogs/room_versions/newsfragments/1131.feature
@@ -1,0 +1,1 @@
+Dummy changelog to make CI happy. Add a very hacky version switcher to navigate between different spec versions.

--- a/config.toml
+++ b/config.toml
@@ -52,6 +52,9 @@ current_version_url = "https://spec.matrix.org/latest"
 #major = "1"
 #minor = "2"
 #release_date = "February 02, 2022"
+# Released versions to show in the version dropdown. Th template will also include a "historical" entry,
+# and (if the status above is "stable") an "unstable" entry.
+history = [ "unstable", "v1.2", "v1.1", "historical" ]
 
 # User interface configuration
 [params.ui]

--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -15,3 +15,4 @@
 */}}
 
 <script defer language="javascript" type="text/javascript"  src="{{ "js/toc.js" | urlize | relURL }}"></script>
+<script defer language="javascript" type="text/javascript"  src="{{ "js/version_selector.js" | urlize | relURL }}"></script>

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -8,9 +8,10 @@
 
 {{ $cover := .HasShortcode "blocks/cover" }}
 <nav class="js-navbar-scroll navbar navbar-expand navbar-light {{ if $cover}} td-navbar-cover {{ end }}flex-column flex-md-row td-navbar">
-        <a class="navbar-brand" href="{{ .Site.Home.RelPermalink }}">
-		<span class="navbar-logo">{{ with resources.Get "icons/logo.svg" }}{{ ( . | minify).Content | safeHTML }}{{ end }}</span><span class="font-weight-bold">specification</span><span class="navbar-version"> &mdash; {{ partial "version-string" . }}</span>
-	</a>
+	<span class="navbar-brand">
+		<a href="{{ .Site.Home.RelPermalink }}">
+			<span class="navbar-logo">{{ with resources.Get "icons/logo.svg" }}{{ ( . | minify).Content | safeHTML }}{{ end }}</span><span class="font-weight-bold">specification</span></a><span class="navbar-version"> &mdash; {{ partial "version-selector" . }}</span>
+	</span>
 	<div class="td-navbar-nav-scroll ml-md-auto" id="main_navbar">
 		<ul class="navbar-nav mt-2 mt-lg-0">
 
@@ -39,17 +40,38 @@
 </nav>
 
 
-{{ define "partials/version-string" }}
-    {{ $ret := "unstable version"}}
+{{ define "partials/version-selector" }}
+	{{ $version := .Site.Params.version }}
+	{{ $current := partial "current-version-short" . }}
+	<noscript>{{ partial "current-version-long" . }}</noscript>
+	<select id="version-selector">
+	{{ range $version.history }}
+		{{ if eq . $current }}
+		<option selected>{{ . }}</option>
+		{{ else }}
+		<option>{{ . }}</option>
+		{{ end }}
+	{{ end }}
+	</select>
+{{ end }}
 
-    {{ $status := .Site.Params.version.status }}
 
-    {{ if ne $status "unstable"}}
-        {{ $path := path.Join "changelogs" }}
+{{ define "partials/current-version-long" }}
+	{{ if eq .Site.Params.version.status "unstable" }}
+		unstable version
+    {{ else }}
+        version {{ partial "current-version-short" . }}
+	{{ end }}
+{{ end }}
 
-        {{/* produces a string similar to "version v1.5" */}}
-        {{ $ret = delimit (slice "version v" .Site.Params.version.major "." .Site.Params.version.minor) "" }}
-    {{ end }}
+
+{{ define "partials/current-version-short" }}
+    {{ $ret := "unstable"}}
+
+    {{ if ne .Site.Params.version.status "unstable"}}
+		{{/* produces a string similar to "version v1.5" */}}
+		{{ $ret = delimit (slice "v" .Site.Params.version.major "." .Site.Params.version.minor) "" }}
+	{{ end }}
 
     {{ return $ret }}
 {{ end }}

--- a/static/js/version_selector.js
+++ b/static/js/version_selector.js
@@ -1,0 +1,32 @@
+window.addEventListener('DOMContentLoaded', () => {
+  const selector = document.getElementById("version-selector")
+
+  // Get the current version number and check that it or "latest" appears in the URL.
+  let current = selector.querySelector("option[selected]").value
+  let current_segment
+  console.log("current", current)
+  if (window.location.href.includes("/" + current + "/")) {
+    current_segment = "/" + current + "/"
+  } else if (window.location.href.includes("/latest/")) {
+    current_segment = "/latest/"
+  } else {
+    // If not, ditch the selector dropdown.
+    let parent = selector.parentElement
+    let fallback = parent.querySelector("noscript")
+    parent.removeChild(fallback)
+    parent.removeChild(selector)
+    parent.appendChild(document.createTextNode(fallback.innerText))
+    return
+  }
+
+  selector.addEventListener("change", event => {
+    let chosen = event.target.value
+    if (chosen === "historical") {
+        // Go to the "historical version" in the current spec's revision.
+        let parts = window.location.href.split(current_segment, 2)
+        window.location.href = parts[0] + current_segment + "changelog/#historical-versions"
+    } else {
+        window.location.href = window.location.href.replace(current_segment, "/" + chosen + "/")
+    }
+  })
+});


### PR DESCRIPTION
Very rough prototype. Corners cut everywhere. Bad javascript habits. I learned babby's first web development back when the `<font>` tag was cool.

Closes #951. (Sort of. We'd need to regenerate /v1.1 and /v1.2 to include the switcher.

- In conf.toml, define a list of historical version strings.
- Use these to generate a `select` element in the navbar.
  - Mark the current version of the spec as the selected option.
  - Include a `noscript` fallback without the selector.
- Add a piece of Javascript which does the following onDOMContentLoaded:
  - Look at the URL for a path segment of the form `/v1.1/` or `/latest/`.
  - If we can't find this, remove the dropdown and replace it with the fallback content.
  - Add an event listener so that selecting a different version changes the version-specific path segment in the URL. No attempt is made to ensure that the new URL exists.
    - The "historical" section is special cased. Selecting it navigates you to the current spec's changelog page which explains about the `r0.x.y` versions.

Somewhat cribbed from what `docs.python.org` does, but written from scratch. (And much less robust.) The machinery for that lives [here](https://github.com/python/docsbuild-scripts/blob/main/templates/switchers.js), but I haven't dug too hard into their setup.

<!-- Replace -->
Preview: https://pr1131--matrix-spec-previews.netlify.app
<!-- Replace -->
