### PR TITLE
Add HTML ids for object definitions in the formatted specification

### DIFF
--- a/changelogs/application_service/newsfragments/1174.clarification
+++ b/changelogs/application_service/newsfragments/1174.clarification
@@ -1,0 +1,1 @@
+Add HTML anchors for object definitions in the formatted specification.

--- a/changelogs/client_server/newsfragments/1174.clarification
+++ b/changelogs/client_server/newsfragments/1174.clarification
@@ -1,0 +1,1 @@
+Add HTML anchors for object definitions in the formatted specification.

--- a/changelogs/identity_service/newsfragments/1174.clarification
+++ b/changelogs/identity_service/newsfragments/1174.clarification
@@ -1,0 +1,1 @@
+Add HTML anchors for object definitions in the formatted specification.

--- a/changelogs/push_gateway/newsfragments/1174.clarification
+++ b/changelogs/push_gateway/newsfragments/1174.clarification
@@ -1,0 +1,1 @@
+Add HTML anchors for object definitions in the formatted specification.

--- a/changelogs/server_server/newsfragments/1174.clarification
+++ b/changelogs/server_server/newsfragments/1174.clarification
@@ -1,0 +1,1 @@
+Add HTML anchors for object definitions in the formatted specification.

--- a/layouts/partials/events/render-event.html
+++ b/layouts/partials/events/render-event.html
@@ -56,7 +56,7 @@
 {{ $additional_types := partial "json-schema/resolve-additional-types" (dict "schema" $event_data.properties.content) }}
 
 {{ range $additional_types }}
-    {{ partial "openapi/render-object-table" (dict "caption" .title "properties" .properties "required" .required) }}
+    {{ partial "openapi/render-object-table" . }}
 {{end}}
 
 <h2>Examples</h2>

--- a/layouts/partials/events/render-event.html
+++ b/layouts/partials/events/render-event.html
@@ -53,7 +53,8 @@
 
 <h2>Content</h2>
 
-{{ $additional_types := partial "json-schema/resolve-additional-types" (dict "schema" $event_data.properties.content) }}
+{{ $anchor_base := anchorize $event_name }}
+{{ $additional_types := partial "json-schema/resolve-additional-types" (dict "schema" $event_data.properties.content "anchor_base" $anchor_base) }}
 
 {{ range $additional_types }}
     {{ partial "openapi/render-object-table" . }}

--- a/layouts/partials/events/render-event.html
+++ b/layouts/partials/events/render-event.html
@@ -53,7 +53,7 @@
 
 <h2>Content</h2>
 
-{{ $additional_types := partial "json-schema/resolve-additional-types" $event_data.properties.content }}
+{{ $additional_types := partial "json-schema/resolve-additional-types" (dict "schema" $event_data.properties.content) }}
 
 {{ range $additional_types }}
     {{ partial "openapi/render-object-table" (dict "caption" .title "properties" .properties "required" .required) }}

--- a/layouts/partials/json-schema/resolve-additional-types.html
+++ b/layouts/partials/json-schema/resolve-additional-types.html
@@ -2,25 +2,33 @@
 
   Finds and returns all nested objects, given a dict containing:
    * `schema`: a JSON schema object
+   * `anchor_base`: a prefix to add to the HTML anchors generated for each object. If nil, no anchors are generated.
 
   This template finds all nested objects inside `schema`.
 
   Assumes that "resolve-refs" and "resolve-allof" has already been called on the
   input schema.
 
-  It "cleans" each object by copying only the parts of the objects that
-  the renderer needs, and adds the result to an array, `additional_objects`.
-
-  Finally it returns the array of all the objects it found.
+  Returns an array of all the objects found. For each object, the following properties are returned:
+    * title
+    * properties
+    * required
+    * enum
+    * anchor: a string suitable for using as an html anchor for this object (if `anchor_base` was set, and the object has a title)
 
   Note that the returned array may contain duplicate objects.
 
 */}}
 
 {{ $this_object := .schema }}
+{{ $anchor_base := .anchor_base }}
 {{ $additional_objects := slice }}
 
 {{ if eq $this_object.type "object" }}
