### PR TITLE
Move `.m.rule.roomnotif` before `.m.rule.tombstone`

### DIFF
--- a/changelogs/client_server/newsfragments/1421.clarification
+++ b/changelogs/client_server/newsfragments/1421.clarification
@@ -1,0 +1,1 @@
+Correct the order of the default override pushrules in the spec.

--- a/content/client-server-api/modules/push.md
+++ b/content/client-server-api/modules/push.md
@@ -524,6 +524,38 @@ Definition:
 }
 ```
 
+**`.m.rule.roomnotif`**
+
+Matches any message whose content is unencrypted and contains the text
+`@room`, signifying the whole room should be notified of the event.
+
+Definition:
+
+```json
+{
+    "rule_id": ".m.rule.roomnotif",
+    "default": true,
+    "enabled": true,
+    "conditions": [
+        {
+            "kind": "event_match",
+            "key": "content.body",
+            "pattern": "@room"
+        },
+        {
+            "kind": "sender_notification_permission",
+            "key": "room"
+        }
+    ],
+    "actions": [
+        "notify",
+        {
+            "set_tweak": "highlight"
+        }
+    ]
+}
+```
+
 **<a name="mruletombstone"></a>`.m.rule.tombstone`**
 
 Matches any state event whose type is `m.room.tombstone`. This is
@@ -584,38 +616,6 @@ Definition:
         }
     ],
     "actions": []
-}
-```
-
-**`.m.rule.roomnotif`**
-
-Matches any message whose content is unencrypted and contains the text
-`@room`, signifying the whole room should be notified of the event.
-
-Definition:
-
-```json
-{
-    "rule_id": ".m.rule.roomnotif",
-    "default": true,
-    "enabled": true,
-    "conditions": [
-        {
-            "kind": "event_match",
-            "key": "content.body",
-            "pattern": "@room"
-        },
-        {
-            "kind": "sender_notification_permission",
-            "key": "room"
-        }
-    ],
-    "actions": [
-        "notify",
-        {
-            "set_tweak": "highlight"
-        }
-    ]
 }
 ```
 


### PR DESCRIPTION
See https://github.com/matrix-org/matrix-spec/issues/1406 for the reasoning on this. TL;DR: the spec has always been wrong here.

Fixes #1406

<!-- Replace -->
Preview: https://pr1421--matrix-spec-previews.netlify.app
<!-- Replace -->
