### PR TITLE
Simplify password requirements

### DIFF
--- a/content/client-server-api/_index.md
+++ b/content/client-server-api/_index.md
@@ -1203,9 +1203,8 @@ forwarded to the login endpoint during the login process. For example:
 #### Notes on password management
 
 {{% boxes/warning %}}
-Clients SHOULD enforce that the password provided is suitably complex.
-The password SHOULD include a lower-case letter, an upper-case letter, a
-number and a symbol and be at a minimum 8 characters in length. Servers
+Clients SHOULD enforce that the password provided is suitably strong.
+The password SHOULD be at a minimum 8 characters in length. Servers
 MAY reject weak passwords with an error code `M_WEAK_PASSWORD`.
 {{% /boxes/warning %}}
 


### PR DESCRIPTION
A strong password is not necessary complex (https://xkcd.com/936/). Having arbitrary password requirements is a bit of a pain - we should rather push for 2FA / passwordless auth. 

I don't think this is a breaking change as it only change a "SHOULD" sentence. Any mismatch between clients / servers should still be 'spec complient' within the old text.

ECP = Enforce Complex Password
Client ECP - Server ECP: ✅
Client ECP - Server not-ECP: ✅
Client not-ECP - Server not-ECP: ✅
Client not-ECP - Server ECP: Potentially `M_WEAK_PASSWORD` which the client should already be able to handle.

This change will probably make it easier to implement [MSC2000](https://github.com/matrix-org/matrix-spec-proposals/pull/2000/)