### PR TITLE
Require `access_token`, `device_id` and `user_id` fields in `/login` response

### DIFF
--- a/changelogs/client_server/newsfragments/1210.clarification
+++ b/changelogs/client_server/newsfragments/1210.clarification
@@ -1,0 +1,1 @@
+Clarify that the "device_id", "user_id" and "access_token" fields are required in the response body of `POST /_matrix/client/v3/login`.

--- a/data/api/client-server/login.yaml
+++ b/data/api/client-server/login.yaml
@@ -210,6 +210,7 @@ paths:
                   form as the one returned from .well-known autodiscovery.
                 allOf:
                   - "$ref": "definitions/wellknown/full.yaml"
+            required: ["access_token", "device_id", "user_id"]
         400:
           description: |-
             Part of the request was invalid. For example, the login type may not be recognised.


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-spec/issues/676







<!-- Replace -->
Preview: https://pr1210--matrix-spec-previews.netlify.app
<!-- Replace -->
