### PR TITLE
Remove duplicated "Note:" from `m.room.power_levels`

### DIFF
--- a/changelogs/client_server/newsfragments/1355.clarification
+++ b/changelogs/client_server/newsfragments/1355.clarification
@@ -1,1 +1,1 @@
-Remove duplicated "Note:" section prefix.
+Clarify the power levels integer range.

--- a/changelogs/client_server/newsfragments/1355.clarification
+++ b/changelogs/client_server/newsfragments/1355.clarification
@@ -1,0 +1,1 @@
+Remove duplicated "Note:" section prefix.

--- a/data/event-schemas/schema/m.room.power_levels.yaml
+++ b/data/event-schemas/schema/m.room.power_levels.yaml
@@ -42,7 +42,7 @@ description: |-
   `m.room.power_levels` event as soon as it is created. See also the
   documentation of the `/createRoom` API.
 
-  Note: the allowed range for power level values is `[-(2**53)+1, (2**53)-1]`,
+  The allowed range for power level values is `[-(2**53)+1, (2**53)-1]`,
   as required by the [Canonical JSON specification](/appendices/#canonical-json).
 
 properties:


### PR DESCRIPTION
Follow-up to https://github.com/matrix-org/matrix-spec/pull/1169. While looking at the preview from #1169, I noticed that the section is already called "Note:".

Signed-off-by: Johannes Becker <j.becker@famedly.com>







<!-- Replace -->
Preview: https://pr1355--matrix-spec-previews.netlify.app
<!-- Replace -->
