### PR TITLE
Replace misuses of 'plaintext' with 'cleartext'

### DIFF
--- a/content/client-server-api/_index.md
+++ b/content/client-server-api/_index.md
@@ -1945,14 +1945,14 @@ parent event, for example.
 {{% /boxes/note %}}
 
 To allow the server to aggregate and find child events for a parent, the `m.relates_to`
-key of an event MUST be included in the plaintext copy of the event. It cannot be
+key of an event MUST be included in the cleartext portion of the event. It cannot be
 exclusively recorded in the encrypted payload as the server cannot decrypt the event
 for processing.
 
 {{% boxes/warning %}}
 If an encrypted event contains an `m.relates_to` in its payload, it should be
-ignored and instead favour the plaintext `m.relates_to` copy (including when there
-is no plaintext copy). This is to ensure the client's behaviour matches the server's
+ignored and instead favour the cleartext `m.relates_to` copy (including when there
+is no cleartext copy). This is to ensure the client's behaviour matches the server's
 capability to handle relationships.
 {{% /boxes/warning %}}
 

--- a/content/client-server-api/modules/instant_messaging.md
+++ b/content/client-server-api/modules/instant_messaging.md
@@ -327,11 +327,12 @@ If a reason were to be supplied, it would look like:
 }
 ```
 
-When sending a spoiler, clients SHOULD provide the plain text fallback in the `body`
+When sending a spoiler, clients SHOULD provide the spoilered text fallback in the `body`
 as shown above (including the reason). The fallback SHOULD omit the spoiler text verbatim
 since `body` might show up in text-only clients or in notifications. To prevent spoilers
-showing up in such situations, clients are strongly encouraged to first upload the plaintext
-to the media repository then reference the MXC URI in a markdown-style link, as shown above.
+showing up in such situations, clients are strongly encouraged to first upload the spoilered
+text to the media repository then reference the MXC URI in a markdown-style link, as shown
+above.
 
 Clients SHOULD render spoilers differently with some sort of disclosure. For example, the
 client could blur the actual text and ask the user to click on it for it to be revealed.

--- a/content/identity-service-api.md
+++ b/content/identity-service-api.md
@@ -280,7 +280,7 @@ request.
 
 #### `none`
 
-This algorithm performs plaintext lookups on the identity server.
+This algorithm performs cleartext lookups on the identity server.
 Typically this algorithm should not be used due to the security concerns
 of unhashed identifiers, however some scenarios (such as LDAP-backed
 identity servers) prevent the use of hashed identifiers. Identity


### PR DESCRIPTION
Closes #1223.

Also replaces the term in the documentation of spoilers, where 'spoilered text' makes more sense in my opinion.