### PR TITLE
event_replacements: fix rationale box

### DIFF
--- a/changelogs/client_server/newsfragments/1525.feature
+++ b/changelogs/client_server/newsfragments/1525.feature
@@ -1,0 +1,1 @@
+Changes to the server-side aggregation of `m.replace` (edit) events, as per [MSC3925](https://github.com/matrix-org/matrix-spec-proposals/pull/3925).

--- a/content/client-server-api/modules/event_replacements.md
+++ b/content/client-server-api/modules/event_replacements.md
@@ -249,14 +249,14 @@ events](#redactions-of-edited-events) below.
 **Note:** the `content` of the original event is left intact. In particular servers
 should **not** replace the content with that of the replacement event.
 
-{{ boxes/rationale }}
+{{% boxes/rationale %}}
 In previous versions of the specification, servers were expected to replace the
 content of an edited event whenever it was served to clients (with the
 exception of the
 [`GET /_matrix/client/v3/rooms/{roomId}/event/{eventId}`](#get_matrixclientv3roomsroomideventeventid)
 endpoint).  However, that behaviour made reliable client-side implementation
 difficult, and servers should no longer make this replacement.
-{{ /boxes/rationale }}
+{{% /boxes/rationale %}}
 
 #### Client behaviour
 


### PR DESCRIPTION
This was missing its %s

<!-- Replace -->
Preview: https://pr1525--matrix-spec-previews.netlify.app
<!-- Replace -->
