### PR TITLE
Update the changelog entry checker script to check newsfragment file extension

### DIFF
--- a/changelogs/internal/newsfragments/1542.clarification
+++ b/changelogs/internal/newsfragments/1542.clarification
@@ -1,0 +1,1 @@
+Update the CI to validate the file extension of changelog entries.

--- a/scripts/check-newsfragments
+++ b/scripts/check-newsfragments
@@ -21,6 +21,12 @@ matched=0
 while read f; do
     basename=$(basename $f)
     dirname=$(dirname $f)
+    extension="${f##*.}"
+
+    # check that each changelog file has a known extension
+    if ! [[ "$extension" == "new" || "$extension" == "feature" || "$extension" == "clarification" || "$extension" == "breaking" || "$extension" == "deprecation" ]]; then
+        echo -e "\e[31mERROR: newsfragment $f does not have one of the required file extensions for a changelog entry: .new, .feature, .clarification, .breaking, .deprecation\e[39m" >&2
+    fi
 
     # check that there is nothing that looks like a newsfile outside one of the
     # expected directories.
@@ -31,6 +37,7 @@ while read f; do
         # see if this newsfile corresponds to the right PR
         [[ -n "$pr" && "$basename" == "$pr".* ]] && matched=1
     fi
+# find all files in the 'changelogs/*/' dirs that are in the form `<digits>.<text>`
 done < <(find changelogs -regex '.*/[0-9]+\.[^/]+$')
 
 if [[ -n "$pr" && "$matched" -eq 0 ]]; then


### PR DESCRIPTION
This PR updates the script that the newsfragment check CI step uses in order to verify that changelog entries have one of the [known newsfragment file extensions](https://github.com/matrix-org/matrix-spec/blob/main/CONTRIBUTING.rst#adding-to-the-changelog).

Inspired by failing to write a valid extension in https://github.com/matrix-org/matrix-spec/pull/1465 :)

```
matrix-spec on  appservice-ping-spec [$!?] took 5.7s …
➜ ./scripts/check-newsfragments 
+++ Checking newsfragments for PR #
ERROR: newsfragment changelogs/client_server/newsfragments/1465.clarifications does not have one of the required file extensions for a changelog entry: .new, .feature, .clarification, .breaking, .deprecation

matrix-spec on  appservice-ping-spec [$!?] …
➜ mv changelogs/client_server/newsfragments/1465.clarification{s,}

matrix-spec on  appservice-ping-spec [$✘!?] …
➜ ./scripts/check-newsfragments                                   
+++ Checking newsfragments for PR #
```




<!-- Replace -->
Preview: https://pr1542--matrix-spec-previews.netlify.app
<!-- Replace -->
