### PR TITLE
Fix definition of response of `POST /_matrix/federation/v1/user/keys/claim`

### DIFF
--- a/changelogs/server_server/newsfragments/1559.clarification
+++ b/changelogs/server_server/newsfragments/1559.clarification
@@ -1,0 +1,1 @@
+Fix definition of response of `POST /_matrix/federation/v1/user/keys/claim`.

--- a/data/api/server-server/user_keys.yaml
+++ b/data/api/server-server/user_keys.yaml
@@ -71,26 +71,28 @@ paths:
                         type: object
                         # Key
                         additionalProperties:
-                          type: object
-                          title: KeyObject
-                          properties:
-                            key:
-                              type: string
-                              description: The key, encoded using unpadded base64.
-                            signatures:
-                              type: object
-                              title: Signatures
-                              additionalProperties:
-                                type: object
-                                additionalProperties:
+                          oneOf:
+                            - type: string
+                            - type: object
+                              title: KeyObject
+                              properties:
+                                key:
                                   type: string
-                              description: |-
-                                Signature of the key object.
+                                  description: The key, encoded using unpadded base64.
+                                signatures:
+                                  type: object
+                                  title: Signatures
+                                  additionalProperties:
+                                    type: object
+                                    additionalProperties:
+                                      type: string
+                                  description: |-
+                                    Signature of the key object.
 
-                                The signature is calculated using the process described at [Signing JSON](/appendices/#signing-json).
-                          required:
-                            - key
-                            - signatures
+                                    The signature is calculated using the process described at [Signing JSON](/appendices/#signing-json).
+                              required:
+                                - key
+                                - signatures
                     example:
                       "@alice:example.com":
                         JLAFKJWSCS:

--- a/layouts/partials/json-schema/resolve-additional-types.html
+++ b/layouts/partials/json-schema/resolve-additional-types.html
@@ -91,17 +91,18 @@
     {{ end }}
 {{ end }}
 
-{{ if and $this_object.oneOf (reflect.IsSlice $this_object.oneOf) }}
+{{/*
+  Handle object schemas using the `oneOf` keyword
+  (https://json-schema.org/understanding-json-schema/reference/combining.html#oneof)
+*/}}
+{{ if $this_object.oneOf }}
     {{ range $idx, $item := $this_object.oneOf }}
-        /* although we expect resolve-allof to be called on the input, resolve-allof does not recurse into
-        * nested objects, so we have to call it again.
-        */
-        {{ $item = partial "json-schema/resolve-allof" $item }}
-        {{ $additional_objects = partial "json-schema/resolve-additional-types" (dict
-            "schema" $item
+        {{ $additional_objects = partial "get-additional-objects" (dict
+            "this_object" $item
+            "additional_objects" $additional_objects
             "anchor_base" $anchor_base
-            "name" (printf "%s.oneOf[%d]" $name $idx))
-        }}
+            "name" (printf "%s.oneOf[%d]" $name $idx)
+        ) }}
     {{ end }}
 {{ end }}
 

--- a/layouts/partials/json-schema/resolve-additional-types.html
+++ b/layouts/partials/json-schema/resolve-additional-types.html
@@ -91,6 +91,20 @@
     {{ end }}
 {{ end }}
 
+{{ if and $this_object.oneOf (reflect.IsSlice $this_object.oneOf) }}
+    {{ range $idx, $item := $this_object.oneOf }}
+        /* although we expect resolve-allof to be called on the input, resolve-allof does not recurse into
+        * nested objects, so we have to call it again.
+        */
+        {{ $item = partial "json-schema/resolve-allof" $item }}
+        {{ $additional_objects = partial "json-schema/resolve-additional-types" (dict
+            "schema" $item
+            "anchor_base" $anchor_base
+            "name" (printf "%s.oneOf[%d]" $name $idx))
+        }}
+    {{ end }}
+{{ end }}
+
 {{ return $additional_objects }}
 
 

--- a/layouts/partials/openapi/render-object-table.html
+++ b/layouts/partials/openapi/render-object-table.html
@@ -36,7 +36,7 @@
         {{ $property := partial "json-schema/resolve-allof" $property }}
         {{ $type := $property.type }}
 
-        {{ if eq $property.type "object" }}
+        {{ if or (eq $property.type "object") (and $property.oneOf (reflect.IsSlice .oneOf)) }}
             {{ $type = partial "type-or-title" $property }}
         {{ end }}
 
@@ -108,7 +108,7 @@
         {{ $types := slice }}
 
         {{ range .oneOf }}
-            {{ $types = $types | append .type }}
+            {{ $types = $types | append (partial "type-or-title" .) }}
         {{ end }}
 
         {{ $type = delimit $types "|" }}


### PR DESCRIPTION
As discussed in https://github.com/matrix-org/matrix-spec/pull/1351#issuecomment-1361787910 and https://github.com/matrix-org/matrix-spec/pull/1310#discussion_r1054687168.

The rendering of the type now looks like this (to compare with current state in the spec in the response of [the endpoint](https://spec.matrix.org/unstable/server-server-api/#post_matrixfederationv1userkeysclaim)):

![image](https://github.com/matrix-org/matrix-spec/assets/76261501/9f47a3e8-5844-4e84-8028-b5f5fc121725)

Also fixes the rendering of nested `OneOf`s, so it has the added bonus of fixing the rendering of [`m.room.encrypted`](https://spec.matrix.org/unstable/client-server-api/#mroomencrypted).

1. It now shows the type of `ciphertext`:
    ![image](https://github.com/matrix-org/matrix-spec/assets/76261501/e0ad78af-1ac4-4119-aeda-092ceb971c1b)
2. And adds the definition of `CiphertextInfo`:
    ![image](https://github.com/matrix-org/matrix-spec/assets/76261501/f4abcb54-3b54-4a23-a32a-c37af4ea8aef)
 
cc @KitsuneRal to make sure I got it right this time.







<!-- Replace -->
Preview: https://pr1559--matrix-spec-previews.netlify.app
<!-- Replace -->
