### PR TITLE
Fix `POST _matrix/federation/v1/user/keys/claim` response schema

### DIFF
--- a/changelogs/server_server/newsfragments/1351.clarification
+++ b/changelogs/server_server/newsfragments/1351.clarification
@@ -1,0 +1,1 @@
+Fix `POST _matrix/federation/v1/user/keys/claim` response schema.

--- a/data/api/server-server/user_keys.yaml
+++ b/data/api/server-server/user_keys.yaml
@@ -76,29 +76,32 @@ paths:
 
                   See the [Client-Server Key Algorithms](/client-server-api/#key-algorithms) section for more information on
                   the Key Object format.
+                # User
                 additionalProperties:
                   type: object
+                  # Device
                   additionalProperties:
-                    type:
-                      - string
-                      - type: object
-                        title: KeyObject
-                        properties:
-                          key:
-                            type: string
-                            description: The key, encoded using unpadded base64.
-                          signatures:
+                    type: object
+                    # Key
+                    additionalProperties:
+                      type: object
+                      title: KeyObject
+                      properties:
+                        key:
+                          type: string
+                          description: The key, encoded using unpadded base64.
+                        signatures:
+                          type: object
+                          title: Signatures
+                          additionalProperties:
                             type: object
-                            title: Signatures
                             additionalProperties:
-                              type: object
-                              additionalProperties:
-                                type: string
-                            description: |-
-                              Signature of the key object.
+                              type: string
+                          description: |-
+                            Signature of the key object.
 
-                              The signature is calculated using the process described at [Signing JSON](/appendices/#signing-json).
-                        required: ['key', 'signatures']
+                            The signature is calculated using the process described at [Signing JSON](/appendices/#signing-json).
+                      required: ['key', 'signatures']
                 example: {
                   "@alice:example.com": {
                     "JLAFKJWSCS": {


### PR DESCRIPTION
The syntax was not compliant with the Swagger spec (the `type` field cannot be an array).

It also lacked one level of nesting (or maybe that's what the syntax was trying to do).

This is a prerequisite for #1310.

Signed-off-by: Kévin Commaille <zecakeh@tedomum.fr>




<!-- Replace -->
Preview: https://pr1351--matrix-spec-previews.netlify.app
<!-- Replace -->
