### PR TITLE
Only include endpoint path in `<summary>`

### DIFF
--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -288,15 +288,19 @@ footer {
 /* Styles for sections that are rendered from data, such as HTTP APIs and event schemas */
 .rendered-data {
   background-color: $secondary-lightest-background;
-  padding: 1rem;
-  margin: 1rem 0;
+  padding: 0.85rem;
+  margin: 0.85rem 0;
 
   details {
     summary {
-      padding: .5rem 0;
-      p {
-        max-width: 80%;
+      h1 {
+        margin: 0;
+        /* Ensure the disclosure control is vertically centred with the header text. */
+        vertical-align: middle;
       }
+    }
+    p {
+      max-width: 80%;
     }
   }
 

--- a/changelogs/internal/newsfragments/1446.clarification
+++ b/changelogs/internal/newsfragments/1446.clarification
@@ -1,0 +1,1 @@
+Endpoint disclosures now hide everything but the URL.

--- a/layouts/partials/openapi/render-operation.html
+++ b/layouts/partials/openapi/render-operation.html
@@ -33,6 +33,7 @@
    <span class="http-api-method {{ $method }}">{{ $method }}</span>
    <span class="endpoint{{ if $operation_data.deprecated }} deprecated-inline{{ end }}">{{ $endpoint }}</span>
   </h1>
+</summary>
 
   <hr/>
 
@@ -49,7 +50,6 @@
 
 <p>{{ $operation_data.description | markdownify }}</p>
 
-</summary>
 
 <table class="basic-info">
   <tr>


### PR DESCRIPTION
As threatened on https://github.com/matrix-org/matrix-spec/issues/1358#issuecomment-1325220859 and https://github.com/matrix-org/matrix-spec/issues/1352#issuecomment-1439033334. (If nothing else, I seem to be consistent.)


Fixes #1352.




<!-- Replace -->
Preview: https://pr1446--matrix-spec-previews.netlify.app
<!-- Replace -->
