### PR TITLE
Fixes and clarifications around m.reaction

### DIFF
--- a/content/client-server-api/modules/event_annotations.md
+++ b/content/client-server-api/modules/event_annotations.md
@@ -71,6 +71,12 @@ change their reaction, the original reaction should be redacted and a new one
 sent in its place.
 {{% /boxes/note %}}
 
+{{% boxes/note %}}
+The `key` field in `m.reaction` can be any string so clients must take care to
+render long reactions in a sensible manner. For example, clients can elide
+overly-long reactions.
+{{% /boxes/note %}}
+
 #### Server behaviour
 
 ##### Avoiding duplicate annotations

--- a/content/client-server-api/modules/push.md
+++ b/content/client-server-api/modules/push.md
@@ -700,7 +700,7 @@ Definition:
 
 {{% added-in v="1.7" %}}
 
-Matches any event whose type is `m.room.reaction`. This suppresses notifications for [`m.reaction`](#mreaction) events.
+Matches any event whose type is `m.reaction`. This suppresses notifications for [`m.reaction`](#mreaction) events.
 
 Definition:
 

--- a/content/client-server-api/modules/receipts.md
+++ b/content/client-server-api/modules/receipts.md
@@ -153,12 +153,6 @@ relationships and solid lines showing topological ordering.
 
 ![threaded-dag](/diagrams/threaded-dag.png)
 
-{{% boxes/note %}}
-`m.reaction` relationships are not currently specified, but are shown here for
-their conceptual place in a threaded DAG. They are currently proposed as
-[MSC2677](https://github.com/matrix-org/matrix-spec-proposals/pull/2677).
-{{% /boxes/note %}}
-
 This DAG can be represented as 3 threaded timelines, with `A` and `B` being thread
 roots:
 

--- a/data/event-schemas/schema/m.reaction.yaml
+++ b/data/event-schemas/schema/m.reaction.yaml
@@ -30,8 +30,10 @@ properties:
           key:
             type: string
             description: |-
-              An emoji representing the reaction being made. Should include the
-              unicode emoji presentation selector (`\uFE0F`) for codepoints
-              which allow it (see the [emoji variation sequences
+              The reaction being made, usually an emoji.
+
+              If this is an emoji, it should include the unicode emoji
+              presentation selector (`\uFE0F`) for codepoints which allow it
+              (see the [emoji variation sequences
               list](https://www.unicode.org/Public/UCD/latest/ucd/emoji/emoji-variation-sequences.txt)).
             example: "👍"


### PR DESCRIPTION
See each commit message.

The last two commits might be more controversial given the intent behind the `m.reaction` event, but they respect the original MSC and reflect the current use of this event in the wild.

Signed-off-by: Kévin Commaille <zecakeh@tedomum.fr>