### PR TITLE
Update docsy (hugo theme) git submodule

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -121,6 +121,12 @@ jobs:
         run: |
           npm i
           npm run get-proposals
+      - name: "⚙️ npm — docsy"
+        # Install dependencies according to https://github.com/google/docsy/#prerequisites
+        run: |
+          cd themes/docsy
+          npm i
+          npm i --save-dev autoprefixer postcss-cli postcss
       - name: "⚙️ hugo"
         run: hugo --baseURL "${{ needs.calculate-baseurl.outputs.baseURL }}" -d "spec"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -121,12 +121,6 @@ jobs:
         run: |
           npm i
           npm run get-proposals
-      - name: "⚙️ npm — docsy"
-        # Install dependencies according to https://github.com/google/docsy/#prerequisites
-        run: |
-          cd themes/docsy
-          npm i
-          npm i --save-dev autoprefixer postcss-cli postcss
       - name: "⚙️ hugo"
         run: hugo --baseURL "${{ needs.calculate-baseurl.outputs.baseURL }}" -d "spec"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -115,8 +115,6 @@ jobs:
           extended: true
       - name: "📥 Source checkout"
         uses: actions/checkout@v2
-        with:
-          submodules: 'recursive'
       - name: "⚙️ npm"
         run: |
           npm i
@@ -161,8 +159,6 @@ jobs:
           extended: true
       - name: "📥 Source checkout"
         uses: actions/checkout@v2
-        with:
-          submodules: 'recursive'
       - name: "⚙️ npm"
         run: |
           npm i

--- a/README.md
+++ b/README.md
@@ -65,15 +65,14 @@ place after an MSC has been accepted, not as part of a proposal itself.
    Alternatively, use the Docker image at
    https://hub.docker.com/r/klakegg/hugo/. (The "extended edition" is required
    to process the SCSS.)
-2. Run `git submodule update --init --recursive` for good measure.
-3. Run `npm i` to install the dependencies. Note that this will require NodeJS to be installed.
-4. Run `npm run get-proposals` to seed proposal data. This is merely for populating the content of the "Spec Change Proposals"
+2. Run `npm i` to install the dependencies. Note that this will require NodeJS to be installed.
+3. Run `npm run get-proposals` to seed proposal data. This is merely for populating the content of the "Spec Change Proposals"
    page and is not required.
