### PR TITLE
Reinstate margin between tables

### DIFF
--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -313,10 +313,6 @@ footer {
     margin: 1.5rem 0 .75rem 0;
   }
 
-  h2 + table, h3 + table, h3 + div.highlight {
-    margin-top: 0;
-  }
-
   hr {
     border-bottom: 2px solid $dark;
     margin-bottom: 1.5rem;
@@ -329,6 +325,11 @@ footer {
   table {
     table-layout: fixed;
     width: 100%;
+
+    // add some space between two tables when they are right next to each other
+    & + table {
+        margin-top: 4rem;
+    }
 
     caption {
       caption-side: top;


### PR DESCRIPTION
This partially undoes a change made in https://github.com/matrix-org/matrix-spec/pull/1166, but only includes a margin where two tables are adjacent.

Includes changes from #1193 

<!-- Replace -->
Preview: https://pr1192--matrix-spec-previews.netlify.app
<!-- Replace -->
