### PR TITLE
Fix up description of `knock_room_state` field, which implied the required field was optional

### DIFF
--- a/changelogs/client_server/newsfragments/1276.clarification
+++ b/changelogs/client_server/newsfragments/1276.clarification
@@ -1,0 +1,1 @@
+Fix various typos throughout the specification.

--- a/data/api/server-server/knocks.yaml
+++ b/data/api/server-server/knocks.yaml
@@ -287,7 +287,7 @@ paths:
                 items:
                   $ref: "../../event-schemas/schema/core-event-schema/stripped_state.yaml"
                 description: |-
-                  An optional list of [stripped state events](/client-server-api/#stripped-state)
+                  A list of [stripped state events](/client-server-api/#stripped-state)
                   to help the initiator of the knock identify the room.
                 example:
                   $ref: "../../event-schemas/examples/knock_room_state.json"


### PR DESCRIPTION
[MSC2403](https://github.com/matrix-org/matrix-spec-proposals/pull/2403) states that [this field is required](https://github.com/matrix-org/matrix-spec-proposals/blob/main/proposals/2403-knock.md#put-_matrixfederationv1send_knockroomideventid). I'm not sure I actually agree with that, but it's what the MSC says.

Before this PR, the description of this field looked like:

![image](https://user-images.githubusercontent.com/1342360/194370733-d522b0c5-6f32-46b8-8a7f-5324d1300525.png)

This PR drops the optional part:

![image](https://user-images.githubusercontent.com/1342360/194370913-01425d06-cc88-41d1-92d3-8176b35b3823.png)





<!-- Replace -->
Preview: https://pr1276--matrix-spec-previews.netlify.app
<!-- Replace -->
