### PR TITLE
Clarify that /context always returns 'event' even if limit is zero

### DIFF
--- a/changelogs/client_server/newsfragments/1239.clarification
+++ b/changelogs/client_server/newsfragments/1239.clarification
@@ -1,0 +1,1 @@
+Clarified that /context always returns 'event' even if limit is zero. Contributed by @sumnerevans at @beeper.

--- a/changelogs/client_server/newsfragments/1239.clarification
+++ b/changelogs/client_server/newsfragments/1239.clarification
@@ -1,1 +1,1 @@
-Clarified that /context always returns 'event' even if limit is zero. Contributed by @sumnerevans at @beeper.
+Clarify that `/context` always returns `event` even if `limit` is zero. Contributed by @sumnerevans at @beeper.

--- a/data/api/client-server/event_context.yaml
+++ b/data/api/client-server/event_context.yaml
@@ -60,7 +60,7 @@ paths:
             The maximum number of context events to return. The limit applies
             to the sum of the `events_before` and `events_after` arrays. The
             requested event ID is always returned in `event` even if `limit` is
-            0. Default: 10.
+            0. Defaults to 10.
           x-example: 3
         - in: query
           name: filter

--- a/data/api/client-server/event_context.yaml
+++ b/data/api/client-server/event_context.yaml
@@ -57,7 +57,10 @@ paths:
           type: integer
           name: limit
           description: |-
-            The maximum number of events to return. Default: 10.
+            The maximum number of context events to return. The limit applies
+            to the sum of the `events_before` and `events_after` arrays. The
+            requested event ID is always returned in `event` even if `limit` is
+            0. Default: 10.
           x-example: 3
         - in: query
           name: filter


### PR DESCRIPTION
Signed-off-by: Sumner Evans <me@sumnerevans.com>

---
name: Clarify that /context always returns 'event' even if limit is zero
about: The spec is not clear that the limit does not apply to the event itself.
title: ''
labels: ''
assignees: ''

---

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)





<!-- Replace -->
Preview: https://pr1239--matrix-spec-previews.netlify.app
<!-- Replace -->