+    {{/* give this object an anchor, if it has a name */}}
+    {{ if (and $anchor_base $this_object.title) }}
+        {{ $this_object = merge $this_object (dict "anchor" (printf "%s_%s" $anchor_base (anchorize $this_object.title))) }}
+    {{ end }}
 
     {{/*
       Add the object we were passed into the $additional_objects array
@@ -35,7 +43,7 @@
             {{ $additional_objects = $additional_objects | append (partial "clean-object" $this_object.additionalProperties) }}
 
             {{ range $key, $property := $this_object.additionalProperties.properties }}
-                {{ $additional_objects = partial "get-additional-objects" (dict "this_object" $property "additional_objects" $additional_objects) }}
+                {{ $additional_objects = partial "get-additional-objects" (dict "this_object" $property "additional_objects" $additional_objects "anchor_base" $anchor_base) }}
             {{ end }}
 
         {{ end }}
@@ -45,7 +53,7 @@
       Add any nested objects referenced in this object's `properties`
     */}}
     {{ range $key, $property := $this_object.properties}}
-        {{ $additional_objects = partial "get-additional-objects" (dict "this_object" $property "additional_objects" $additional_objects) }}
+        {{ $additional_objects = partial "get-additional-objects" (dict "this_object" $property "additional_objects" $additional_objects "anchor_base" $anchor_base) }}
     {{ end }}
 
 {{ end }}
@@ -56,10 +64,10 @@
     */}}
     {{ if reflect.IsSlice $this_object.items}}
         {{ range $this_object.items }}
-            {{ $additional_objects = partial "get-additional-objects" (dict "this_object" . "additional_objects" $additional_objects) }}
+            {{ $additional_objects = partial "get-additional-objects" (dict "this_object" . "additional_objects" $additional_objects "anchor_base" $anchor_base) }}
         {{ end }}
     {{ else }}
-        {{ $additional_objects = partial "get-additional-objects" (dict "this_object" $this_object.items "additional_objects" $additional_objects) }}
+        {{ $additional_objects = partial "get-additional-objects" (dict "this_object" $this_object.items "additional_objects" $additional_objects "anchor_base" $anchor_base) }}
     {{ end }}
 {{ end }}
 
@@ -77,7 +85,7 @@
      */
     {{ $this_object := partial "json-schema/resolve-allof" .this_object }}
 
-    {{ $more_objects := partial "json-schema/resolve-additional-types" (dict "schema" $this_object) }}
+    {{ $more_objects := partial "json-schema/resolve-additional-types" (dict "schema" $this_object "anchor_base" .anchor_base) }}
     {{/*
       As far as I know we don't have something like Array.concat(), so add them one at a time
     */}}
@@ -93,5 +101,5 @@
   but with (for example) different examples will be considered different.
 */}}
 {{ define "partials/clean-object" }}
-    {{ return (dict "title" .title "properties" .properties "required" .required "enum" .enum) }}
+    {{ return (dict "title" .title "properties" .properties "required" .required "enum" .enum "anchor" .anchor) }}
 {{ end }}

--- a/layouts/partials/json-schema/resolve-additional-types.html
+++ b/layouts/partials/json-schema/resolve-additional-types.html
@@ -1,11 +1,9 @@
 {{/*
 
-  Finds and returns all nested objects, given:
+  Finds and returns all nested objects, given a dict containing:
+   * `schema`: a JSON schema object
 
-  * `this_object`: a JSON schema object
-
-  Given a schema object, this template finds all nested objects under that
-  schema.
+  This template finds all nested objects inside `schema`.
 
   Assumes that "resolve-refs" and "resolve-allof" has already been called on the
   input schema.
@@ -19,7 +17,7 @@
 
 */}}
 
-{{ $this_object := . }}
+{{ $this_object := .schema }}
 {{ $additional_objects := slice }}
 
 {{ if eq $this_object.type "object" }}
@@ -79,7 +77,7 @@
      */
     {{ $this_object := partial "json-schema/resolve-allof" .this_object }}
 
