### PR TITLE
Make definition anchors more unique

### DIFF
--- a/changelogs/internal/newsfragments/1339.clarification
+++ b/changelogs/internal/newsfragments/1339.clarification
@@ -1,0 +1,1 @@
+Make definition anchors more unique.

--- a/layouts/shortcodes/definition.html
+++ b/layouts/shortcodes/definition.html
@@ -30,7 +30,7 @@
 {{ $definition = partial "json-schema/resolve-refs" (dict "schema" $definition "path" $path) }}
 {{ $definition = partial "json-schema/resolve-allof" $definition }}
 
-<section class="rendered-data definition" id="{{ anchorize $definition.title }}">
+<section class="rendered-data definition" id="definition-{{ anchorize $definition.title }}">
 
 <details {{ if not $compact }}open{{ end }}>
 <summary>


### PR DESCRIPTION
Stick a `definition-` on the front of the autogenerated anchors for definition blocks.

This solves a problem where, for example, https://spec.matrix.org/unstable/application-service-api/#registration could refer to either the "Registration" section or the `Registration` definition therein.

(These anchors are relatively recent: they were added in #1191.)




<!-- Replace -->
Preview: https://pr1339--matrix-spec-previews.netlify.app
<!-- Replace -->
