### PR TITLE
add missing description to m.call.answer schema

### DIFF
--- a/changelogs/client_server/newsfragments/1353.clarification
+++ b/changelogs/client_server/newsfragments/1353.clarification
@@ -1,0 +1,1 @@
+Add missing description to m.call.answer schema.

--- a/data/event-schemas/schema/m.call.answer.yaml
+++ b/data/event-schemas/schema/m.call.answer.yaml
@@ -31,7 +31,7 @@
                 },
                 "version": {
                     "type": "number",
-                    "description": ""
+                    "description": "The version of the VoIP specification this messages adheres to. This specification is version 0."
                 }
             },
             "required": ["call_id", "answer", "version"]


### PR DESCRIPTION
This property is required but is missing a description.
I'm guessing the same description from the other `m.call` events applies, hence I copy it here.

Signed-off-by: Kim Brose <2803622+HarHarLinks@users.noreply.github.com>

<!-- Replace -->
Preview: https://pr1353--matrix-spec-previews.netlify.app
<!-- Replace -->