-    {{ $more_objects := partial "json-schema/resolve-additional-types" $this_object }}
+    {{ $more_objects := partial "json-schema/resolve-additional-types" (dict "schema" $this_object) }}
     {{/*
       As far as I know we don't have something like Array.concat(), so add them one at a time
     */}}

--- a/layouts/partials/json-schema/resolve-additional-types.html
+++ b/layouts/partials/json-schema/resolve-additional-types.html
@@ -7,6 +7,9 @@
   Given a schema object, this template finds all nested objects under that
   schema.
 
+  Assumes that "resolve-refs" and "resolve-allof" has already been called on the
+  input schema.
+
   It "cleans" each object by copying only the parts of the objects that
   the renderer needs, and adds the result to an array, `additional_objects`.
 
@@ -16,7 +19,7 @@
 
 */}}
 
-{{ $this_object := partial "json-schema/resolve-allof" . }}
+{{ $this_object := . }}
 {{ $additional_objects := slice }}
 
 {{ if eq $this_object.type "object" }}
@@ -71,7 +74,11 @@
 {{ define "partials/get-additional-objects" }}
     {{ $additional_objects := .additional_objects }}
 
+    /* although we expect resolve-allof to be called on the input, resolve-allof does not recurse into
+     * nested objects, so we have to call it again.
+     */
     {{ $this_object := partial "json-schema/resolve-allof" .this_object }}
+
     {{ $more_objects := partial "json-schema/resolve-additional-types" $this_object }}
     {{/*
       As far as I know we don't have something like Array.concat(), so add them one at a time

--- a/layouts/partials/openapi/render-object-table.html
+++ b/layouts/partials/openapi/render-object-table.html
@@ -2,23 +2,25 @@
 
   Render a table listing the properties of an object, given:
 
-  * `caption`: optional caption for the table
+  * `title`: optional caption for the table
+
   * `properties`: dictionary of the properties to list, each given as:
-  `property_name` : `property_data`
+    `property_name` : `property_data`
+
   * `required`: array containing the names of required properties.
-  In some cases (such as response body specifications) this isn't used, and
-  instead properties have a `required` boolean attribute. We support this too.
+    In some cases (such as response body specifications) this isn't used, and
+    instead properties have a `required` boolean attribute. We support this too.
 
 */}}
 
-{{ $caption := .caption }}
+{{ $title := .title }}
 {{ $properties := .properties}}
 {{ $required := .required}}
 
 {{ if $properties }}
 
 <table class>
- {{ with $caption }}
+ {{ with $title }}
  <caption>{{ . }}</caption>
  {{ end }}
  <thead>

--- a/layouts/partials/openapi/render-object-table.html
+++ b/layouts/partials/openapi/render-object-table.html
@@ -4,6 +4,8 @@
 
   * `title`: optional caption for the table
 
+  * `anchor`: optional HTML element id for the table
+
   * `properties`: dictionary of the properties to list, each given as:
     `property_name` : `property_data`
 
@@ -19,7 +21,7 @@
 
 {{ if $properties }}
 
-<table class>
+<table{{ if .anchor }} id="{{ .anchor }}"{{ end }}>
  {{ with $title }}
  <caption>{{ . }}</caption>
  {{ end }}

--- a/layouts/partials/openapi/render-operation.html
+++ b/layouts/partials/openapi/render-operation.html
@@ -22,13 +22,14 @@
 {{ $endpoint := .endpoint }}
 {{ $operation_data := .operation_data }}
 {{ $path := .path }}
+{{ $anchor := anchorize $endpoint }}
 
 <section class="rendered-data http-api {{ $method }}">
 
 <details {{ if not site.Params.ui.rendered_data_collapsed }}open{{ end }}>
 <summary>
 
-  <h1 id="{{ lower $method }}{{ anchorize $endpoint }}">
+  <h1 id="{{ lower $method }}{{ $anchor }}">
    <span class="http-api-method {{ $method }}">{{ $method }}</span>
    <span class="endpoint{{ if $operation_data.deprecated }} deprecated-inline{{ end }}">{{ $endpoint }}</span>
   </h1>
@@ -63,9 +64,9 @@
 </table>
 
 <hr/>
