### PR TITLE
Fix `edu_type` on EDU examples

### DIFF
--- a/changelogs/server_server/newsfragments/1383.clarification
+++ b/changelogs/server_server/newsfragments/1383.clarification
@@ -1,0 +1,1 @@
+Fix `edu_type` in EDU examples.

--- a/content/server-server-api.md
+++ b/content/server-server-api.md
@@ -657,7 +657,7 @@ EDUs, by comparison to PDUs, do not have an ID, a room ID, or a list of
 "previous" IDs. They are intended to be non-persistent data such as user
 presence, typing notifications, etc.
 
-{{% definition path="api/server-server/definitions/edu" %}}
+{{% definition path="api/server-server/definitions/edu_with_example" %}}
 
 ## Room State Resolution
 

--- a/data/api/server-server/definitions/edu_with_example.yaml
+++ b/data/api/server-server/definitions/edu_with_example.yaml
@@ -1,4 +1,4 @@
-# Copyright 2018 New Vector Ltd
+# Copyright 2022 The Matrix.org Foundation C.I.C.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,15 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-type: object
-title: Ephemeral Data Unit
-description: An ephemeral data unit.
-properties:
-  edu_type:
-    type: string
-    description: The type of ephemeral message.
-    example: "m.presence"
-  content:
-    type: object
-    description: The content of the ephemeral message.
-required: ['edu_type', 'content']
+# this file exists, separately to edu.yaml, so that the individual EDU
+# type definitions can inherit from edu.yaml without inheriting the example.
+
+allOf:
+  - $ref: edu.yaml
+  - example:
+      $ref: "../examples/edu.json"

--- a/data/api/server-server/definitions/transaction.yaml
+++ b/data/api/server-server/definitions/transaction.yaml
@@ -11,6 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# note that this defintion excludes `edus`, which are typically included in
+# a transaction; this is so that it can be referenced in single_pdu_transaction.
+
 type: object
 title: Transaction
 description: Transaction

--- a/data/api/server-server/definitions/transaction.yaml
+++ b/data/api/server-server/definitions/transaction.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# note that this defintion excludes `edus`, which are typically included in
+# note that this definition excludes `edus`, which are typically included in
 # a transaction; this is so that it can be referenced in single_pdu_transaction.
 
 type: object

--- a/data/api/server-server/transactions.yaml
+++ b/data/api/server-server/transactions.yaml
@@ -66,11 +66,7 @@ paths:
                       List of ephemeral messages. May be omitted if there are no ephemeral
                       messages to be sent. Must not include more than 100 EDUs.
                     items:
-                      $ref: "definitions/edu.yaml"
-          example: {
-            "$ref": "examples/transaction.json",
-            "edus": [{"$ref": "examples/edu.json"}]
-          }
+                      $ref: "definitions/edu_with_example.yaml"
       responses:
         200:
           description: |-


### PR DESCRIPTION
The top-level `example` in `edu.yaml` was overriding the individual examples
for `edu_type`. Let's fix that by getting rid of the example in `edu.yaml`.

Fixes https://github.com/matrix-org/matrix-spec/issues/805




<!-- Replace -->
Preview: https://pr1383--matrix-spec-previews.netlify.app
<!-- Replace -->
