### PR TITLE
Aggregations: remove not about "future extensions"

### DIFF
--- a/changelogs/client_server/newsfragments/1263.clarification
+++ b/changelogs/client_server/newsfragments/1263.clarification
@@ -1,0 +1,1 @@
+Fix various typos throughout the specification.

--- a/content/client-server-api/_index.md
+++ b/content/client-server-api/_index.md
@@ -1988,11 +1988,6 @@ of times that `key` was used by child events.
 
 The actual aggregation format depends on the `rel_type`.
 
-{{% boxes/note %}}
-This specification does not currently describe any `rel_type`s which require
-aggregation. This functionality forms a framework for future extensions.
-{{% /boxes/note %}}
-
 Aggregations are sometimes automatically included by a server alongside the parent
 event. This is known as a "bundled aggregation" or "bundle" for simplicity. The
 act of doing this is "bundling".


### PR DESCRIPTION
It is now used by threading.




<!-- Replace -->
Preview: https://pr1263--matrix-spec-previews.netlify.app
<!-- Replace -->
