### PR TITLE
Remove the `dont_notify` and `coalesce` push rule actions.

### DIFF
--- a/changelogs/client_server/newsfragments/1501.clarification
+++ b/changelogs/client_server/newsfragments/1501.clarification
@@ -1,0 +1,1 @@
+Remove the `dont_notify` and `coalesce` push rule actions per [MSC3987](https://github.com/matrix-org/matrix-spec-proposals/pull/3987).

--- a/content/client-server-api/modules/push.md
+++ b/content/client-server-api/modules/push.md
@@ -147,17 +147,6 @@ actions are defined:
 
 :   This causes each matching event to generate a notification.
 
-`dont_notify`
-
-:   This prevents each matching event from generating a notification.
-
-`coalesce`
-
-:   This enables notifications for matching events but activates homeserver
-    specific behaviour to intelligently coalesce multiple events into a
-    single notification. Not all homeservers may support this. Those that do
-    not support it should treat it as the `notify` action.
-
 `set_tweak`
 
 :   Sets an entry in the `tweaks` dictionary key that is sent in the
@@ -194,6 +183,12 @@ Actions that have no parameters are represented as a string. Otherwise,
 they are represented as a dictionary with a key equal to their name and
 other keys as their parameters, e.g.
 `{ "set_tweak": "sound", "value": "default" }`.
+
+{{% boxes/note %}}
+Older versions of the Matrix specification included the `dont_notify` and
+`coalesce` actions. These should both be considered no-ops (ignored, not
+rejected) if received from a client.
+{{% /boxes/note %}}
 
 ##### Conditions
 


### PR DESCRIPTION
Per MSC3987, these should both be considered no-ops.