### PR TITLE
Remove `origin` field from transactions

### DIFF
--- a/changelogs/server_server/newsfragments/1278.clarification
+++ b/changelogs/server_server/newsfragments/1278.clarification
@@ -1,0 +1,1 @@
+Remove `origin` field from transactions which was redundant and not enforced to be present by Synapse.

--- a/data/api/server-server/definitions/single_pdu_transaction.yaml
+++ b/data/api/server-server/definitions/single_pdu_transaction.yaml
@@ -29,4 +29,4 @@ properties:
       properties: {}
       example:
         $ref: "../examples/minimal_pdu.json"
-required: ['origin', 'origin_server_ts', 'pdus']
+required: ['origin_server_ts', 'pdus']

--- a/data/api/server-server/definitions/transaction.yaml
+++ b/data/api/server-server/definitions/transaction.yaml
@@ -17,11 +17,6 @@ description: Transaction
 example:
   $ref: "../examples/transaction.json"
 properties:
-  origin:
-    type: string
-    description: |-
-      The `server_name` of the homeserver sending this transaction.
-    example: "example.org"
   origin_server_ts:
     type: integer
     format: int64
@@ -44,4 +39,4 @@ properties:
       properties: {}
       example:
         $ref: "../examples/minimal_pdu.json"
-required: ['origin', 'origin_server_ts', 'pdus']
+required: ['origin_server_ts', 'pdus']

--- a/data/api/server-server/definitions/unlimited_pdu_transaction.yaml
+++ b/data/api/server-server/definitions/unlimited_pdu_transaction.yaml
@@ -30,4 +30,4 @@ properties:
       properties: {}
       example:
         $ref: "../examples/minimal_pdu.json"
-required: ['origin', 'origin_server_ts', 'pdus']
+required: ['origin_server_ts', 'pdus']

--- a/data/api/server-server/examples/transaction.json
+++ b/data/api/server-server/examples/transaction.json
@@ -1,5 +1,4 @@
 {
-    "origin": "matrix.org",
     "origin_server_ts": 1234567890,
     "pdus": [{
         "$ref": "minimal_pdu.json"


### PR DESCRIPTION
Part of #374. According to latest comments there, the inclusion of `origin` can likely be considered a spec bug, which is why this isn't an MSC with a migration plan or anything like that.

<!-- Replace -->
Preview: https://pr1278--matrix-spec-previews.netlify.app
<!-- Replace -->
