### PR TITLE
Add missing `x-addedInMatrixVersion` to `servers_in_room` in `v2/send_join`

### DIFF
--- a/changelogs/server_server/newsfragments/1398.feature
+++ b/changelogs/server_server/newsfragments/1398.feature
@@ -1,0 +1,1 @@
+Extend `/_matrix/federation/v2/send_join` to allow omitting membership events, per [MSC3706](https://github.com/matrix-org/matrix-doc/pull/3706).

--- a/data/api/server-server/joins-v2.yaml
+++ b/data/api/server-server/joins-v2.yaml
@@ -255,6 +255,7 @@ paths:
                   server's signature.
               servers_in_room:
                 type: array
+                x-addedInMatrixVersion: "1.6"
                 description: |-
                   **Required** if `members_omitted` is true.
 


### PR DESCRIPTION
Signed-off-by: Kévin Commaille <zecakeh@tedomum.fr>




<!-- Replace -->
Preview: https://pr1398--matrix-spec-previews.netlify.app
<!-- Replace -->
