### PR TITLE
Fix typo in m.secret.request device event name

### DIFF
--- a/changelogs/client_server/newsfragments/1135.clarification
+++ b/changelogs/client_server/newsfragments/1135.clarification
@@ -1,0 +1,1 @@
+Fix a typo in the secret sharing event name `m.secret.request`

--- a/changelogs/client_server/newsfragments/1135.clarification
+++ b/changelogs/client_server/newsfragments/1135.clarification
@@ -1,1 +1,1 @@
-Fix a typo in the secret sharing event name `m.secret.request`
+Fix a typo in the secret sharing event name `m.secret.request`.

--- a/changelogs/client_server/newsfragments/1135.clarification
+++ b/changelogs/client_server/newsfragments/1135.clarification
@@ -1,1 +1,1 @@
-Fix a typo in the secret sharing event name `m.secret.request`.
+Fix various typos throughout the specification.

--- a/content/client-server-api/modules/secrets.md
+++ b/content/client-server-api/modules/secrets.md
@@ -276,7 +276,7 @@ Example:
 #### Sharing
 
 To request a secret from other devices, a client sends an
-`m.secret.requests` device event with `action` set to `request` and
+`m.secret.request` device event with `action` set to `request` and
 `name` set to the identifier of the secret. A device that wishes to
 share the secret will reply with an `m.secret.send` event, encrypted
 using olm. When the original client obtains the secret, it sends an


### PR DESCRIPTION
I don't think this is supposed to be plural according to the various SDKs

Signed-off-by: Brad Murray <brad@beeper.com>


<!-- Replace -->
Preview: https://pr1135--matrix-spec-previews.netlify.app
<!-- Replace -->
