### PR TITLE
Update /pushers/set info to make deletion clearer

### DIFF
--- a/changelogs/client_server/newsfragments/1293.clarification
+++ b/changelogs/client_server/newsfragments/1293.clarification
@@ -1,0 +1,1 @@
+Update `/pushers/set` endpoint info to make deletion proccess clearer.

--- a/changelogs/client_server/newsfragments/1293.clarification
+++ b/changelogs/client_server/newsfragments/1293.clarification
@@ -1,1 +1,1 @@
-Update `/pushers/set` endpoint info to make deletion proccess clearer.
+Update `/pushers/set` endpoint info to make deletion process clearer.

--- a/data/api/client-server/pusher.yaml
+++ b/data/api/client-server/pusher.yaml
@@ -139,6 +139,7 @@ paths:
         This endpoint allows the creation, modification and deletion of [pushers](/client-server-api/#push-notifications)
         for this user ID. The behaviour of this endpoint varies depending on the
         values in the JSON body.
+        
         For deletion, send a request with`kind:null`, also including `app_id` and `pushkey` of the pusher you want to remove. 
       operationId: postPusher
       security:

--- a/data/api/client-server/pusher.yaml
+++ b/data/api/client-server/pusher.yaml
@@ -139,6 +139,7 @@ paths:
         This endpoint allows the creation, modification and deletion of [pushers](/client-server-api/#push-notifications)
         for this user ID. The behaviour of this endpoint varies depending on the
         values in the JSON body.
+        For deletion, send a request with`kind:null`, including `app_id` and `pushkey` of the pusher you want to remove. 
       operationId: postPusher
       security:
         - accessToken: []

--- a/data/api/client-server/pusher.yaml
+++ b/data/api/client-server/pusher.yaml
@@ -139,7 +139,7 @@ paths:
         This endpoint allows the creation, modification and deletion of [pushers](/client-server-api/#push-notifications)
         for this user ID. The behaviour of this endpoint varies depending on the
         values in the JSON body.
-        For deletion, send a request with`kind:null`, including `app_id` and `pushkey` of the pusher you want to remove. 
+        For deletion, send a request with`kind:null`, also including `app_id` and `pushkey` of the pusher you want to remove. 
       operationId: postPusher
       security:
         - accessToken: []


### PR DESCRIPTION
I had trouble figuring out how to remove a pusher with this endpoint today, and had to look synapse's implementation to figure it out. Later @richvdh  pointed out that this bit of info was indeed already there, in the `kind` property: "null deletes the pusher.", but I feel it would still be valuable to add this info to the top and specify what additional params required for the operation (at least according to synapse).  Maybe the text I added needs some changes to make it more in line with the pattern from the rest of the specs, let me know.

Signed-off-by: Victor von Sydow <victor@jigvis.com.br> 

PS: This is my first spec PR, I think I got everything covered now but not sure.







<!-- Replace -->
Preview: https://pr1293--matrix-spec-previews.netlify.app
<!-- Replace -->
