### PR TITLE
Clarify room version grammar

### DIFF
--- a/changelogs/room_versions/newsfragments/1422.clarification
+++ b/changelogs/room_versions/newsfragments/1422.clarification
@@ -1,0 +1,1 @@
+Clarify the grammar for room versions.

--- a/content/rooms/_index.md
+++ b/content/rooms/_index.md
@@ -86,7 +86,7 @@ split-brain situation due to not understanding the new rules.
 
 A room version is defined as a string of characters which MUST NOT
 exceed 32 codepoints in length. Room versions MUST NOT be empty and
-SHOULD contain only the characters `a-z`, `0-9`, `.`, and `-`.
+MUST contain only the characters `a-z`, `0-9`, `.`, and `-`.
 
 Room versions are not intended to be parsed and should be treated as
 opaque identifiers. Room versions consisting only of the characters


### PR DESCRIPTION
It is not legal to use characters outside `a-z`, `0-9`, `.`, and `-`.

Fixes #1408 

<!-- Replace -->
Preview: https://pr1422--matrix-spec-previews.netlify.app
<!-- Replace -->
