### PR TITLE
Fix typos in the spec related to account data

### DIFF
--- a/changelogs/client_server/newsfragments/1243.clarification
+++ b/changelogs/client_server/newsfragments/1243.clarification
@@ -1,0 +1,1 @@
+Fix various typos throughout the specification.

--- a/content/client-server-api/modules/account_data.md
+++ b/content/client-server-api/modules/account_data.md
@@ -17,10 +17,10 @@ data with the same `type`.
 #### Events
 
 The client receives the account data as events in the `account_data`
-sections of a `/sync`.
+sections of a [`/sync`](#get_matrixclientv3sync) response.
 
 These events can also be received in a `/events` response or in the
-`account_data` section of a room in `/sync`. `m.tag` events appearing in
+`account_data` section of a room in a `/sync` response. `m.tag` events appearing in
 `/events` will have a `room_id` with the room the tags are for.
 
 #### Client Behaviour

--- a/content/client-server-api/modules/push.md
+++ b/content/client-server-api/modules/push.md
@@ -768,7 +768,7 @@ per-device using the APIs below.
 ##### Push Rules: Events
 
 When a user changes their push rules a `m.push_rules` event is sent to
-all clients in the `account_data` section of their next `/sync` request.
+all clients in the `account_data` section of their next [`/sync`](#get_matrixclientv3sync) request.
 The content of the event is the current push rules for the user.
 
 {{% event event="m.push_rules" %}}

--- a/content/client-server-api/modules/secrets.md
+++ b/content/client-server-api/modules/secrets.md
@@ -30,7 +30,7 @@ clients can access, depending on what keys are given to them.
 ##### Key storage
 
 Each key has an ID, and the description of the key is stored in the
-user's account\_data using the event type
+user's account data using the event type
 `m.secret_storage.key.[key ID]`. The contents of the account data for
 the key will include an `algorithm` property, which indicates the
 encryption algorithm used, as well as a `name` property, which is a
@@ -51,7 +51,7 @@ Other properties depend on the encryption algorithm, and are described
 below.
 
 A key can be marked as the "default" key by setting the user's
-account\_data with event type `m.secret_storage.default_key` to an
+account data with event type `m.secret_storage.default_key` to an
 object that has the ID of the key as its `key` property. The default key
 will be used to encrypt all secrets that the user would expect to be
 available on all their clients. Unless the user specifies otherwise,
@@ -71,8 +71,8 @@ default key.
 
 ##### Secret storage
 
-Encrypted data is stored in the user's account\_data using the event
-type defined by the feature that uses the data. The account\_data will
+Encrypted data is stored in the user's account data using the event
+type defined by the feature that uses the data. The account data will
 have an `encrypted` property that is a map from key ID to an object. The
 algorithm from the `m.secret_storage.key.[key ID]` data for the given
 key defines how the other properties are interpreted, though it's

--- a/data/api/client-server/account-data.yaml
+++ b/data/api/client-server/account-data.yaml
@@ -158,7 +158,7 @@ paths:
           examples:
             application/json: {
               "errcode": "M_NOT_FOUND",
-              "error": "Room account data not found."
+              "error": "Account data not found."
             }
           schema:
             $ref: "../client-server/definitions/errors/error.yaml"

--- a/data/api/client-server/account-data.yaml
+++ b/data/api/client-server/account-data.yaml
@@ -29,11 +29,12 @@ securityDefinitions:
 paths:
   "/user/{userId}/account_data/{type}":
     put:
-      summary: Set some account_data for the user.
+      summary: Set some account data for the user.
       description: |-
-        Set some account_data for the client. This config is only visible to the user
-        that set the account_data. The config will be synced to clients in the
-        top-level `account_data`.
+        Set some account data for the client. This config is only visible to the user
+        that set the account data. The config will be available to clients through the
+        top-level `account_data` field in the homeserver response to
+        [/sync](#get_matrixclientv3sync).
       operationId: setAccountData
       security:
         - accessToken: []
@@ -43,7 +44,7 @@ paths:
           name: userId
           required: true
           description: |-
-            The ID of the user to set account_data for. The access token must be
+            The ID of the user to set account data for. The access token must be
             authorized to make requests for this user ID.
           x-example: "@alice:example.com"
         - in: path
@@ -51,14 +52,14 @@ paths:
           name: type
           required: true
           description: |-
-            The event type of the account_data to set. Custom types should be
+            The event type of the account data to set. Custom types should be
             namespaced to avoid clashes.
           x-example: "org.example.custom.config"
         - in: body
           name: content
           required: true
           description: |-
-            The content of the account_data
+            The content of the account data.
           schema:
             type: object
             example: {
@@ -66,7 +67,7 @@ paths:
       responses:
         200:
           description:
-            The account_data was successfully added.
+            The account data was successfully added.
           examples:
             application/json: {}
           schema:
@@ -107,10 +108,10 @@ paths:
       tags:
         - User data
     get:
-      summary: Get some account_data for the user.
+      summary: Get some account data for the user.
       description: |-
-        Get some account_data for the client. This config is only visible to the user
-        that set the account_data.
+        Get some account data for the client. This config is only visible to the user
+        that set the account data.
       operationId: getAccountData
       security:
         - accessToken: []
@@ -120,7 +121,7 @@ paths:
           name: userId
           required: true
           description: |-
-            The ID of the user to get account_data for. The access token must be
+            The ID of the user to get account data for. The access token must be
             authorized to make requests for this user ID.
           x-example: "@alice:example.com"
         - in: path
@@ -128,7 +129,7 @@ paths:
           name: type
           required: true
           description: |-
-            The event type of the account_data to get. Custom types should be
+            The event type of the account data to get. Custom types should be
             namespaced to avoid clashes.
           x-example: "org.example.custom.config"
       responses:
@@ -165,11 +166,11 @@ paths:
         - User data
   "/user/{userId}/rooms/{roomId}/account_data/{type}":
     put:
-      summary: Set some account_data for the user that is specific to a room.
+      summary: Set some account data for the user that is specific to a room.
       description: |-
-        Set some account_data for the client on a given room. This config is only
-        visible to the user that set the account_data. The config will be synced to
-        clients in the per-room `account_data`.
+        Set some account data for the client on a given room. This config is only
+        visible to the user that set the account data. The config will be delivered to
+        clients in the per-room entries via [/sync](#get_matrixclientv3sync).
       operationId: setAccountDataPerRoom
       security:
         - accessToken: []
@@ -179,7 +180,7 @@ paths:
           name: userId
           required: true
           description: |-
-            The ID of the user to set account_data for. The access token must be
+            The ID of the user to set account data for. The access token must be
             authorized to make requests for this user ID.
           x-example: "@alice:example.com"
         - in: path
@@ -187,21 +188,21 @@ paths:
           name: roomId
           required: true
           description: |-
-            The ID of the room to set account_data on.
+            The ID of the room to set account data on.
           x-example: "!726s6s6q:example.com"
         - in: path
           type: string
           name: type
           required: true
           description: |-
-            The event type of the account_data to set. Custom types should be
+            The event type of the account data to set. Custom types should be
             namespaced to avoid clashes.
           x-example: "org.example.custom.room.config"
         - in: body
           name: content
           required: true
           description: |-
-            The content of the account_data
+            The content of the account data.
           schema:
             type: object
             example: {
@@ -209,7 +210,7 @@ paths:
       responses:
         200:
           description:
-            The account_data was successfully added.
+            The account data was successfully added.
           examples:
             application/json: {}
           schema:
@@ -251,10 +252,10 @@ paths:
       tags:
         - User data
     get:
-      summary: Get some account_data for the user that is specific to a room.
+      summary: Get some account data for the user that is specific to a room.
       description: |-
-        Get some account_data for the client on a given room. This config is only
-        visible to the user that set the account_data.
+        Get some account data for the client on a given room. This config is only
+        visible to the user that set the account data.
       operationId: getAccountDataPerRoom
       security:
         - accessToken: []
@@ -264,7 +265,7 @@ paths:
           name: userId
           required: true
           description: |-
-            The ID of the user to set account_data for. The access token must be
+            The ID of the user to get account data for. The access token must be
             authorized to make requests for this user ID.
           x-example: "@alice:example.com"
         - in: path
@@ -272,14 +273,14 @@ paths:
           name: roomId
           required: true
           description: |-
-            The ID of the room to get account_data for.
+            The ID of the room to get account data for.
           x-example: "!726s6s6q:example.com"
         - in: path
           type: string
           name: type
           required: true
           description: |-
-            The event type of the account_data to get. Custom types should be
+            The event type of the account data to get. Custom types should be
             namespaced to avoid clashes.
           x-example: "org.example.custom.room.config"
       responses:


### PR DESCRIPTION
This PR:

* Only use an underscore between 'account' and 'data' when referring to a field.
* Correct some grammar, and one instance of "set" that should have been "get".
* Add markdown links to /sync.







<!-- Replace -->
Preview: https://pr1243--matrix-spec-previews.netlify.app
<!-- Replace -->
