### PR TITLE
Disable RSS for spec

### DIFF
--- a/changelogs/internal/newsfragments/1346.clarification
+++ b/changelogs/internal/newsfragments/1346.clarification
@@ -1,0 +1,1 @@
+Disable RSS generation for the spec.

--- a/config.toml
+++ b/config.toml
@@ -10,7 +10,10 @@ enableRobotsTXT = true
 # Hugo allows theme composition (and inheritance). The precedence is from left to right.
 theme = ["docsy"]
 
-disableKinds = ["taxonomy", "taxonomyTerm"]
+# We disable RSS, because (a) it's useless, (b) Hugo seems to generate broken
+# links to it when used with a --baseURL (for example, https://spec.matrix.org/v1.4/
+# contains `<link rel="alternate" type="application/rss&#43;xml" href="/v1.4/v1.4/index.xml">`).
+disableKinds = ["taxonomy", "taxonomyTerm", "RSS"]
 
 [languages]
 [languages.en]


### PR DESCRIPTION
I don't think the RSS is very useful, and the links to it were broken anyway.

This should really fix #1336.

<!-- Replace -->
Preview: https://pr1346--matrix-spec-previews.netlify.app
<!-- Replace -->
