### PR TITLE
Spec implicit filter event limit

### DIFF
--- a/changelogs/client_server/newsfragments/1463.clarification
+++ b/changelogs/client_server/newsfragments/1463.clarification
@@ -1,0 +1,1 @@
+Clarify that servers should enforce a default `limit` on a filter if one is not specified.

--- a/data/api/client-server/definitions/event_filter.yaml
+++ b/data/api/client-server/definitions/event_filter.yaml
@@ -14,7 +14,7 @@
 title: EventFilter
 properties:
   limit:
-    description: The maximum number of events to return.
+    description: The maximum number of events to return. If not specified defaults to 10.
     type: integer
   not_senders:
     description: A list of sender IDs to exclude. If this list is absent then no senders

--- a/data/api/client-server/definitions/event_filter.yaml
+++ b/data/api/client-server/definitions/event_filter.yaml
@@ -14,7 +14,11 @@
 title: EventFilter
 properties:
   limit:
-    description: The maximum number of events to return. If not specified defaults to 10.
+    description: |
+      The maximum number of events to return, must be an integer greater than 0.
+
+      Servers should apply a default value, and impose a maximum value to avoid
+      resource exhaustion.
     type: integer
   not_senders:
     description: A list of sender IDs to exclude. If this list is absent then no senders


### PR DESCRIPTION
This is an attempt to address #200 

I think I am understanding the issue correctly. ~~I took the default out of [synapse](https://github.com/matrix-org/synapse/blob/a1c986939444db9bbf2343224091c88d18b3f598/synapse/api/filtering.py#L336) I haven't looked in any other implementations to see if they also use the default of 10.~~







<!-- Replace -->
Preview: https://pr1463--matrix-spec-previews.netlify.app
<!-- Replace -->
