### PR TITLE
Clarify that verifications without a request only happens over to-device

### DIFF
--- a/changelogs/client_server/newsfragments/1345.clarification
+++ b/changelogs/client_server/newsfragments/1345.clarification
@@ -1,0 +1,1 @@
+Clarify parts of the end-to-end encryption sections.

--- a/content/client-server-api/modules/end_to_end_encryption.md
+++ b/content/client-server-api/modules/end_to_end_encryption.md
@@ -551,7 +551,8 @@ then the device IDs should be compared instead.  If the two
 method, then the verification should be cancelled with a `code` of
 `m.unexpected_message`.
 
-An `m.key.verification.start` message can also be sent independently of any
+When verifying using to-device messages, an `m.key.verification.start`
+message can also be sent independently of any
 request, specifying the verification method to use. This behaviour is
 deprecated, and new clients should not begin verifications in this way.
 However, clients should handle such verifications started by other clients.


### PR DESCRIPTION
In-room verifications must always start with a request.  This is enforced on a technical level by the fact that with in-room verifications, all the verification events are required to reference the request event.




<!-- Replace -->
Preview: https://pr1345--matrix-spec-previews.netlify.app
<!-- Replace -->
