### PR TITLE
Clarification to transaction identifier idempotent semantics

### DIFF
--- a/changelogs/client_server/newsfragments/1449.clarification
+++ b/changelogs/client_server/newsfragments/1449.clarification
@@ -1,0 +1,1 @@
+Clarify the semantics that make requests idempotent.


### PR DESCRIPTION
The Client-Server API currently describes requests as being "idempotent" in the [transaction identifier](https://spec.matrix.org/v1.6/client-server-api/#transaction-identifiers) section:

> The client-server API typically uses HTTP PUT to submit requests with a client-generated transaction identifier. This means that these requests are idempotent.

However, there is no definition of what the expected idempotency semantics are.

I've attempted to clarify what I believe are the intended semantics.

I've also added a complement test for this behaviour: https://github.com/matrix-org/complement/pull/613




<!-- Replace -->
Preview: https://pr1449--matrix-spec-previews.netlify.app
<!-- Replace -->
