### PR TITLE
Fix `m.call.negotiate` schema and example

### DIFF
--- a/changelogs/client_server/newsfragments/1546.clarification
+++ b/changelogs/client_server/newsfragments/1546.clarification
@@ -1,0 +1,1 @@
+Fix `m.call.negotiate` schema and example.

--- a/data/event-schemas/examples/m.call.negotiate.yaml
+++ b/data/event-schemas/examples/m.call.negotiate.yaml
@@ -5,6 +5,7 @@
     "version" : "1",
     "party_id": "67890",
     "call_id": "12345",
+    "lifetime": 10000,
     "description": {
       "type" : "offer",
       "sdp" : "v=0\r\no=- 6584580628695956864 2 IN IP4 127.0.0.1[...]"

--- a/data/event-schemas/examples/m.call.negotiate.yaml
+++ b/data/event-schemas/examples/m.call.negotiate.yaml
@@ -5,8 +5,7 @@
     "version" : "1",
     "party_id": "67890",
     "call_id": "12345",
-    "lifetime": 10000,
-    "offer": {
+    "description": {
       "type" : "offer",
       "sdp" : "v=0\r\no=- 6584580628695956864 2 IN IP4 127.0.0.1[...]"
     }

--- a/data/event-schemas/schema/m.call.negotiate.yaml
+++ b/data/event-schemas/schema/m.call.negotiate.yaml
@@ -42,15 +42,16 @@ properties:
     allOf:
     - "$ref": core-event-schema/call_event.yaml
     properties:
-      offer:
+      description:
         type: object
-        title: Offer
+        title: Description
         description: The session description object
         properties:
           type:
             type: string
             enum:
             - offer
+            - answer
             description: The type of session description.
           sdp:
             type: string
@@ -58,15 +59,8 @@ properties:
         required:
         - type
         - sdp
-      lifetime:
-        type: integer
-        description: The time in milliseconds that the invite is valid for.
-          Once the invite age exceeds this value, clients should discard it.
-          They should also no longer show the call as awaiting an answer in the
-          UI.
     required:
-    - offer
-    - lifetime
+    - description
   type:
     type: string
     enum:

--- a/data/event-schemas/schema/m.call.negotiate.yaml
+++ b/data/event-schemas/schema/m.call.negotiate.yaml
@@ -59,8 +59,15 @@ properties:
         required:
         - type
         - sdp
+      lifetime:
+        type: integer
+        description: The time in milliseconds that the invite is valid for.
+          Once the invite age exceeds this value, clients should discard it.
+          They should also no longer show the call as awaiting an answer in the
+          UI.
     required:
     - description
+    - lifetime
   type:
     type: string
     enum:

--- a/data/event-schemas/schema/m.call.negotiate.yaml
+++ b/data/event-schemas/schema/m.call.negotiate.yaml
@@ -61,10 +61,8 @@ properties:
         - sdp
       lifetime:
         type: integer
-        description: The time in milliseconds that the invite is valid for.
-          Once the invite age exceeds this value, clients should discard it.
-          They should also no longer show the call as awaiting an answer in the
-          UI.
+        description: The time in milliseconds that the negotiation is valid for.
+          Once the negotiation age exceeds this value, clients should discard it.
     required:
     - description
     - lifetime


### PR DESCRIPTION
Introduced in #1511. The properties and example look like a copy-paste of `m.call.invite`, but don't match the description of the event, nor MSC2746.

cc @dbkr










<!-- Replace -->
Preview: https://pr1546--matrix-spec-previews.netlify.app
<!-- Replace -->
