### PR TITLE
Add Event Replacements, Threading and Reference Relations modules to module summary table

### DIFF
--- a/changelogs/internal/newsfragments/1344.clarification
+++ b/changelogs/internal/newsfragments/1344.clarification
@@ -1,0 +1,1 @@
+Update module summary table with new modules: Event Replacements, Threading and Reference Relations.

--- a/content/client-server-api/_index.md
+++ b/content/client-server-api/_index.md
@@ -2556,6 +2556,9 @@ that profile.
 | [Server Notices](#server-notices)                          | Optional  | Optional | Optional | Optional | Optional |
 | [Moderation policies](#moderation-policy-lists)            | Optional  | Optional | Optional | Optional | Optional |
 | [Spaces](#spaces)                                          | Optional  | Optional | Optional | Optional | Optional |
+| [Event Replacements](#event-replacements)                  | Optional  | Optional | Optional | Optional | Optional |
+| [Threading](#threading)                                    | Optional  | Optional | Optional | Optional | Optional |
+| [Reference Relations](#reference-relations)                | Optional  | Optional | Optional | Optional | Optional |
 
 *Please see each module for more details on what clients need to
 implement.*


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-spec/issues/1296.

The issue mentions that all new modules are optional. Threading is of course not a required feature. Event replacements are not required as we have fallbacks for those. Reference relations are optional too...?




<!-- Replace -->
Preview: https://pr1344--matrix-spec-previews.netlify.app
<!-- Replace -->
