### PR TITLE
Add standard error responses (MSC3743).

### DIFF
--- a/changelogs/application_service/newsfragments/1347.feature
+++ b/changelogs/application_service/newsfragments/1347.feature
@@ -1,0 +1,1 @@
+Add information on standard error responses for unknown endpoints/methods.

--- a/changelogs/client_server/newsfragments/1347.feature
+++ b/changelogs/client_server/newsfragments/1347.feature
@@ -1,0 +1,1 @@
+Add information on standard error responses for unknown endpoints/methods.

--- a/changelogs/identity_service/newsfragments/1347.feature
+++ b/changelogs/identity_service/newsfragments/1347.feature
@@ -1,0 +1,1 @@
+Add information on standard error responses for unknown endpoints/methods.

--- a/changelogs/push_gateway/newsfragments/1347.feature
+++ b/changelogs/push_gateway/newsfragments/1347.feature
@@ -1,0 +1,1 @@
+Add information on standard error responses for unknown endpoints/methods.

--- a/changelogs/server_server/newsfragments/1347.feature
+++ b/changelogs/server_server/newsfragments/1347.feature
@@ -1,0 +1,1 @@
+Add information on standard error responses for unknown endpoints/methods.

--- a/content/application-service-api.md
+++ b/content/application-service-api.md
@@ -166,10 +166,10 @@ because the application service may have been updated.
 
 #### Unknown routes
 
-If a request for an unsupported (or unknown) endpoint is received than the server
+If a request for an unsupported (or unknown) endpoint is received then the server
 must respond with 404 `M_UNRECOGNIZED` error.
 
-Similarly, a 405 `M_UNREOCGNIZED` error is used to denote an unsupported method
+Similarly, a 405 `M_UNRECOGNIZED` error is used to denote an unsupported method
 to a known endpoint.
 
 #### Pushing events

--- a/content/application-service-api.md
+++ b/content/application-service-api.md
@@ -164,6 +164,14 @@ each is as follows:
 Homeservers should periodically try again for the newer endpoints
 because the application service may have been updated.
 
+#### Unknown routes
+
+If a request for an unsupported (or unknown) endpoint is received than the server
+must respond with 404 `M_UNRECOGNIZED` error.
+
+Similarly, a 405 `M_UNREOCGNIZED` error is used to denote an unsupported method
+to a known endpoint.
+
 #### Pushing events
 
 The application service API provides a transaction API for sending a

--- a/content/application-service-api.md
+++ b/content/application-service-api.md
@@ -167,7 +167,7 @@ because the application service may have been updated.
 #### Unknown routes
 
 If a request for an unsupported (or unknown) endpoint is received then the server
-must respond with 404 `M_UNRECOGNIZED` error.
+must respond with a 404 `M_UNRECOGNIZED` error.
 
 Similarly, a 405 `M_UNRECOGNIZED` error is used to denote an unsupported method
 to a known endpoint.

--- a/content/client-server-api/_index.md
+++ b/content/client-server-api/_index.md
@@ -108,7 +108,7 @@ Too many requests have been sent in a short period of time. Wait a while
 then try again.
 
 `M_UNRECOGNIZED`
-The server did not understand the request, this is expected to be returned with
+The server did not understand the request. This is expected to be returned with
 an 404 HTTP status code if the endpoint is not implemented or an 405 HTTP status
 code if the endpoint is implemented, but the incorrect HTTP method is used.
 

--- a/content/client-server-api/_index.md
+++ b/content/client-server-api/_index.md
@@ -107,6 +107,11 @@ No resource was found for this request.
 Too many requests have been sent in a short period of time. Wait a while
 then try again.
 
+`M_UNRECOGNIZED`
+The server did not understand the request, this is expected to be returned with
+an 404 HTTP status code if the endpoint is not implemented or an 405 HTTP status
+code if the endpoint is implemented, but the incorrect HTTP method is used.
+
 `M_UNKNOWN`
 An unknown error has occurred.
 
@@ -115,9 +120,6 @@ An unknown error has occurred.
 The following error codes are specific to certain endpoints.
 
 <!-- TODO: move them to the endpoints that return them -->
-
-`M_UNRECOGNIZED`
-The server did not understand the request.
 
 `M_UNAUTHORIZED`
 The request was not correctly authorized. Usually due to login failures.

--- a/content/client-server-api/_index.md
+++ b/content/client-server-api/_index.md
@@ -109,7 +109,7 @@ then try again.
 
 `M_UNRECOGNIZED`
 The server did not understand the request. This is expected to be returned with
-an 404 HTTP status code if the endpoint is not implemented or an 405 HTTP status
+a 404 HTTP status code if the endpoint is not implemented or a 405 HTTP status
 code if the endpoint is implemented, but the incorrect HTTP method is used.
 
 `M_UNKNOWN`

--- a/content/identity-service-api.md
+++ b/content/identity-service-api.md
@@ -108,6 +108,11 @@ attempting to verify ownership of a given third party address.
 The request contained an unrecognised value, such as an unknown token or
 medium.
 
+This is also used as the response if a server did not understand the request,
+this is expected to be returned with an 404 HTTP status code if the endpoint is
+not implemented or an 405 HTTP status code if the endpoint is implemented, but
+the incorrect HTTP method is used.
+
 `M_THREEPID_IN_USE`
 The third party identifier is already in use by another user. Typically
 this error will have an additional `mxid` property to indicate who owns

