### PR TITLE
Remove reference to a `room_id` key for typing events

### DIFF
--- a/changelogs/client_server/newsfragments/1265.clarification
+++ b/changelogs/client_server/newsfragments/1265.clarification
@@ -1,0 +1,1 @@
+Fix various typos throughout the specification.

--- a/content/client-server-api/modules/typing_notifications.md
+++ b/content/client-server-api/modules/typing_notifications.md
@@ -7,7 +7,7 @@ type: module
 Users may wish to be informed when another user is typing in a room.
 This can be achieved using typing notifications. These are ephemeral
 events, so they do not form part of the
-[Event Graph](index.html#event-graphs), even though they are scoped
+[Event Graph](index.html#event-graphs). Typing notifications are scoped
 to a room.
 
 #### Events

--- a/content/client-server-api/modules/typing_notifications.md
+++ b/content/client-server-api/modules/typing_notifications.md
@@ -6,8 +6,8 @@ type: module
 
 Users may wish to be informed when another user is typing in a room.
 This can be achieved using typing notifications. These are ephemeral
-events scoped to a `room_id`. This means they do not form part of the
-[Event Graph](index.html#event-graphs) but still have a `room_id` key.
+events scoped to a room, but they do not form part of the
+[Event Graph](index.html#event-graphs).
 
 #### Events
 

--- a/content/client-server-api/modules/typing_notifications.md
+++ b/content/client-server-api/modules/typing_notifications.md
@@ -6,8 +6,9 @@ type: module
 
 Users may wish to be informed when another user is typing in a room.
 This can be achieved using typing notifications. These are ephemeral
-events scoped to a room, but they do not form part of the
-[Event Graph](index.html#event-graphs).
+events, so they do not form part of the
+[Event Graph](index.html#event-graphs), even though they are scoped
+to a room.
 
 #### Events
 


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-spec/issues/578

Typing events do not contain a `room_id` key. They are instead scoped to a room, for example under a specific room's ephemeral events listing in a [`/sync`](https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3sync) response.

Removing the reference to `room_id` helps reduce confusion.







<!-- Replace -->
Preview: https://pr1265--matrix-spec-previews.netlify.app
<!-- Replace -->
