### PR TITLE
Fix naming of `device_one_time_keys_count` in `/sync`

### DIFF
--- a/changelogs/client_server/newsfragments/1266.clarification
+++ b/changelogs/client_server/newsfragments/1266.clarification
@@ -1,0 +1,1 @@
+Fix naming of `device_one_time_keys_count` in `/sync`.

--- a/content/client-server-api/modules/end_to_end_encryption.md
+++ b/content/client-server-api/modules/end_to_end_encryption.md
@@ -1622,7 +1622,7 @@ specified). The client is expected to use [`/keys/query`](/client-server-api/#po
 sync, as documented in [Tracking the device list for a
 user](#tracking-the-device-list-for-a-user).
 
-It also adds a `one_time_keys_count` property. Note the spelling
+It also adds a `device_one_time_keys_count` property. Note the spelling
 difference with the `one_time_key_counts` property in the
 [`/keys/upload`](/client-server-api/#post_matrixclientv3keysupload) response.
 


### PR DESCRIPTION
Fixes #671

I checked this against Synapse, as well as that `one_time_key_counts` is the right field in `/keys/upload`




<!-- Replace -->
Preview: https://pr1266--matrix-spec-previews.netlify.app
<!-- Replace -->
