### PR TITLE
Give rendered-data sections a background and some padding

### DIFF
--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -30,6 +30,9 @@ $note: $secondary;
 $note-background: $secondary-background;
 $warning-background: #FFE0E0;
 
+// colours for definition tables.
+// the border colour matches that used for "highlight" divs
+$table-border-color: rgba(black, .125);
 $table-row-alternate: $secondary-lightest-background;
 $table-row-default: $secondary-lighter-background;
 

--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -277,8 +277,6 @@ footer {
   details {
     summary {
       padding: .5rem 0;
-      list-style-position: outside;
-
       p {
         max-width: 80%;
       }

--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -359,7 +359,6 @@ footer {
     &.basic-info, &.basic-info th, &.basic-info td {
       table-layout: fixed;
       margin: 1rem 0 .5rem 0;
-      background-color: $white;
     }
 
     &.basic-info th {

--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -342,16 +342,18 @@ footer {
       padding: 1rem;
     }
 
-    th {
-      background-color: $white;
-    }
+    &.object-table, &.response-table {
+        caption, tr {
+            background-color: $table-row-default;
+        }
 
-    caption, tr {
-      background-color: $table-row-default;
-    }
+        tr:nth-child(even) {
+            background-color: $table-row-alternate;
+        }
 
-    tr:nth-child(even) {
-      background-color: $table-row-alternate;
+        th {
+            background-color: $white;
+        }
     }
 
     &.basic-info, &.basic-info th, &.basic-info td {

--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -270,7 +270,9 @@ footer {
 
 /* Styles for sections that are rendered from data, such as HTTP APIs and event schemas */
 .rendered-data {
-  margin: 1rem 0 3rem 0;
+  background-color: $secondary-lightest-background;
+  padding: 1rem;
+  margin: 1rem 0;
 
   details {
     summary {

--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -343,6 +343,17 @@ footer {
     }
 
     &.object-table, &.response-table {
+        border: 1px $table-border-color solid;
+
+        caption {
+            // the caption is outside the table's border box,
+            // so we have to give it its own border.
+            border: 1px $table-border-color solid;
+
+            // ... but avoid double border between caption and table
+            border-bottom: 0px;
+        }
+
         caption, tbody tr {
             background-color: $table-row-default;
         }

--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -351,7 +351,7 @@ footer {
             border: 1px $table-border-color solid;
 
             // ... but avoid double border between caption and table
-            border-bottom: 0px;
+            border-bottom: 0;
         }
 
         caption, tbody tr {

--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -343,16 +343,12 @@ footer {
     }
 
     &.object-table, &.response-table {
-        caption, tr {
+        caption, tbody tr {
             background-color: $table-row-default;
         }
 
-        tr:nth-child(even) {
+        tbody tr:nth-child(even) {
             background-color: $table-row-alternate;
-        }
-
-        th {
-            background-color: $white;
         }
     }
 

--- a/changelogs/internal/newsfragments/1195.clarification
+++ b/changelogs/internal/newsfragments/1195.clarification
@@ -1,0 +1,1 @@
+Give rendered-data sections a background and some padding.

--- a/layouts/partials/openapi/render-object-table.html
+++ b/layouts/partials/openapi/render-object-table.html
@@ -21,7 +21,7 @@
 
 {{ if $properties }}
 
-<table{{ if .anchor }} id="{{ .anchor }}"{{ end }}>
+<table{{ if .anchor }} id="{{ .anchor }}"{{ end }} class="object-table">
  {{ with $title }}
  <caption>{{ . }}</caption>
  {{ end }}

--- a/layouts/partials/openapi/render-responses.html
+++ b/layouts/partials/openapi/render-responses.html
@@ -20,7 +20,7 @@
 
 <h2>Responses</h2>
 
-<table class>
+<table class="response-table">
  <thead>
   <th class="col-status">Status</th>
   <th class="col-status-description">Description</th>


### PR DESCRIPTION
Not sure if everyone will like this, but it gives definition sections for APIs, events, etc a background and a small indent, which I find very helpful to guide the eye.

Suggest reviewing commit-by-commit as I had to move some stuff out of the way first.







<!-- Replace -->
Preview: https://pr1195--matrix-spec-previews.netlify.app
<!-- Replace -->
