### PR TITLE
Include examples inline instead of using a reference for invite endpoint definitions

### DIFF
--- a/changelogs/server_server/newsfragments/1349.clarification
+++ b/changelogs/server_server/newsfragments/1349.clarification
@@ -1,1 +1,1 @@
-Include examples parts instead of using a reference for invite endpoints definitions.
+Include examples inline instead of using a reference for invite endpoint definitions.

--- a/changelogs/server_server/newsfragments/1349.clarification
+++ b/changelogs/server_server/newsfragments/1349.clarification
@@ -1,0 +1,1 @@
+Include examples parts instead of using a reference for invite endpoints definitions.

--- a/data/api/server-server/invites-v1.yaml
+++ b/data/api/server-server/invites-v1.yaml
@@ -133,9 +133,24 @@ paths:
                   "origin_server_ts": 1549041175876,
                   "sender": "@someone:example.org",
                   "unsigned": {
-                    "invite_room_state": {
-                      "$ref": "../../event-schemas/examples/invite_room_state.json"
-                    }
+                    "invite_room_state": [
+                      {
+                        "type": "m.room.name",
+                        "sender": "@bob:example.org",
+                        "state_key": "",
+                        "content": {
+                          "name": "Example Room"
+                        }
+                      },
+                      {
+                        "type": "m.room.join_rules",
+                        "sender": "@bob:example.org",
+                        "state_key": "",
+                        "content": {
+                          "join_rule": "invite"
+                        }
+                      }
+                    ]
                   },
                   "content": {
                       "membership": "invite"

--- a/data/api/server-server/invites-v2.yaml
+++ b/data/api/server-server/invites-v2.yaml
@@ -129,9 +129,24 @@ paths:
                 "origin_server_ts": 1549041175876,
                 "sender": "@someone:example.org",
                 "unsigned": {
-                  "invite_room_state": {
-                    "$ref": "../../event-schemas/examples/invite_room_state.json"
-                  }
+                  "invite_room_state": [
+                    {
+                      "type": "m.room.name",
+                      "sender": "@bob:example.org",
+                      "state_key": "",
+                      "content": {
+                        "name": "Example Room"
+                      }
+                    },
+                    {
+                      "type": "m.room.join_rules",
+                      "sender": "@bob:example.org",
+                      "state_key": "",
+                      "content": {
+                        "join_rule": "invite"
+                      }
+                    }
+                  ]
                 },
                 "content": {
                     "membership": "invite"


### PR DESCRIPTION
The OpenAPI 3.x spec doesn't allow building examples by composition. Either the whole example must be a reference, or all of it has to be included.

This is a prerequisite for #1310.

Signed-off-by: Kévin Commaille <zecakeh@tedomum.fr>




<!-- Replace -->
Preview: https://pr1349--matrix-spec-previews.netlify.app
<!-- Replace -->
