### PR TITLE
Document that non-spec changes should get an 'internal' changelog entry

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -76,8 +76,12 @@ All API specifications require a changelog entry. Adding to the changelog can on
 be done after you've opened your pull request, so be sure to do that first.
 
 The changelog is managed by `Towncrier <https://github.com/twisted/towncrier>`_ in the
-form of "news fragments". The news fragments for the client-server API are stored
-under ``changelogs/client_server/newsfragments``.
+form of "news fragments". Depending on which API you changed, an entry should be added to
+each relevant API's ``newsfragments`` directory. A directory exists for each API under
+``changelogs/``. For instance, news fragments for the client-server API are stored
+under ``changelogs/client_server/newsfragments``. Any changes to the repository that do
+not affect the spec content itself, such as changes to the build script, formatting, CSS,
+etc. should be documented under ``changelogs/internal/newsfragments``.
 
 To create a changelog entry, create a file named in the format ``prNumber.type`` in
 the ``newsfragments`` directory. The ``type`` can be one of the following:
@@ -98,9 +102,6 @@ the ``newsfragments`` directory. The ``type`` can be one of the following:
 All news fragments must have a brief summary explaining the change in the
 contents of the file. The summary must end in a full stop to be in line with
 the style guide and formatting must be done using Markdown.
-
-Changes that do not change the spec, such as changes to the build script, formatting,
-CSS, etc should not get a news fragment.
 
 Sign off
 --------

--- a/changelogs/internal/newsfragments/1342.clarification
+++ b/changelogs/internal/newsfragments/1342.clarification
@@ -1,0 +1,1 @@
+Update CONTRIBUTING.md to mention that non-content changes to this repo should have an "internal" changelog entry.


### PR DESCRIPTION
Updates the contributing documentation to mention that we now support "internal" changelog entries after https://github.com/matrix-org/matrix-spec/pull/1194.




<!-- Replace -->
Preview: https://pr1342--matrix-spec-previews.netlify.app
<!-- Replace -->
