### PR TITLE
Remove leftover {key_id} from /_matrix/key/v2/server/

### DIFF
--- a/changelogs/server_server/newsfragments/1473.clarification
+++ b/changelogs/server_server/newsfragments/1473.clarification
@@ -1,0 +1,1 @@
+* Remove leftover `{key_id}` from `/_matrix/key/v2/server/`

--- a/content/server-server-api.md
+++ b/content/server-server-api.md
@@ -227,7 +227,7 @@ keys returned by a given notary server by querying other servers.
 #### Publishing Keys
 
 Homeservers publish their signing keys in a JSON object at
-`/_matrix/key/v2/server/{key_id}`. The response contains a list of
+`/_matrix/key/v2/server`. The response contains a list of
 `verify_keys` that are valid for signing federation requests made by the
 homeserver and for signing events. It contains a list of
 `old_verify_keys` which are only valid for signing events.


### PR DESCRIPTION
The parameter was removed in v1.6 (specifically in 9e4503712960a3cfcbf85531e8e2215b9962d8fd)

<!-- Replace -->
Preview: https://pr1473--matrix-spec-previews.netlify.app
<!-- Replace -->
