### PR TITLE
Notify additionally access token required when "require_auth_for_profile_requests" is True for _matrix/client/v3/profile/

### DIFF
--- a/changelogs/client_server/newsfragments/1445.clarification
+++ b/changelogs/client_server/newsfragments/1445.clarification
@@ -1,0 +1,1 @@
+Added note indicating the need of authentication when require_auth_for_profile_requests is true for profile information api.

--- a/data/api/client-server/profile.yaml
+++ b/data/api/client-server/profile.yaml
@@ -185,6 +185,8 @@ paths:
         to fetch the user's own profile information or other users; either
         locally or on remote homeservers. This API may return keys which are not
         limited to `displayname` or `avatar_url`.
+
+        _Please note that access token is required if require_auth_for_profile_requests is true [in configuration](https://matrix-org.github.io/synapse/latest/usage/configuration/config_documentation.html#require_auth_for_profile_requests)._
       operationId: getUserProfile
       parameters:
         - in: path
@@ -211,6 +213,15 @@ paths:
               displayname:
                 type: string
                 description: The user's display name if they have set one, otherwise not present.
+        401:
+          description: The access token is not provided or is invalid.
+          examples:
+            application/json: {
+              "errcode": "M_MISSING_TOKEN",
+              "error": "Missing access token"
+            }
+          schema:
+            "$ref": "definitions/errors/error.yaml"
         403:
           x-addedInMatrixVersion: "1.2"
           description: The server is unwilling to disclose whether the user exists and/or has profile information.


### PR DESCRIPTION
Read [this synapse issue](https://github.com/matrix-org/synapse/issues/15118) for background information.

Initially the spec didn't account for the need of access token in case when _require_auth_for_profile_requests_ is true, In that case the API endpoint _GET /_matrix/client/v3/profile/ will return 401 Unauthorized, Updated spec to reflect on this.

<!-- Replace -->
Preview: https://pr1445--matrix-spec-previews.netlify.app
<!-- Replace -->
