### PR TITLE
Revert "Note a more efficient computation of the auth difference. (#1119)"

### DIFF
--- a/changelogs/room_versions/newsfragments/1119.clarification
+++ b/changelogs/room_versions/newsfragments/1119.clarification
@@ -1,1 +1,0 @@
-For room version 2 through 10: Note a more efficient way to compute the auth difference during state resolution.

--- a/changelogs/room_versions/newsfragments/1132.misc
+++ b/changelogs/room_versions/newsfragments/1132.misc
@@ -1,1 +1,0 @@
-Revert #1119. The stylistic changes were correct, but the sentence `This can be computed more efficiently as...` was incorrect.

--- a/changelogs/room_versions/newsfragments/1132.misc
+++ b/changelogs/room_versions/newsfragments/1132.misc
@@ -1,0 +1,1 @@
+Revert #1119. The stylistic changes were correct, but the sentence `This can be computed more efficiently as...` was incorrect.

--- a/content/rooms/fragments/v2-state-res.md
+++ b/content/rooms/fragments/v2-state-res.md
@@ -47,20 +47,13 @@ all of *their* auth events, and so on recursively, stretching back to the
 start of the room. Put differently, these are the events reachable by walking
 the graph induced by an event's `auth_events` links.
 
-If *S* is a collection of
-events, the *full auth chain of S* is the union of the auth chains of every
-event *E* in *S*.
-
 **Auth difference.**
-For each state *S<sub>i</sub>*, compute its full auth chain.
-The *auth difference* is the set of events which belong to some, but not all,
-of these full auth chains. In symbols: if *F*(*S*) is the full auth
-chain of a collection of events *S*, the auth difference is
-    ∪<sub>*i*</sub> *F*(*S<sub>i</sub>*) - ∩<sub>*i*</sub> *F*(*S<sub>i</sub>*).
-
-This can be computed more efficiently as
-    *F*(*C*) - ∩<sub>*i*</sub> *F*(*S*<sub>*i* - *C*</sub>) ,
-where *C* is the conflicted state set.
+The *auth difference* is calculated by first calculating the full auth
+chain for each state *S*<sub>*i*</sub>, that is the union of the auth
+chains for each event in *S*<sub>*i*</sub>, and then taking every event
+that doesn't appear in every auth chain. If *C*<sub>*i*</sub> is the
+full auth chain of *S*<sub>*i*</sub>, then the auth difference is
+ ∪ *C*<sub>*i*</sub> −  ∩ *C*<sub>*i*</sub>.
 
 **Full conflicted set.**
 The *full conflicted set* is the union of the conflicted state set and


### PR DESCRIPTION
This reverts commit a707266e50a770a2bdb272600e09671fe6ca8e41.

The final sentence was incorrect. The rest of the changes were fine.

Given that 1.3 is due to be cut imminently, the most expedient thing to do is revert the whole thing.

<!-- Replace -->
Preview: https://pr1132--matrix-spec-previews.netlify.app
<!-- Replace -->
