### PR TITLE
Disable blank issue reporting

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
  - name: Matrix Spec Discussion
    url: "https://matrix.to/#/#matrix-spec:matrix.org"


### PR DESCRIPTION
Folks who want to report a blank issue can still get at the form if they try hard enough, but in general everything should have a label to make triage easier.