### PR TITLE
Remove fictitious `token` parameter on `/keys/query`

### DIFF
--- a/changelogs/client_server/newsfragments/1485.clarification
+++ b/changelogs/client_server/newsfragments/1485.clarification
@@ -1,0 +1,1 @@
+Remove fictitious `token` parameter on `/keys/query` endpoint

--- a/data/api/client-server/keys.yaml
+++ b/data/api/client-server/keys.yaml
@@ -177,13 +177,6 @@ paths:
                     description: "device ID"
                 example:
                   "@alice:example.com": []
-              token:
-                type: string
-                description: |-
-                  If the client is fetching keys as a result of a device update received
-                  in a sync request, this should be the 'since' token of that sync request,
-                  or any later sync token. This allows the server to ensure its response
-                  contains the keys advertised by the notification in that sync.
             required:
               - device_keys
 


### PR DESCRIPTION
This was added in https://github.com/matrix-org/matrix-doc/pull/1104, but was never subject to an MSC, and has never been implemented. (And `/keys/query` itself was added in https://github.com/matrix-org/matrix-doc/pull/894, which again long predates the MSC process).

So I think this is just correcting a long-standing error in the spec document, rather than something we need to MSC.

Fixes https://github.com/matrix-org/matrix-spec/issues/1039