### PR TITLE
Fix a list formatting error under C-S API -> `m.room.member` definition

### DIFF
--- a/changelogs/client_server/newsfragments/1509.clarification
+++ b/changelogs/client_server/newsfragments/1509.clarification
@@ -1,0 +1,1 @@
+Fix various typos throughout the specification.

--- a/data/event-schemas/schema/m.room.member.yaml
+++ b/data/event-schemas/schema/m.room.member.yaml
@@ -7,13 +7,9 @@ description: |-
   The following membership states are specified:
 
   - `invite` - The user has been invited to join a room, but has not yet joined it. They may not participate in the room until they join.
-
   - `join` - The user has joined the room (possibly after accepting an invite), and may participate in it.
-
   - `leave` - The user was once joined to the room, but has since left (possibly by choice, or possibly by being kicked).
-
   - `ban` - The user has been banned from the room, and is no longer allowed to join it until they are un-banned from the room (by having their membership state set to a value other than `ban`).
-
   - `knock` - The user has knocked on the room, requesting permission to participate. They may not participate in the room until they join.
 
   The `third_party_invite` property will be set if this invite is an `invite` event and is the successor of an `m.room.third_party_invite` event, and absent otherwise.


### PR DESCRIPTION
Looks like double-newlines between list items in a yaml multiline string doesn't work and adds a newline to the beginning of each list item. We remove the extra newlines to fix the formatting.

Before:

![Screenshot from 2023-05-03 18-04-31](https://user-images.githubusercontent.com/1342360/235989020-26e1f6fa-72aa-4141-927e-965d83e1b9b5.png)

After:

![image](https://user-images.githubusercontent.com/1342360/235989342-4fa2c859-1c93-45a9-8919-f7992e4e75dc.png)





<!-- Replace -->
Preview: https://pr1509--matrix-spec-previews.netlify.app
<!-- Replace -->
