### PR TITLE
Mark the appservice ping response `duration_ms` field as required

### DIFF
--- a/changelogs/application_service/newsfragments/1541.feature
+++ b/changelogs/application_service/newsfragments/1541.feature
@@ -1,0 +1,1 @@
+Add homeserver->appservice ping mechanism, as per [MSC2659](https://github.com/matrix-org/matrix-spec-proposals/pull/2659). Contributed by @tulir at @beeper.

--- a/data/api/client-server/appservice_ping.yaml
+++ b/data/api/client-server/appservice_ping.yaml
@@ -82,6 +82,8 @@ paths:
                     The duration in milliseconds that the
                     [`/_matrix/app/v1/ping`](#post_matrixappv1ping)
                     request took from the homeserver's point of view.
+            required:
+              - duration_ms
           examples:
             application/json: {"duration_ms": 123}
         400:


### PR DESCRIPTION
As intended in MSC2659, forgotten in #1516.

Checked with the author [in the matrix spec room](https://matrix.to/#/!NasysSDfxKxZBzJJoE:matrix.org/$jKIn1Rh4T6NcCO0D38rFyOi6JOlQCxHSPr-kFHfU76o?via=matrix.org&via=libera.chat&via=element.io).




<!-- Replace -->
Preview: https://pr1541--matrix-spec-previews.netlify.app
<!-- Replace -->
