### PR TITLE
Reinstate a smaller margin between struct tables

### DIFF
--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -323,12 +323,15 @@ footer {
   table {
     table-layout: fixed;
     width: 100%;
+    margin: 1.7rem 0;
+    border-bottom: 2px solid $gray-200;
 
     caption {
       caption-side: top;
       color: $dark;
       font-size: 1rem;
       font-weight: $font-weight-bold;
+      border-top: 2px solid $gray-200;
     }
 
     th, td, caption {

--- a/changelogs/client_server/newsfragments/1178.clarification
+++ b/changelogs/client_server/newsfragments/1178.clarification
@@ -1,0 +1,1 @@
+Improve the styling of adjacent `<table>`s rendered from OpenAPI definitions.

--- a/changelogs/server_server/newsfragments/1178.clarification
+++ b/changelogs/server_server/newsfragments/1178.clarification
@@ -1,0 +1,1 @@
+Improve the styling of adjacent `<table>`s rendered from OpenAPI definitions.


### PR DESCRIPTION
Without a margin, things look poor if the last row is blue: it then
merges into the caption at the top of the next table. 

I've also added a small border because I think it helps to break things
up a little.

Before: ![Before](https://user-images.githubusercontent.com/8614563/180253738-16fc1ea8-c53f-46f9-9132-a7537cd21804.png)
After: ![after](https://user-images.githubusercontent.com/8614563/180266911-2943828c-5373-4c90-b4da-15c7782d745c.png)

Xref: https://github.com/matrix-org/matrix-spec/commit/ea42cd3c7b40caae0b6925e1620173dd004e04a7#r79080321 and https://github.com/matrix-org/matrix-spec/pull/1166#discussion_r926890649

<!-- Replace -->
Preview: https://pr1178--matrix-spec-previews.netlify.app
<!-- Replace -->
