### PR TITLE
Fix wording for globs in policy lists

### DIFF
--- a/content/client-server-api/modules/moderation_policies.md
+++ b/content/client-server-api/modules/moderation_policies.md
@@ -91,7 +91,7 @@ included in the ban list.
 #### Events
 
 The `entity` described by the state events can contain `*` and `?` to
-match zero or more and one or more characters respectively. Note that
+match zero or more characters and exactly one character respectively. Note that
 rules against rooms can describe a room ID or room alias - the
 subscriber is responsible for resolving the alias to a room ID if
 desired.

--- a/data/event-schemas/moderation_policy_rule.yaml
+++ b/data/event-schemas/moderation_policy_rule.yaml
@@ -15,7 +15,7 @@ properties:
   entity:
     description: |-
       The entity affected by this rule. Glob characters `*` and `?` can be used
-      to match zero or more and one or more characters respectively.
+      to match zero or more characters or exactly one character respectively.
     type: string
   recommendation:
     description: The suggested action to take. Currently only `m.ban` is specified.


### PR DESCRIPTION
The specification here does neither match how globs work in common
libraries nor do they match how they are used in practice currently or
how the MSC worded them (which said they should be like server ACLs). As
such this seems to be an issue introduced when writing the spec text.

Ref mjolnir:
- https://github.com/matrix-org/mjolnir/blob/b48904bc2b4fcd636176b12dbe173ad651930f23/src/models/ListRule.ts#L44

Ref matrix bot sdk (which implements the glob used above):
- https://github.com/turt2live/matrix-bot-sdk/blob/473e563236dd6edb25e7bd18d3517d1a61e037a1/src/helpers/MatrixGlob.ts#L26
- https://github.com/turt2live/matrix-bot-sdk/blob/f799b1fe1a72b9a4a6053c50cedfb43bee962558/test/helpers/MatrixGlobTest.ts#L44

Ref original MSC:
- https://github.com/matrix-org/matrix-spec-proposals/blob/c7b3d998537d21694a166b4a6a4cf0490ebc0cc2/proposals/2313-moderation-policy-rooms.md?plain=1#L36
- https://spec.matrix.org/v1.3/client-server-api/#server-access-control-lists-acls-for-rooms

fixes https://github.com/matrix-org/matrix-spec/issues/17

Signed-off-by: Nicolas Werner <nicolas.werner@hotmail.de>