### PR TITLE
Add mention of private sign off to contributing guidelines

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -167,3 +167,15 @@ include the line in your commit or pull request comment::
 can't be accepted. Git makes this trivial - just use the -s flag when you do
 ``git commit``, having first set ``user.name`` and ``user.email`` git configs
 (which you should have done anyway :)
+
+Private sign off
+~~~~~~~~~~~~~~~~
+
+If you would like to provide your legal name privately to the Matrix.org
+Foundation (instead of in a public commit or comment), you can do so by emailing
+your legal name and a link to the pull request to dco@matrix.org. It helps to
+include "sign off" or similar in the subject line. You will then be instructed
+further.
+
+Once private sign off is complete, doing so for future contributions will not
+be required.


### PR DESCRIPTION
borrowed from Synapse: https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#private-sign-off

**Partnered with https://github.com/matrix-org/matrix-spec-proposals/pull/3976**

<!-- Replace -->
Preview: https://pr1462--matrix-spec-previews.netlify.app
<!-- Replace -->
