### PR TITLE
Improve distinction between tags and their attributes in the rich text section

### DIFF
--- a/changelogs/client_server/newsfragments/1433.clarification
+++ b/changelogs/client_server/newsfragments/1433.clarification
@@ -1,0 +1,1 @@
+Improve distinction between tags and their attributes in the rich text section. Contributed by Nico.

--- a/content/client-server-api/modules/instant_messaging.md
+++ b/content/client-server-api/modules/instant_messaging.md
@@ -48,27 +48,14 @@ are listed, clients should translate the value (a `#` character followed
 by a 6-character hex color code) to the appropriate CSS/attributes for
 the tag.
 
-`font`
-`data-mx-bg-color`, `data-mx-color`, `color`
-
-`span`
-`data-mx-bg-color`, `data-mx-color`, `data-mx-spoiler` (see
-[spoiler messages](#spoiler-messages))
-
-`a`
-`name`, `target`, `href` (provided the value is not relative and has a
-scheme matching one of: `https`, `http`, `ftp`, `mailto`, `magnet`)
-
-`img`
-`width`, `height`, `alt`, `title`, `src` (provided it is a [Matrix
-Content (MXC) URI](#matrix-content-mxc-uris))
-
-`ol`
-`start`
-
-`code`
-`class` (only classes which start with `language-` for syntax
-highlighting)
+| Tag    | Permitted Attributes                                                                                                                       |
+|--------|--------------------------------------------------------------------------------------------------------------------------------------------|
+| `font` | `data-mx-bg-color`, `data-mx-color`, `color`                                                                                               |
+| `span` | `data-mx-bg-color`, `data-mx-color`, `data-mx-spoiler` (see [spoiler messages](#spoiler-messages))                                         |
+| `a`    | `name`, `target`, `href` (provided the value is not relative and has a scheme matching one of: `https`, `http`, `ftp`, `mailto`, `magnet`) |
+| `img`  | `width`, `height`, `alt`, `title`, `src` (provided it is a [Matrix Content (MXC) URI](#matrix-content-mxc-uris))                           |
+| `ol`   | `start`                                                                                                                                    |
+| `code` | `class` (only classes which start with `language-` for syntax highlighting)                                                                |
 
 Additionally, web clients should ensure that *all* `a` tags get a
 `rel="noopener"` to prevent the target page from referencing the


### PR DESCRIPTION

Originally the tags used to be bold, followed by a colon and separated into two columns in a table. This at least restores the table aspect, which makes it clear, that font is not an attribute (and similar).

This seems to have gotten lost in the transition to the new design.

Signed-off-by: Nicolas Werner <nicolas.werner@hotmail.de>




<!-- Replace -->
Preview: https://pr1433--matrix-spec-previews.netlify.app
<!-- Replace -->
