### PR TITLE
Render HTML anchors for definition blocks

### DIFF
--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -165,16 +165,10 @@ footer {
 
 }
 
-/* Adjust heading anchors for site header */
-.td-content {
-  &> h2,
-  &> h3,
-  &> h4,
-  &> h5,
-  &> h6,
-  .rendered-data h1 {
-    scroll-margin-top: 5rem;
-  }
+/* Adjust the scroll margin for everything in the main content, so that
+ * it doesn't disappear behind the header bar */
+.td-content * {
+  scroll-margin-top: 5.5rem;
 }
 
 /* Styles for the table of contents */

--- a/changelogs/internal/newsfragments/1191.clarification
+++ b/changelogs/internal/newsfragments/1191.clarification
@@ -1,0 +1,1 @@
+Render HTML anchors for object definition tables.

--- a/layouts/shortcodes/definition.html
+++ b/layouts/shortcodes/definition.html
@@ -30,7 +30,7 @@
 {{ $definition = partial "json-schema/resolve-refs" (dict "schema" $definition "path" $path) }}
 {{ $definition = partial "json-schema/resolve-allof" $definition }}
 
-<section class="rendered-data definition">
+<section class="rendered-data definition" id="{{ anchorize $definition.title }}">
 
 <details {{ if not $compact }}open{{ end }}>
 <summary>


### PR DESCRIPTION
It's handy to be able to link to these.