### PR TITLE
"MXC URI" -> "`mxc://` URI"

### DIFF
--- a/changelogs/client_server/newsfragments/1500.clarification
+++ b/changelogs/client_server/newsfragments/1500.clarification
@@ -1,0 +1,1 @@
+Fix various typos throughout the specification.

--- a/content/client-server-api/modules/content_repo.md
+++ b/content/client-server-api/modules/content_repo.md
@@ -7,7 +7,7 @@ user wants to send to a room would be uploaded here, as would an avatar
 the user wants to use.
 
 Uploads are POSTed to a resource on the user's local homeserver which
-returns a MXC URI which can later be used to GET the download. Content
+returns a `mxc://` URI which can later be used to GET the download. Content
 is downloaded from the recipient's local homeserver, which must first
 transfer the content from the origin homeserver using the same API
 (unless the origin and destination homeservers are the same).
@@ -23,9 +23,9 @@ When serving content, the server SHOULD provide a
 interacting with the media repository.
 {{% /boxes/added-in-paragraph %}}
 
-#### Matrix Content (MXC) URIs
+#### Matrix Content (`mxc://`) URIs
 
-Content locations are represented as Matrix Content (MXC) URIs. They
+Content locations are represented as Matrix Content (`mxc://`) URIs. They
 look like:
 
     mxc://<server-name>/<media-id>
@@ -88,10 +88,10 @@ The HTTP GET endpoint does not require any authentication. Knowing the
 URL of the content is sufficient to retrieve the content, even if the
 entity isn't in the room.
 
-MXC URIs are vulnerable to directory traversal attacks such as
+`mxc://` URIs are vulnerable to directory traversal attacks such as
 `mxc://127.0.0.1/../../../some_service/etc/passwd`. This would cause the
 target homeserver to try to access and return this file. As such,
-homeservers MUST sanitise MXC URIs by allowing only alphanumeric
+homeservers MUST sanitise `mxc://` URIs by allowing only alphanumeric
 (`A-Za-z0-9`), `_` and `-` characters in the `server-name` and
 `media-id` values. This set of whitelisted characters allows URL-safe
 base64 encodings specified in RFC 4648. Applying this character

--- a/content/client-server-api/modules/content_repo.md
+++ b/content/client-server-api/modules/content_repo.md
@@ -7,7 +7,7 @@ user wants to send to a room would be uploaded here, as would an avatar
 the user wants to use.
 
 Uploads are POSTed to a resource on the user's local homeserver which
-returns a `mxc://` URI which can later be used to GET the download. Content
+returns an `mxc://` URI which can later be used to GET the download. Content
 is downloaded from the recipient's local homeserver, which must first
 transfer the content from the origin homeserver using the same API
 (unless the origin and destination homeservers are the same).

--- a/content/client-server-api/modules/instant_messaging.md
+++ b/content/client-server-api/modules/instant_messaging.md
@@ -315,7 +315,7 @@ When sending a spoiler, clients SHOULD provide the fallback in the `body` as sho
 (including the reason). The fallback SHOULD NOT include the text containing spoilers since
 `body` might show up in text-only clients or in notifications. To prevent spoilers showing up in
 such situations, clients are strongly encouraged to first upload the text containing spoilers
-to the media repository, then reference the MXC URI in a markdown-style link, as shown above.
+to the media repository, then reference the `mxc://` URI in a markdown-style link, as shown above.
 
 Clients SHOULD render spoilers differently with some sort of disclosure. For example, the
 client could blur the actual text and ask the user to click on it for it to be revealed.

