### PR TITLE
move login API definitions to the right heading

### DIFF
--- a/changelogs/client_server/newsfragments/1382.clarification
+++ b/changelogs/client_server/newsfragments/1382.clarification
@@ -1,0 +1,1 @@
+Move login API definitions to the right heading. Contributed by @HarHarLinks.

--- a/content/client-server-api/_index.md
+++ b/content/client-server-api/_index.md
@@ -1145,6 +1145,12 @@ client supports it, the client should redirect the user to the
 is complete, the client will need to submit a `/login` request matching
 `m.login.token`.
 
+{{% http-api spec="client-server" api="login" %}}
+
+{{% http-api spec="client-server" api="refresh" %}}
+
+{{% http-api spec="client-server" api="logout" %}}
+
 #### Appservice Login
 
 {{% added-in v="1.2" %}}
@@ -1181,12 +1187,6 @@ respond with an errcode of `M_FORBIDDEN`.
 If the access token does correspond to an appservice, but the user id does
 not lie within its namespace then the homeserver will respond with an
 errcode of `M_EXCLUSIVE`.
-
-{{% http-api spec="client-server" api="login" %}}
-
-{{% http-api spec="client-server" api="refresh" %}}
-
-{{% http-api spec="client-server" api="logout" %}}
 
 #### Login Fallback
 


### PR DESCRIPTION
- regressed from https://github.com/matrix-org/matrix-spec-proposals/pull/3324
- discussed in the SCT "office" https://matrix.to/#/!ewdjhNcPcEmYNKzlWp:t2l.io/$21n929cNSZGWtxgRtwMKpRs_ye_tEdE7KyAE0FYVKok?via=matrix.org&via=element.io&via=envs.net

Signed-off-by: Kim Brose [2803622+HarHarLinks@users.noreply.github.com](mailto:2803622+HarHarLinks@users.noreply.github.com)




<!-- Replace -->
Preview: https://pr1382--matrix-spec-previews.netlify.app
<!-- Replace -->