-{{ partial "openapi/render-request"   (dict "parameters" $operation_data.parameters "path" $path) }}
+{{ partial "openapi/render-request"   (dict "parameters" $operation_data.parameters "path" $path "anchor_base" $anchor ) }}
 <hr/>
-{{ partial "openapi/render-responses" (dict "responses"  $operation_data.responses  "path" $path) }}
+{{ partial "openapi/render-responses" (dict "responses"  $operation_data.responses  "path" $path "anchor_base" $anchor ) }}
 
 </details>
 

--- a/layouts/partials/openapi/render-parameters.html
+++ b/layouts/partials/openapi/render-parameters.html
@@ -25,6 +25,6 @@
     {{ end }}
 
     {{/* and render the parameters */}}
-    {{ partial "openapi/render-object-table" (dict "caption" $caption "properties" $param_dict) }}
+    {{ partial "openapi/render-object-table" (dict "title" $caption "properties" $param_dict) }}
 
 {{ end }}

--- a/layouts/partials/openapi/render-request.html
+++ b/layouts/partials/openapi/render-request.html
@@ -38,7 +38,7 @@
         {{ $schema := partial "json-schema/resolve-refs" (dict "schema" $body_parameter.schema "path" $path) }}
         {{ $schema := partial "json-schema/resolve-allof" $schema }}
 
-        {{ $additional_types := partial "json-schema/resolve-additional-types" $schema }}
+        {{ $additional_types := partial "json-schema/resolve-additional-types" (dict "schema" $schema) }}
         {{ $additional_types = uniq $additional_types }}
         {{ range $additional_types }}
             {{ partial "openapi/render-object-table" (dict "caption" .title "properties" .properties "required" .required) }}

--- a/layouts/partials/openapi/render-request.html
+++ b/layouts/partials/openapi/render-request.html
@@ -41,7 +41,7 @@
         {{ $additional_types := partial "json-schema/resolve-additional-types" (dict "schema" $schema) }}
         {{ $additional_types = uniq $additional_types }}
         {{ range $additional_types }}
-            {{ partial "openapi/render-object-table" (dict "caption" .title "properties" .properties "required" .required) }}
+            {{ partial "openapi/render-object-table" . }}
         {{ end }}
 
 <h3>Request body example</h3>

--- a/layouts/partials/openapi/render-request.html
+++ b/layouts/partials/openapi/render-request.html
@@ -4,6 +4,7 @@
 
   * `parameters`: OpenAPI/Swagger data specifying the parameters
   * `path`: the path where this definition was found, to enable us to resolve "$ref"
+  * `anchor_base`: a prefix to add to the HTML anchors generated for each object
 
   This template renders:
   * the "simple parameters" (header, path, query parameters)
@@ -14,6 +15,7 @@
 
 {{ $parameters := .parameters }}
 {{ $path := .path }}
+{{ $anchor_base := .anchor_base }}
 
 <h2>Request</h2>
 
@@ -38,7 +40,7 @@
         {{ $schema := partial "json-schema/resolve-refs" (dict "schema" $body_parameter.schema "path" $path) }}
         {{ $schema := partial "json-schema/resolve-allof" $schema }}
 
-        {{ $additional_types := partial "json-schema/resolve-additional-types" (dict "schema" $schema) }}
+        {{ $additional_types := partial "json-schema/resolve-additional-types" (dict "schema" $schema "anchor_base" $anchor_base) }}
         {{ $additional_types = uniq $additional_types }}
         {{ range $additional_types }}
             {{ partial "openapi/render-object-table" . }}

--- a/layouts/partials/openapi/render-responses.html
+++ b/layouts/partials/openapi/render-responses.html
@@ -74,7 +74,7 @@
         {{ $additional_types := partial "json-schema/resolve-additional-types" (dict "schema" $schema) }}
         {{ $additional_types = uniq $additional_types }}
         {{ range $additional_types }}
