### PR TITLE
Add links to the spec for the definition of 3PID `medium`

### DIFF
--- a/changelogs/client_server/newsfragments/1417.clarification
+++ b/changelogs/client_server/newsfragments/1417.clarification
@@ -1,0 +1,1 @@
+Add links to the spec for the definition of 3PID `medium`.

--- a/data/api/client-server/create_room.yaml
+++ b/data/api/client-server/create_room.yaml
@@ -155,8 +155,9 @@ paths:
                         and this specification version.
                     medium:
                       type: string
-                      # TODO: Link to Identity Service spec when it eixsts
-                      description: The kind of address being passed in the address field, for example `email`.
+                      description: |-
+                        The kind of address being passed in the address field, for example `email`
+                        (see [the list of recognised values](/appendices/#3pid-types)).
                     address:
                       type: string
                       description: The invitee's third party identifier.

--- a/data/api/client-server/third_party_membership.yaml
+++ b/data/api/client-server/third_party_membership.yaml
@@ -105,8 +105,9 @@ paths:
                   and this specification version.
               medium:
                 type: string
-                # TODO: Link to Identity Service spec when it eixsts
-                description: The kind of address being passed in the address field, for example `email`.
+                description: |-
+                  The kind of address being passed in the address field, for example
+                  `email` (see [the list of recognised values](/appendices/#3pid-types)).
               address:
                 type: string
                 description: The invitee's third party identifier.


### PR DESCRIPTION
Removing the corresponding TODOs.

Signed-off-by: Kévin Commaille <zecakeh@tedomum.fr>




<!-- Replace -->
Preview: https://pr1417--matrix-spec-previews.netlify.app
<!-- Replace -->