--- a/content/identity-service-api.md
+++ b/content/identity-service-api.md
@@ -109,8 +109,8 @@ The request contained an unrecognised value, such as an unknown token or
 medium.
 
 This is also used as the response if a server did not understand the request.
-This is expected to be returned with an 404 HTTP status code if the endpoint is
-not implemented or an 405 HTTP status code if the endpoint is implemented, but
+This is expected to be returned with a 404 HTTP status code if the endpoint is
+not implemented or a 405 HTTP status code if the endpoint is implemented, but
 the incorrect HTTP method is used.
 
 `M_THREEPID_IN_USE`

--- a/content/identity-service-api.md
+++ b/content/identity-service-api.md
@@ -108,8 +108,8 @@ attempting to verify ownership of a given third party address.
 The request contained an unrecognised value, such as an unknown token or
 medium.
 
-This is also used as the response if a server did not understand the request,
-this is expected to be returned with an 404 HTTP status code if the endpoint is
+This is also used as the response if a server did not understand the request.
+This is expected to be returned with an 404 HTTP status code if the endpoint is
 not implemented or an 405 HTTP status code if the endpoint is implemented, but
 the incorrect HTTP method is used.
 

--- a/content/push-gateway-api.md
+++ b/content/push-gateway-api.md
@@ -37,6 +37,16 @@ notification provider (e.g. APNS, GCM).
          Mobile Device or Client
 ```
 
+## API standards
+
+### Unsupported endpoints
+
+If a request for an unsupported (or unknown) endpoint is received than the server
+must respond with 404 `M_UNRECOGNIZED` error.
+
+Similarly, a 405 `M_UNREOCGNIZED` error is used to denote an unsupported method
+to a known endpoint.
+
 ## Homeserver behaviour
 
 This describes the format used by "HTTP" pushers to send notifications

--- a/content/push-gateway-api.md
+++ b/content/push-gateway-api.md
@@ -41,10 +41,10 @@ notification provider (e.g. APNS, GCM).
 
 ### Unsupported endpoints
 
-If a request for an unsupported (or unknown) endpoint is received than the server
+If a request for an unsupported (or unknown) endpoint is received then the server
 must respond with 404 `M_UNRECOGNIZED` error.
 
-Similarly, a 405 `M_UNREOCGNIZED` error is used to denote an unsupported method
+Similarly, a 405 `M_UNRECOGNIZED` error is used to denote an unsupported method
 to a known endpoint.
 
 ## Homeserver behaviour

--- a/content/push-gateway-api.md
+++ b/content/push-gateway-api.md
@@ -42,7 +42,7 @@ notification provider (e.g. APNS, GCM).
 ### Unsupported endpoints
 
 If a request for an unsupported (or unknown) endpoint is received then the server
-must respond with 404 `M_UNRECOGNIZED` error.
+must respond with a 404 `M_UNRECOGNIZED` error.
 
 Similarly, a 405 `M_UNRECOGNIZED` error is used to denote an unsupported method
 to a known endpoint.

--- a/content/server-server-api.md
+++ b/content/server-server-api.md
@@ -84,6 +84,14 @@ to be an IP address in which case SNI is not supported and should not be sent.
 Servers are encouraged to make use of the [Certificate
 Transparency](https://www.certificate-transparency.org/) project.
 
+### Unsupported endpoints
+
+If a request for an unsupported (or unknown) endpoint is received than the server
+must respond with 404 `M_UNRECOGNIZED` error.
+
+Similarly, a 405 `M_UNREOCGNIZED` error is used to denote an unsupported method
+to a known endpoint.
+
 ## Server discovery
 
 ### Resolving server names

--- a/content/server-server-api.md
+++ b/content/server-server-api.md
@@ -86,10 +86,10 @@ Transparency](https://www.certificate-transparency.org/) project.
 
 ### Unsupported endpoints
 
-If a request for an unsupported (or unknown) endpoint is received than the server
+If a request for an unsupported (or unknown) endpoint is received then the server
 must respond with 404 `M_UNRECOGNIZED` error.
 
-Similarly, a 405 `M_UNREOCGNIZED` error is used to denote an unsupported method
+Similarly, a 405 `M_UNRECOGNIZED` error is used to denote an unsupported method
 to a known endpoint.
 
 ## Server discovery

--- a/content/server-server-api.md
+++ b/content/server-server-api.md
@@ -87,7 +87,7 @@ Transparency](https://www.certificate-transparency.org/) project.
 ### Unsupported endpoints
 
 If a request for an unsupported (or unknown) endpoint is received then the server
-must respond with 404 `M_UNRECOGNIZED` error.
+must respond with a 404 `M_UNRECOGNIZED` error.
 
 Similarly, a 405 `M_UNRECOGNIZED` error is used to denote an unsupported method
 to a known endpoint.


### PR DESCRIPTION
Spec PR for matrix-org/matrix-spec-proposals#3743.

I wasn't sure if there was a single spot I should put this or if we should just put it into each separate bit of the spec. I chose the latter since there didn't seem to be a good consolidated spot.

This isn't quite as clear as I'd like it to be (as it should apply to everything under `/_matrix`). 













<!-- Replace -->
Preview: https://pr1347--matrix-spec-previews.netlify.app
<!-- Replace -->
