### PR TITLE
Fix /refresh endpoint to be V1 instead of V3

### DIFF
--- a/content/client-server-api/_index.md
+++ b/content/client-server-api/_index.md
@@ -403,7 +403,7 @@ Access tokens can expire after a certain amount of time. Any HTTP calls that
 use an expired access token will return with an error code `M_UNKNOWN_TOKEN`,
 preferably with `soft_logout: true`. When a client receives this error and it
 has a refresh token, it should attempt to refresh the access token by calling
-[`/refresh`](#post_matrixclientv3refresh). Clients can also refresh their
+[`/refresh`](#post_matrixclientv1refresh). Clients can also refresh their
 access token at any time, even if it has not yet expired. If the token refresh
 succeeds, the client should use the new token for future requests, and can
 re-try previously-failed requests with the new token. When an access token is

--- a/data/api/client-server/refresh.yaml
+++ b/data/api/client-server/refresh.yaml
@@ -19,7 +19,7 @@ host: localhost:8008
 schemes:
   - https
   - http
-basePath: /_matrix/client/v3
+basePath: /_matrix/client/v1
 consumes:
   - application/json
 produces:


### PR DESCRIPTION
The implementations in synapse and matrix-js-sdk use this as /v1/refresh, which, according to @KitsuneRal, is correct

Signed-off-by: Tobias Fella <fella@posteo.de>

<!-- Replace -->
Preview: https://pr1289--matrix-spec-previews.netlify.app
<!-- Replace -->