-            {{ partial "openapi/render-object-table" (dict "caption" .title "properties" .properties "required" .required) }}
+            {{ partial "openapi/render-object-table" . }}
         {{ end }}
 
         {{/*

--- a/layouts/partials/openapi/render-responses.html
+++ b/layouts/partials/openapi/render-responses.html
@@ -4,6 +4,7 @@
 
   * `responses`: OpenAPI/Swagger data specifying the responses
   * `path`: the path where this definition was found, to enable us to resolve "$ref"
+  * `anchor_base`: a prefix to add to the HTML anchors generated for each object
 
   This template renders:
   * a summary of all the different responses
@@ -15,6 +16,7 @@
 
 {{ $responses := .responses }}
 {{ $path := .path }}
+{{ $anchor_base := .anchor_base }}
 
 <h2>Responses</h2>
 
@@ -71,7 +73,7 @@
           response. (This will be a no-op for response types which aren't
           objects or arrays.)
         */}}
-        {{ $additional_types := partial "json-schema/resolve-additional-types" (dict "schema" $schema) }}
+        {{ $additional_types := partial "json-schema/resolve-additional-types" (dict "schema" $schema "anchor_base" $anchor_base) }}
         {{ $additional_types = uniq $additional_types }}
         {{ range $additional_types }}
             {{ partial "openapi/render-object-table" . }}

--- a/layouts/partials/openapi/render-responses.html
+++ b/layouts/partials/openapi/render-responses.html
@@ -71,7 +71,7 @@
           response. (This will be a no-op for response types which aren't
           objects or arrays.)
         */}}
-        {{ $additional_types := partial "json-schema/resolve-additional-types" $schema }}
+        {{ $additional_types := partial "json-schema/resolve-additional-types" (dict "schema" $schema) }}
         {{ $additional_types = uniq $additional_types }}
         {{ range $additional_types }}
             {{ partial "openapi/render-object-table" (dict "caption" .title "properties" .properties "required" .required) }}

--- a/layouts/shortcodes/definition.html
+++ b/layouts/shortcodes/definition.html
@@ -45,7 +45,7 @@
 
 </summary>
 
-{{ $additional_types := partial "json-schema/resolve-additional-types" $definition }}
+{{ $additional_types := partial "json-schema/resolve-additional-types" (dict "schema" $definition) }}
 {{ $additional_types = uniq $additional_types }}
 
 {{ range $additional_types }}

--- a/layouts/shortcodes/definition.html
+++ b/layouts/shortcodes/definition.html
@@ -49,7 +49,7 @@
 {{ $additional_types = uniq $additional_types }}
 
 {{ range $additional_types }}
-    {{ partial "openapi/render-object-table" (dict "caption" .title "properties" .properties "required" .required) }}
+    {{ partial "openapi/render-object-table" . }}
 {{end}}
 
 <h2>Examples</h2>

--- a/layouts/shortcodes/event-fields.html
+++ b/layouts/shortcodes/event-fields.html
@@ -35,7 +35,7 @@
 
 {{ $event = merge $event (dict "title" "") }}
 
-{{ $additional_types := partial "json-schema/resolve-additional-types" $event }}
+{{ $additional_types := partial "json-schema/resolve-additional-types" (dict "schema" $event) }}
 {{ range $additional_types }}
     {{ partial "openapi/render-object-table" (dict "caption" .title "properties" .properties "required" .required) }}
 {{end}}

--- a/layouts/shortcodes/event-fields.html
+++ b/layouts/shortcodes/event-fields.html
@@ -37,7 +37,7 @@
 
 {{ $additional_types := partial "json-schema/resolve-additional-types" (dict "schema" $event) }}
 {{ range $additional_types }}
-    {{ partial "openapi/render-object-table" (dict "caption" .title "properties" .properties "required" .required) }}
+    {{ partial "openapi/render-object-table" . }}
 {{end}}
 
 </details>


### PR DESCRIPTION
I want to be able to hyperlink between the various object definitions in the spec. By way of a start, let's give each of the generated `<table>`s an `id`.

Suggest reviewing this commit-by-commit. It's not terribly complicated, but the total diff isn't that easy to follow.

Also, for easy reference, the diff in the generated spec: [spec.diff.txt](https://github.com/matrix-org/matrix-spec/files/9143970/spec.diff.txt)


<!-- Replace -->
Preview: https://pr1174--matrix-spec-previews.netlify.app
<!-- Replace -->
