### PR TITLE
Add 'deprecated:true' to /v1/send_{join,leave}

### DIFF
--- a/changelogs/server_server/newsfragments/1518.clarification
+++ b/changelogs/server_server/newsfragments/1518.clarification
@@ -1,0 +1,1 @@
+Fix various typos throughout the specification.

--- a/data/api/server-server/joins-v1.yaml
+++ b/data/api/server-server/joins-v1.yaml
@@ -218,6 +218,7 @@ paths:
 
   "/send_join/{roomId}/{eventId}":
     put:
+      deprecated: true
       summary: Submit a signed join event to a resident server
       description: |-
         **Note:**

--- a/data/api/server-server/leaving-v1.yaml
+++ b/data/api/server-server/leaving-v1.yaml
@@ -141,6 +141,7 @@ paths:
             }
   "/send_leave/{roomId}/{eventId}":
     put:
+      deprecated: true
       summary: Submit a signed leave event to a resident server
       description: |-
         **Note:**


### PR DESCRIPTION
The words already say this is deprecated, but it was missing the flag.




<!-- Replace -->
Preview: https://pr1518--matrix-spec-previews.netlify.app
<!-- Replace -->
