### PR TITLE
CSS hack to fix scroll anchoring

### DIFF
--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -29,6 +29,12 @@ Custom SCSS for the Matrix spec
  */
 @import "syntax.scss";
 
+/* Workaround for https://github.com/google/docsy/issues/1116:
+ * fix scroll-anchoring */
+.td-outer {
+    height: auto;
+}
+
 /* Overrides for the navbar */
 .td-navbar {
   box-shadow: 0px 0px 8px rgba(179, 179, 179, 0.25);

--- a/changelogs/client_server/newsfragments/1183.clarification
+++ b/changelogs/client_server/newsfragments/1183.clarification
@@ -1,1 +1,0 @@
-Fix various typos throughout the specification.

--- a/changelogs/client_server/newsfragments/1183.clarification
+++ b/changelogs/client_server/newsfragments/1183.clarification
@@ -1,0 +1,1 @@
+Fix various typos throughout the specification.


### PR DESCRIPTION
Disable explicit `height` setting for the top-level div, which breaks scroll anchoring

<!-- Replace -->
Preview: https://pr1183--matrix-spec-previews.netlify.app
<!-- Replace -->
