### PR TITLE
Add missing type enum for m.reaction

### DIFF
--- a/changelogs/client_server/newsfragments/1552.clarification
+++ b/changelogs/client_server/newsfragments/1552.clarification
@@ -1,1 +1,1 @@
-Added missing enumerated type for the m.reaction event.
+Fix missing `type` property for the m.reaction event.

--- a/changelogs/client_server/newsfragments/1552.clarification
+++ b/changelogs/client_server/newsfragments/1552.clarification
@@ -1,0 +1,1 @@
+Added missing enumerated type for the m.reaction event.

--- a/changelogs/client_server/newsfragments/1552.clarification
+++ b/changelogs/client_server/newsfragments/1552.clarification
@@ -1,1 +1,1 @@
-Fix missing `type` property for the m.reaction event.
+Fix missing `type` property in the JSON schema definition of the `m.reaction` event.  Contributed by @chebureki.

--- a/data/event-schemas/schema/m.reaction.yaml
+++ b/data/event-schemas/schema/m.reaction.yaml
@@ -37,3 +37,7 @@ properties:
               (see the [emoji variation sequences
               list](https://www.unicode.org/Public/UCD/latest/ucd/emoji/emoji-variation-sequences.txt)).
             example: "👍"
+  type:
+    enum:
+      - m.reaction
+    type: string


### PR DESCRIPTION
The specification does not specify the `m.reaction` for the event type




<!-- Replace -->
Preview: https://pr1552--matrix-spec-previews.netlify.app
<!-- Replace -->