-5. Run `hugo serve` (or `docker run --rm -it -v $(pwd):/src -p 1313:1313
+4. Run `hugo serve` (or `docker run --rm -it -v $(pwd):/src -p 1313:1313
    klakegg/hugo:ext serve`) to run a local webserver which builds whenever a file
    change is detected. If watching doesn't appear to be working for you, try
    adding `--disableFastRender` to the commandline.
-6. Edit the specification 🙂
+5. Edit the specification 🙂
 
 We use a highly customized [Docsy](https://www.docsy.dev/) theme for our generated site, which uses Bootstrap and Font
 Awesome. If you're looking at making design-related changes to the spec site, please coordinate with us in

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ place after an MSC has been accepted, not as part of a proposal itself.
    Alternatively, use the Docker image at
    https://hub.docker.com/r/klakegg/hugo/. (The "extended edition" is required
    to process the SCSS.)
-2. Run `npm i` to install the dependencies. Note that this will require NodeJS to be installed.
+2. Run `npm i` to install the dependencies and fetch the docsy git submodule.
+   Note that this will require NodeJS to be installed.
 3. Run `npm run get-proposals` to seed proposal data. This is merely for populating the content of the "Spec Change Proposals"
    page and is not required.
 4. Run `hugo serve` (or `docker run --rm -it -v $(pwd):/src -p 1313:1313

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -36,19 +36,16 @@ $table-border-color: rgba(black, .125);
 $table-row-alternate: $secondary-lightest-background;
 $table-row-default: $secondary-lighter-background;
 
-/*
- Disable loading any fonts from Google Fonts.
- */
+/* Disable loading any fonts from Google Fonts. */
 $td-enable-google-fonts: false;
 
 /*
- Replace the default font with Inter - we load it from a local copy, which is downloaded from
- Google Fonts manually via a script:
- https://github.com/matrix-org/matrix-spec/tree/main/static/css/fonts
-
- The $font-family-sans-serif definition here overrides the default value set by docsy:
- https://github.com/matrix-org/docsy/blob/66a4e61d2d34edc7196b9df83a7d09cd4af14b47/assets/scss/_variables.scss#L68
- and adds "Inter" to the front.
- */
+ * Replace the default font with Inter - we load it from a local copy, which is downloaded from
+ * Google Fonts manually via a script:
+ * https://github.com/matrix-org/matrix-spec/tree/main/static/css/fonts
+ *
+ * The $font-family-sans-serif definition here overrides the default value set by docsy:
+ * https://github.com/matrix-org/docsy/blob/66a4e61d2d34edc7196b9df83a7d09cd4af14b47/assets/scss/_variables.scss#L68
+ * and adds "Inter" to the front. */
 @import url("../css/fonts/Inter.css");
 $font-family-sans-serif: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -36,7 +36,8 @@ $table-border-color: rgba(black, .125);
 $table-row-alternate: $secondary-lightest-background;
 $table-row-default: $secondary-lighter-background;
 
-/* Disable loading any fonts from Google Fonts. */
+/* Configure docsy to use the default system fonts instead of Google Fonts.
+ * See https://www.docsy.dev/docs/adding-content/lookandfeel/#fonts */
 $td-enable-google-fonts: false;
 
 /*

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -37,8 +37,17 @@ $table-row-alternate: $secondary-lightest-background;
 $table-row-default: $secondary-lighter-background;
 
 /*
- Opt to serve fonts locally by overriding web-font-path to be a non-google fonts URL.
- This is only possible with our modified docsy theme: https://github.com/matrix-org/docsy
+ Disable loading any fonts from Google Fonts.
  */
-$web-font-path: "../css/fonts/Inter.css";
-$google_font_name: "Inter";
+$td-enable-google-fonts: false;
+
+/*
+ Replace the default font with Inter - we load it from a local copy, which is downloaded from
+ Google Fonts manually via a script:
+ https://github.com/matrix-org/matrix-spec/tree/main/static/css/fonts
+
+ The list of fonts (with Inter prepended) is taken from docsy's source code:
+ https://github.com/matrix-org/docsy/blob/66a4e61d2d34edc7196b9df83a7d09cd4af14b47/assets/scss/_variables.scss#L68
+ */
+@import url("../css/fonts/Inter.css");
+$font-family-sans-serif: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -46,8 +46,9 @@ $td-enable-google-fonts: false;
  Google Fonts manually via a script:
  https://github.com/matrix-org/matrix-spec/tree/main/static/css/fonts
 
- The list of fonts (with Inter prepended) is taken from docsy's source code:
+ The $font-family-sans-serif definition here overrides the default value set by docsy:
  https://github.com/matrix-org/docsy/blob/66a4e61d2d34edc7196b9df83a7d09cd4af14b47/assets/scss/_variables.scss#L68
+ and adds "Inter" to the front.
  */
 @import url("../css/fonts/Inter.css");
 $font-family-sans-serif: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";

--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -340,6 +340,16 @@ footer {
   }
 
   table {
+    /* Docsy makes all tables "responsive tables", which causes Bootstrap 4 to create
+     * tables with a "display" property of "block".
+     *
+     * However, for "table-layout: fixed" to be effective, an element must have a
+     * "display" property of "table".
+     *
+     * Thus, we override the "display" property here. This may no longer be necessary once
+     * Docsy updates to Bootstrap v5+: https://github.com/google/docsy/issues/470.
+     * For more details, see
+     * https://github.com/matrix-org/matrix-spec/pull/1295/files#r1010759688 */
     display: table;
     table-layout: fixed;
     width: 100%;

--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -340,6 +340,7 @@ footer {
   }
 
   table {
+    display: table;
     table-layout: fixed;
     width: 100%;
 
@@ -462,10 +463,4 @@ Make padding symmetrical (this selector is used in the default styles to apply p
   background-position: left 1rem center;
   background-repeat: no-repeat;
   padding-left: 100px;
-}
-
-/* Full-width tables */
-.td-content > table {
-  width: 100%;
-  display: table;
 }

--- a/changelogs/internal/newsfragments/1295.feature
+++ b/changelogs/internal/newsfragments/1295.feature
@@ -1,0 +1,1 @@
+Update docsy theme to v0.5.0 + matrix.org modifications (https://github.com/matrix-org/docsy/commit/a0032f8db919a6c67ba6cdef2c455f105b6272a2).

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "main": "none.js",
   "scripts": {
     "get-proposals": "node ./scripts/proposals.js",
+    "get:submodule": "git submodule update --init --depth 1",
+    "_prepare:docsy": "cd themes/docsy && npm install",
+    "prepare": "npm run get:submodule && npm run _prepare:docsy",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
This PR updates our git submodule checkout of [docsy](https://www.docsy.dev/) to https://github.com/matrix-org/docsy/commit/a0032f8db919a6c67ba6cdef2c455f105b6272a2, which is [the latest current commit](https://github.com/google/docsy/commit/90843e360b921ea8417995e0261a355f2f3aed7a) of google/docsy + [some changes to locally-load fonts/css/js](https://github.com/google/docsy/compare/main...matrix-org:docsy:master).

The previous version of docsy was >1 year old.

---

A few visual changes that I've noticed. These look fine and don't require fixing IMO:

**(Table cell vertical text alignment) Before**

![image](https://user-images.githubusercontent.com/1342360/196682517-d7144cc3-f11e-499e-a807-bce8bbc6d850.png)

**After**

![image](https://user-images.githubusercontent.com/1342360/196682567-8240d05c-4001-4c50-9979-ebcfa70b5945.png)

---

**(Breadcrumbs) Before**

![image](https://user-images.githubusercontent.com/1342360/196682748-4cce3b8e-80e2-49f9-8f3a-3ebf41f1eda2.png)

**After**

![image](https://user-images.githubusercontent.com/1342360/196682683-6d2ceec9-4dac-4c57-bdfd-0ad454560399.png)

---

**(Rate-limit/Auth text) Before**

![image](https://user-images.githubusercontent.com/1342360/196682983-b1b39ba3-259a-4c70-8a2c-ecc1bb911236.png)

**After**

![image](https://user-images.githubusercontent.com/1342360/196683086-bf41c258-6bf4-4d25-a221-51c520e0dbd9.png)

---

This change does not require a newsfragment.
















<!-- Replace -->
Preview: https://pr1295--matrix-spec-previews.netlify.app
<!-- Replace -->
