### PR TITLE
Fix generation of anchors for additional properties

### DIFF
--- a/changelogs/internal/newsfragments/1488.clarification
+++ b/changelogs/internal/newsfragments/1488.clarification
@@ -1,0 +1,1 @@
+Fix generation of anchors for additional properties

--- a/layouts/partials/json-schema/resolve-additional-types.html
+++ b/layouts/partials/json-schema/resolve-additional-types.html
@@ -43,17 +43,12 @@
     */}}
     {{ if $this_object.additionalProperties }}
         {{ if reflect.IsMap $this_object.additionalProperties }}
-            {{ $additional_objects = $additional_objects | append (partial "clean-object" $this_object.additionalProperties) }}
-
-            {{ range $key, $property := $this_object.additionalProperties.properties }}
-                {{ $additional_objects = partial "get-additional-objects" (dict
-                    "this_object" $property
-                    "additional_objects" $additional_objects
-                    "anchor_base" $anchor_base
-                    "name" (printf "%s.%s" $name $key)
-                ) }}
-            {{ end }}
-
+            {{ $additional_objects = partial "get-additional-objects" (dict
+                "this_object" $this_object.additionalProperties
+                "additional_objects" $additional_objects
+                "anchor_base" $anchor_base
+                "name" (printf "%s.additional" $name)
+            ) }}
         {{ end }}
     {{ end }}
 


### PR DESCRIPTION
\#1174 added HTML anchors for object definitions, but objects defined under `additionalProperties` missed out on them. This fixes that.

<!-- Replace -->
Preview: https://pr1488--matrix-spec-previews.netlify.app
<!-- Replace -->
