### PR TITLE
Document why `/state_ids` can respond with a 404

### DIFF
--- a/changelogs/server_server/newsfragments/1521.clarification
+++ b/changelogs/server_server/newsfragments/1521.clarification
@@ -1,0 +1,1 @@
+Document why `/state_ids` can respond with a 404.

--- a/data/api/server-server/events.yaml
+++ b/data/api/server-server/events.yaml
@@ -137,6 +137,17 @@ paths:
                   type: string
                 example: ["$an_event:example.org"]
             required: ['auth_chain_ids', 'pdu_ids']
+        404:
+          description: |-
+            No event was found or the server doesn't know about the state at that event
+            to return anything useful.
+          examples:
+            application/json: {
+                "errcode": "M_NOT_FOUND",
+                "error": "Could not find event `$Rqnc-F-dvnEYJTyHq_iKxU2bZ1CI92-kuZq3a5lr5Zg"
+              }
+          schema:
+            "$ref": "../client-server/definitions/errors/error.yaml"
   "/event/{eventId}":
     get:
       summary: Get a single event

--- a/data/api/server-server/events.yaml
+++ b/data/api/server-server/events.yaml
@@ -144,7 +144,7 @@ paths:
           examples:
             application/json: {
                 "errcode": "M_NOT_FOUND",
-                "error": "Could not find event `$Rqnc-F-dvnEYJTyHq_iKxU2bZ1CI92-kuZq3a5lr5Zg"
+                "error": "Could not find event $Rqnc-F-dvnEYJTyHq_iKxU2bZ1CI92-kuZq3a5lr5Zg"
               }
           schema:
             "$ref": "../client-server/definitions/errors/error.yaml"

--- a/data/api/server-server/events.yaml
+++ b/data/api/server-server/events.yaml
@@ -139,7 +139,7 @@ paths:
             required: ['auth_chain_ids', 'pdu_ids']
         404:
           description: |-
-            The given `event_id` was found or the server doesn't know about the state at
+            The given `event_id` was not found or the server doesn't know about the state at
             that event to return anything useful.
           examples:
             application/json: {

--- a/data/api/server-server/events.yaml
+++ b/data/api/server-server/events.yaml
@@ -139,8 +139,8 @@ paths:
             required: ['auth_chain_ids', 'pdu_ids']
         404:
           description: |-
-            No event was found or the server doesn't know about the state at that event
-            to return anything useful.
+            The given `event_id` was found or the server doesn't know about the state at
+            that event to return anything useful.
           examples:
             application/json: {
                 "errcode": "M_NOT_FOUND",


### PR DESCRIPTION
Document why `/state_ids` can respond with a 404

*As [discussed in an internal room](https://matrix.to/#/!SGNQGPGUwtcPBUotTL:matrix.org/$SoOPVIJch_TV84Df3uqf1SOUUNFil2d6GZJwE4mcqZs?via=jki.re&via=matrix.org&via=element.io)*










<!-- Replace -->
Preview: https://pr1521--matrix-spec-previews.netlify.app
<!-- Replace -->
