### PR TITLE
Receipts: Add `thread_id` to the `/receipt` endpoint

### DIFF
--- a/changelogs/client_server/newsfragments/1261.clarification
+++ b/changelogs/client_server/newsfragments/1261.clarification
@@ -1,0 +1,1 @@
+Add `thread_id` to the `/receipt` endpoint, as per [MSC3771](https://github.com/matrix-org/matrix-spec-proposals/pull/3771)

--- a/data/api/client-server/receipts.yaml
+++ b/data/api/client-server/receipts.yaml
@@ -74,8 +74,18 @@ paths:
           required: true
           schema:
             type: object
+            properties:
+              thread_id:
+                type: string
+                x-addedInMatrixVersion: "1.4"
+                description: |-
+                    The root thread event's ID (or `main`) for which
+                    thread this receipt is intended to be under. If
+                    not specified, the read receipt is *unthreaded*
+                    (default).
             example: {
-              }
+              "thread_id": "main"
+            }
       responses:
         200:
           description: The receipt was sent.
@@ -88,5 +98,17 @@ paths:
           description: This request was rate-limited.
           schema:
             "$ref": "definitions/errors/rate_limited.yaml"
+        400:
+          description: |-
+            The `thread_id is not a string, or is empty, or it is provided for
+            a receipt of type `m.fully_read`, or the `event_id` is not related
+            to the `thread_id`.
+          schema:
+            $ref: "definitions/errors/error.yaml"
+          examples:
+            application/json: {
+              "errcode": "M_INVALID_PARAM",
+              "error": "thread_id field must be a non-empty string"
+            }
       tags:
         - Room participation

--- a/data/api/client-server/receipts.yaml
+++ b/data/api/client-server/receipts.yaml
@@ -100,9 +100,11 @@ paths:
             "$ref": "definitions/errors/rate_limited.yaml"
         400:
           description: |-
-            The `thread_id` is not a string, or is empty, or it is provided for
-            a receipt of type `m.fully_read`, or the `event_id` is not related
-            to the `thread_id`.
+            The `thread_id` is invalid in some way. For example:
+            * It is not a string.
+            * It is empty.
+            * It is provided for an incompatible receipt type.
+            * The `event_id` is not related to the `thread_id`.
           schema:
             $ref: "definitions/errors/error.yaml"
           examples:

--- a/data/api/client-server/receipts.yaml
+++ b/data/api/client-server/receipts.yaml
@@ -100,7 +100,7 @@ paths:
             "$ref": "definitions/errors/rate_limited.yaml"
         400:
           description: |-
-            The `thread_id is not a string, or is empty, or it is provided for
+            The `thread_id` is not a string, or is empty, or it is provided for
             a receipt of type `m.fully_read`, or the `event_id` is not related
             to the `thread_id`.
           schema:


### PR DESCRIPTION
It seems to have been omitted in #1255.

Per [MSC3771](https://github.com/matrix-org/matrix-spec-proposals/pull/3771).













<!-- Replace -->
Preview: https://pr1261--matrix-spec-previews.netlify.app
<!-- Replace -->
