### PR TITLE
Require refresh_token on refresh token endpoint

### DIFF
--- a/changelogs/client_server/newsfragments/1323.clarification
+++ b/changelogs/client_server/newsfragments/1323.clarification
@@ -1,0 +1,1 @@
+Require request field `refresh_token` at endpoint `POST /_matrix/client/v3/refresh`.

--- a/data/api/client-server/refresh.yaml
+++ b/data/api/client-server/refresh.yaml
@@ -61,6 +61,8 @@ paths:
               refresh_token:
                 type: string
                 description: The refresh token
+            required:
+              - refresh_token
       responses:
         200:
           description: A new access token and refresh token were generated.


### PR DESCRIPTION
At API endpoint [POST /_matrix/client/v3/refresh](https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3refresh), the `refresh_token` field is not marked as required. This implies that the client is allowed to refresh an access token without specifying a refresh token - which doesn't really make any sense.

## Implications

It is not specified how the server should behave if the client sends an empty object as the request body, and the idea of sending an empty object is quite nonsensical for this endpoint. To solve this issue, this pull request specifies that the `refresh_token` is **required** on the given API endpoint.

## Implementations

- Synapse [already requires the `refresh_token` field](https://github.com/matrix-org/synapse/blob/v1.70.1/synapse/rest/client/login.py#L553).
- I haven't found a Dendrite implementation of this API endpoint.
- Conduit [doesn't support refresh tokens](https://gitlab.com/famedly/conduit/-/blob/next/src/api/client_server/account.rs#L202).

## Potential issues

Since the field has been specified as optional for a while, it is possible that a client has implemented a script that refreshes a long list of access tokens and then sends an empty object if no refresh token is available or supported. With the implementation of this bug fix, the expected response from a homeserver might change.

A given implementation might suggest [smelly code](https://en.wikipedia.org/wiki/Code_smell) if they intentionally send nonsensical requests to a homeserver, however, and I do not think that that is an issue worth considering.

## Sign off

Signed-off-by: Bram van den Heuvel <matrix-spec@noordstar.me>




<!-- Replace -->
Preview: https://pr1323--matrix-spec-previews.netlify.app
<!-- Replace -->
