### PR TITLE
Correct a small typo in the push rules spec (#1465

### DIFF
--- a/changelogs/client_server/newsfragments/1465.clarifications
+++ b/changelogs/client_server/newsfragments/1465.clarifications
@@ -1,0 +1,1 @@
+Fix various typos throughout the specification.

--- a/content/client-server-api/modules/push.md
+++ b/content/client-server-api/modules/push.md
@@ -249,7 +249,7 @@ Other `topic` values which will match are:
 
  * `"LUNCH"` (case-insensitive; `*` may match zero characters)
 
-The following `membership` values will NOT match:
+The following `topic` values will NOT match:
  * `" lunch"` (note leading space)
  * `"lunc"` (`?` must match a character)
  * `null` (not a string)


### PR DESCRIPTION
This PR fixes a field name in an example that does not make sense.

The example does not talk about a "membership" field in any case. It looks like this was instead supposed to be "topic", as the previous paragraph also talks about.




<!-- Replace -->
Preview: https://pr1465--matrix-spec-previews.netlify.app
<!-- Replace -->