--- a/content/client-server-api/modules/instant_messaging.md
+++ b/content/client-server-api/modules/instant_messaging.md
@@ -53,7 +53,7 @@ the tag.
 | `font` | `data-mx-bg-color`, `data-mx-color`, `color`                                                                                               |
 | `span` | `data-mx-bg-color`, `data-mx-color`, `data-mx-spoiler` (see [spoiler messages](#spoiler-messages))                                         |
 | `a`    | `name`, `target`, `href` (provided the value is not relative and has a scheme matching one of: `https`, `http`, `ftp`, `mailto`, `magnet`) |
-| `img`  | `width`, `height`, `alt`, `title`, `src` (provided it is a [Matrix Content (MXC) URI](#matrix-content-mxc-uris))                           |
+| `img`  | `width`, `height`, `alt`, `title`, `src` (provided it is a [Matrix Content (`mxc://`) URI](#matrix-content-mxc-uris))                      |
 | `ol`   | `start`                                                                                                                                    |
 | `code` | `class` (only classes which start with `language-` for syntax highlighting)                                                                |
 

--- a/data/api/client-server/content-repo.yaml
+++ b/data/api/client-server/content-repo.yaml
@@ -59,7 +59,7 @@ paths:
             format: byte
       responses:
         200:
-          description: The [MXC URI](/client-server-api/#matrix-content-mxc-uris) for the uploaded content.
+          description: The [`mxc://` URI](/client-server-api/#matrix-content-mxc-uris) for the uploaded content.
           schema:
             type: object
             required: ["content_uri"]
@@ -67,7 +67,7 @@ paths:
               content_uri:
                 type: string
                 format: uri
-                description: "The [MXC URI](/client-server-api/#matrix-content-mxc-uris) to the uploaded content."
+                description: "The [`mxc://` URI](/client-server-api/#matrix-content-mxc-uris) to the uploaded content."
           examples:
             application/json: {
               "content_uri": "mxc://example.com/AQwafuaFswefuhsfAFAgsw"
@@ -393,7 +393,7 @@ paths:
                 type: string
                 format: uri
                 description: |-
-                  An [MXC URI](/client-server-api/#matrix-content-mxc-uris) to the image. Omitted if there is no image.
+                  An [`mxc://` URI](/client-server-api/#matrix-content-mxc-uris) to the image. Omitted if there is no image.
           examples:
             application/json: {
                 "og:title": "Matrix Blog Post",

--- a/data/api/client-server/definitions/sso_login_flow.yaml
+++ b/data/api/client-server/definitions/sso_login_flow.yaml
@@ -54,7 +54,7 @@ properties:
         icon:
           type: string
           description: |-
-            Optional MXC URI to provide an image/icon representing the IdP.
+            Optional `mxc://` URI to provide an image/icon representing the IdP.
             Intended to be shown alongside the `name` if provided.
           example: "mxc://example.org/abc123"
         brand:

--- a/data/api/client-server/rooms.yaml
+++ b/data/api/client-server/rooms.yaml
@@ -297,7 +297,7 @@ paths:
                     avatar_url:
                       type: string
                       format: uri
-                      description: The mxc avatar url of the user this object is representing.
+                      description: The avatar of the user this object is representing, as an [`mxc://` URI](/client-server-api/#matrix-content-mxc-uris).
                 description: A map from user ID to a RoomMember object.
                 type: object
         403:

--- a/data/api/client-server/users.yaml
+++ b/data/api/client-server/users.yaml
@@ -98,7 +98,7 @@ paths:
                       type: string
                       format: uri
                       example: "mxc://bar.com/foo"
-                      description: The avatar url, as an MXC, if one exists.
+                      description: The avatar url, as an [`mxc://` URI](/client-server-api/#matrix-content-mxc-uris), if one exists.
               limited:
                 type: boolean
                 description: Indicates if the result list has been truncated by the limit.

--- a/data/event-schemas/schema/core-event-schema/msgtype_infos/image_info.yaml
+++ b/data/event-schemas/schema/core-event-schema/msgtype_infos/image_info.yaml
@@ -19,7 +19,7 @@ properties:
     type: integer
   thumbnail_url:
     description: |-
-      The URL (typically [MXC URI](/client-server-api/#matrix-content-mxc-uris)) to a thumbnail of the image.
+      The URL (typically [`mxc://` URI](/client-server-api/#matrix-content-mxc-uris)) to a thumbnail of the image.
       Only present if the thumbnail is unencrypted.
     type: string
   thumbnail_file:

--- a/data/event-schemas/schema/m.room.message$m.audio.yaml
+++ b/data/event-schemas/schema/m.room.message$m.audio.yaml
@@ -28,7 +28,7 @@ properties:
         type: string
       url:
         description: |-
-          Required if the file is unencrypted. The URL (typically [MXC URI](/client-server-api/#matrix-content-mxc-uris))
+          Required if the file is unencrypted. The URL (typically [`mxc://` URI](/client-server-api/#matrix-content-mxc-uris))
           to the audio clip.
         type: string
       file:

--- a/data/event-schemas/schema/m.room.message$m.file.yaml
+++ b/data/event-schemas/schema/m.room.message$m.file.yaml
@@ -44,7 +44,7 @@ properties:
         type: string
       url:
         description: |-
-          Required if the file is unencrypted. The URL (typically [MXC URI](/client-server-api/#matrix-content-mxc-uris))
+          Required if the file is unencrypted. The URL (typically [`mxc://` URI](/client-server-api/#matrix-content-mxc-uris))
           to the file.
         type: string
       file:

--- a/data/event-schemas/schema/m.room.message$m.image.yaml
+++ b/data/event-schemas/schema/m.room.message$m.image.yaml
@@ -18,7 +18,7 @@ properties:
         type: string
       url:
         description: |-
-          Required if the file is unencrypted. The URL (typically [MXC URI](/client-server-api/#matrix-content-mxc-uris))
+          Required if the file is unencrypted. The URL (typically [`mxc://` URI](/client-server-api/#matrix-content-mxc-uris))
           to the image.
         type: string
       file:

--- a/data/event-schemas/schema/m.room.message$m.video.yaml
+++ b/data/event-schemas/schema/m.room.message$m.video.yaml
@@ -28,7 +28,7 @@ properties:
             type: integer
           thumbnail_url:
             description: |-
-              The URL (typically [MXC URI](/client-server-api/#matrix-content-mxc-uris)) to an image thumbnail of
+              The URL (typically [`mxc://` URI](/client-server-api/#matrix-content-mxc-uris)) to an image thumbnail of
               the video clip. Only present if the thumbnail is unencrypted.
             type: string
           thumbnail_file:
@@ -50,7 +50,7 @@ properties:
         type: string
       url:
         description: |-
-          Required if the file is unencrypted. The URL (typically [MXC URI](/client-server-api/#matrix-content-mxc-uris))
+          Required if the file is unencrypted. The URL (typically [`mxc://` URI](/client-server-api/#matrix-content-mxc-uris))
           to the video clip.
         type: string
       file:


### PR DESCRIPTION
We're a bit inconsistent with this currently, and IMHO "`mxc://` URI" is more
explicit.







<!-- Replace -->
Preview: https://pr1500--matrix-spec-previews.netlify.app
<!-- Replace -->
