### PR TITLE
Fix rendering of properties with a list of types

### DIFF
--- a/changelogs/client_server/newsfragments/1487.clarification
+++ b/changelogs/client_server/newsfragments/1487.clarification
@@ -1,0 +1,1 @@
+Fix rendering of properties with a list of types

--- a/layouts/partials/openapi/render-object-table.html
+++ b/layouts/partials/openapi/render-object-table.html
@@ -34,47 +34,30 @@
     {{ range $property_name, $property := $properties }}
 
         {{ $property := partial "json-schema/resolve-allof" $property }}
+        {{ $type := $property.type }}
 
-        {{/*
-            If the property has a `title`, use that rather than `type`.
-            This means we can write things like `EventFilter` rather than `object`.
-        */}}
-        {{ $type := $property.type}}
-        {{ if $property.title }}
-            {{ $type = $property.title }}
+        {{ if eq $property.type "object" }}
+            {{ $type = partial "type-or-title" $property }}
         {{ end }}
 
         {{/*
             If the property is an array, indicate this with square brackets,
             like `[type]`.
         */}}
-        {{ if eq $type "array"}}
+        {{ if eq $property.type "array"}}
             {{ $items := $property.items }}
             {{ if $property.items }}
                 {{ $items = partial "json-schema/resolve-allof" $property.items }}
             {{ end }}
-            {{ $inner_type := $items.type }}
-            {{ if $items.title }}
-                {{ $inner_type = $items.title }}
-            {{ end }}
+            {{ $inner_type := partial "type-or-title" $items }}
             {{ $type = delimit (slice "[" $inner_type "]") "" }}
         {{ end }}
 
         {{/*
             If the property is an enum, indicate this.
         */}}
-        {{ if (and (eq $type "string") ($property.enum)) }}
+        {{ if (and (eq $property.type "string") ($property.enum)) }}
             {{ $type = "enum" }}
-        {{ end }}
-
-        {{/*
-            If the property uses `additionalProperties` to describe its
-            internal structure, handle this.
-        */}}
-        {{ if reflect.IsMap $property.additionalProperties }}
-            {{ if $property.additionalProperties.title }}
-                {{ $type = delimit (slice "{string: " $property.additionalProperties.title "}" ) "" }}
-            {{ end }}
         {{ end }}
 
         {{/*
@@ -99,4 +82,31 @@
 
 </table>
 
+{{ end }}
+
+{{/*
+   Picks either the `title` of a property, or the `type`, to turn into the rendered type field.
+   Also handles `additionalProperties`, if no `title` is present.
+*/}}
+{{ define "partials/type-or-title" }}
+    {{ $type := "" }}
+    {{ if .title }}
+        {{/*
+            If the property has a `title`, use that rather than `type`.
+            This means we can write things like `EventFilter` rather than `object`.
+        */}}
+        {{ $type = .title }}
+    {{ else if reflect.IsMap .additionalProperties }}
+        {{/*
+            If the property uses `additionalProperties` to describe its
+            internal structure, handle this with a bit of recursion
+        */}}
+        {{ $type = delimit (slice "{string: " (partial "type-or-title" .additionalProperties) "}" ) "" }}
+    {{ else if reflect.IsSlice .type }}
+        {{/* It's legal to specify an array of types. Join them together in that case */}}
+        {{ $type = delimit .type "|" }}
+    {{ else }}
+        {{ $type = .type }}
+    {{ end }}
+    {{ return $type }}
 {{ end }}


### PR DESCRIPTION
Some properties (notably `actions` in the [push rules API](https://spec.matrix.org/v1.6/client-server-api/#push-rules-api)) specify a list of types. This is valid, but its rendering has been broken ever since spec v1.0.

This fixes it up, and as a side-effect also fixes the rendering of some nested `additionalProperties` properties, such as the request body on `/sendToDevice`.

<!-- Replace -->
Preview: https://pr1487--matrix-spec-previews.netlify.app
<!-- Replace -->
