### PR TITLE
More cleanup before upgrading to OpenAPI 3.1

### DIFF
--- a/changelogs/client_server/newsfragments/1455.clarification
+++ b/changelogs/client_server/newsfragments/1455.clarification
@@ -1,0 +1,1 @@
+Fix various typos throughout the specification.

--- a/data/api/client-server/capabilities.yaml
+++ b/data/api/client-server/capabilities.yaml
@@ -69,8 +69,7 @@ paths:
                 description: |-
                     The custom capabilities the server supports, using the
                     Java package naming convention.
-                additionalProperties:
-                  type: object
+                additionalProperties: true
                 properties:
                   "m.change_password":
                     type: object

--- a/data/api/client-server/capabilities.yaml
+++ b/data/api/client-server/capabilities.yaml
@@ -69,7 +69,8 @@ paths:
                 description: |-
                     The custom capabilities the server supports, using the
                     Java package naming convention.
-                additionalProperties: true
+                additionalProperties:
+                  type: object
                 properties:
                   "m.change_password":
                     type: object

--- a/data/api/client-server/definitions/cross_signing_key.yaml
+++ b/data/api/client-server/definitions/cross_signing_key.yaml
@@ -35,6 +35,8 @@ properties:
       The public key.  The object must have exactly one property, whose name is
       in the form `<algorithm>:<unpadded_base64_public_key>`, and whose value
       is the unpadded base64 public key.
+    minProperties: 1
+    maxProperties: 1
     example:
       "ed25519:alice+base64+public+key": "alice+base64+public+key"
   signatures:

--- a/data/api/client-server/receipts.yaml
+++ b/data/api/client-server/receipts.yaml
@@ -93,7 +93,8 @@ paths:
             application/json: {
               }
           schema:
-            type: object  # empty json object
+            type: object
+            maxProperties: 0  # empty json object
         429:
           description: This request was rate-limited.
           schema:


### PR DESCRIPTION
- ~~`capabilities.yaml`: additional properties are actually more likely to be strings (but can also be objects)~~
- `cross_signing_key.yaml`: the parameter documentation already restricts the number of properties
- `receipts.yaml`: use `maxProperties: 0` to say the object is empty (the comment is still there but is not really needed any more)

Signed-off-by: Alexey Rusakov \<Kitsune.Ral@users.sf.net\>










<!-- Replace -->
Preview: https://pr1455--matrix-spec-previews.netlify.app
<!-- Replace -->
