### PR TITLE
improve documentation of ephemeral events

### DIFF
--- a/changelogs/client_server/newsfragments/1284.clarification
+++ b/changelogs/client_server/newsfragments/1284.clarification
@@ -1,0 +1,1 @@
+Improve documentation about ephemeral events.

--- a/content/client-server-api/_index.md
+++ b/content/client-server-api/_index.md
@@ -1521,7 +1521,7 @@ any given point in time:
 
 ### Types of room events
 
-Room events are split into three categories:
+Room events are split into two categories:
 
 * **State events**: These are events which update the metadata state of the room (e.g. room
 topic, room membership etc). State is keyed by a tuple of event `type`
@@ -1531,12 +1531,6 @@ overwritten.
 * **Message events**: These are events which describe transient "once-off" activity in a room:
 typically communication such as sending an instant message or setting up
 a VoIP call.
-
-* **Ephemeral events**: These are events which are not persisted in the room's
-timeline. In this version of the spec, these are [typing
-notification](#typing-notifications) and [read receipt](#receipts) events. Note
-that, unlike state events and message events, there is currently no way of
-defining custom ephemeral events.
 
 This specification outlines several events, all with the event type
 prefix `m.`. (See [Room Events](#room-events) for the m. event
@@ -1565,9 +1559,7 @@ in [room version 1](/rooms/v1#event-format) and [room version
 
 However, it is unusual that a Matrix client would encounter this event
 format. Instead, homeservers are responsible for converting events into the
-format shown below so that they can be easily parsed by clients. Note that the
-format below only applies to state and message events; ephemeral events will
-only have the `type` and `content` properties.
+format shown below so that they can be easily parsed by clients.
 
 {{% boxes/warning %}}
 Event bodies are considered untrusted data. This means that any application using

--- a/content/client-server-api/_index.md
+++ b/content/client-server-api/_index.md
@@ -1521,7 +1521,7 @@ any given point in time:
 
 ### Types of room events
 
-Room events are split into two categories:
+Room events are split into three categories:
 
 * **State events**: These are events which update the metadata state of the room (e.g. room
 topic, room membership etc). State is keyed by a tuple of event `type`
@@ -1531,6 +1531,12 @@ overwritten.
 * **Message events**: These are events which describe transient "once-off" activity in a room:
 typically communication such as sending an instant message or setting up
 a VoIP call.
+
+* **Ephemeral events**: These are events which are not persisted in the room's
+timeline. In this version of the spec, these are [typing
+notification](#typing-notifications) and [read receipt](#receipts) events. Note
+that, unlike state events and message events, there is currently no way of
+defining custom ephemeral events.
 
 This specification outlines several events, all with the event type
 prefix `m.`. (See [Room Events](#room-events) for the m. event
@@ -1559,7 +1565,9 @@ in [room version 1](/rooms/v1#event-format) and [room version
 
 However, it is unusual that a Matrix client would encounter this event
 format. Instead, homeservers are responsible for converting events into the
-format shown below so that they can be easily parsed by clients.
+format shown below so that they can be easily parsed by clients. Note that the
+format below only applies to state and message events; ephemeral events will
+only have the `type` and `content` properties.
 
 {{% boxes/warning %}}
 Event bodies are considered untrusted data. This means that any application using

--- a/data/api/client-server/definitions/sync_filter.yaml
+++ b/data/api/client-server/definitions/sync_filter.yaml
@@ -62,7 +62,9 @@ properties:
       ephemeral:
         allOf:
         - $ref: room_event_filter.yaml
-        description: The ephemeral events to include for rooms.
+        description: The ephemeral events to include for rooms. These are the
+          events that appear in the `ephemeral` property in the `/sync`
+          response.
       include_leave:
         description: Include rooms that the user has left in the sync, default false
         type: boolean

--- a/data/api/client-server/definitions/sync_filter.yaml
+++ b/data/api/client-server/definitions/sync_filter.yaml
@@ -62,8 +62,7 @@ properties:
       ephemeral:
         allOf:
         - $ref: room_event_filter.yaml
-        description: The events that aren't recorded in the room history, e.g. typing
-          and receipts, to include for rooms.
+        description: The ephemeral events to include for rooms.
       include_leave:
         description: Include rooms that the user has left in the sync, default false
         type: boolean

--- a/data/api/client-server/sync.yaml
+++ b/data/api/client-server/sync.yaml
@@ -219,7 +219,11 @@ paths:
                           title: Ephemeral
                           type: object
                           description: |-
-                            The new ephemeral events in the room.
+                            The new ephemeral events in the room (events that
+                            aren't recorded in the timeline or state of the
+                            room). In this version of the spec, these are
+                            [typing notification](#typing-notifications) and
+                            [read receipt](#receipts) events.
                           allOf:
                             - $ref: "definitions/event_batch.yaml"
                         account_data:

--- a/data/api/client-server/sync.yaml
+++ b/data/api/client-server/sync.yaml
@@ -219,9 +219,7 @@ paths:
                           title: Ephemeral
                           type: object
                           description: |-
-                            The ephemeral events in the room that aren't
-                            recorded in the timeline or state of the room.
-                            e.g. typing.
+                            The new ephemeral events in the room.
                           allOf:
                             - $ref: "definitions/event_batch.yaml"
                         account_data:


### PR DESCRIPTION
I'm not entirely sure if what I've done here is exactly right, but I think that we need to define ephemeral events in one spot, and then just use the "ephemeral" terminology instead of saying "events that aren't persisted e.g. typing".  Opinions on whether this PR looks good, or whether there's a better place to define it, are welcome.

Addresses part of https://github.com/matrix-org/matrix-spec/issues/136







<!-- Replace -->
Preview: https://pr1284--matrix-spec-previews.netlify.app
<!-- Replace -->
