### PR TITLE
Tweak style of `<code>` samples in rendered tables

### DIFF
--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -317,7 +317,7 @@ footer {
   }
 
   p code, table code {
-    background-color: $white;
+    background-color: inherit;
   }
 
   table {

--- a/changelogs/client_server/newsfragments/1179.clarification
+++ b/changelogs/client_server/newsfragments/1179.clarification
@@ -1,0 +1,1 @@
+Tweak the styling of `<code>` snippets in tables rendered from OpenAPI definitions.

--- a/changelogs/server_server/newsfragments/1179.clarification
+++ b/changelogs/server_server/newsfragments/1179.clarification
@@ -1,0 +1,1 @@
+Tweak the styling of `<code>` snippets in tables rendered from OpenAPI definitions.


### PR DESCRIPTION
This has been subtly irritating me for aaaaaaages

Before (note the grey region around the text on blue rows, e.g. `unstable_features`)
![Screenshot from 2022-07-21 18-29-38](https://user-images.githubusercontent.com/8614563/180277494-4aa90e06-29e3-4bfc-9807-28442f9f82e1.png)

After: 
![Screenshot from 2022-07-21 18-38-02](https://user-images.githubusercontent.com/8614563/180278067-7eb26f2f-d4b8-43d0-97a5-654c9d02df4d.png)


<!-- Replace -->
Preview: https://pr1179--matrix-spec-previews.netlify.app
<!-- Replace -->
