### PR TITLE
Fix level of examples in server keys definition

### DIFF
--- a/changelogs/server_server/newsfragments/1560.clarification
+++ b/changelogs/server_server/newsfragments/1560.clarification
@@ -1,0 +1,1 @@
+Fix level of examples in server keys definition.

--- a/data/api/server-server/definitions/keys.yaml
+++ b/data/api/server-server/definitions/keys.yaml
@@ -33,17 +33,17 @@ properties:
     additionalProperties:
       type: object
       title: Verify Key
-      example: {
-        "ed25519:abc123": {
-          "key": "VGhpcyBzaG91bGQgYmUgYSByZWFsIGVkMjU1MTkgcGF5bG9hZA"
-        }
-      }
       properties:
         key:
           type: string
           description: The [Unpadded base64](/appendices/#unpadded-base64) encoded key.
           example: "VGhpcyBzaG91bGQgYmUgYSByZWFsIGVkMjU1MTkgcGF5bG9hZA"
       required: ["key"]
+    example: {
+      "ed25519:abc123": {
+        "key": "VGhpcyBzaG91bGQgYmUgYSByZWFsIGVkMjU1MTkgcGF5bG9hZA"
+      }
+    }
   old_verify_keys:
     type: object
     description: |-
@@ -56,12 +56,6 @@ properties:
     additionalProperties:
       type: object
       title: Old Verify Key
-      example: {
-        "ed25519:0ldK3y": {
-          "expired_ts": 1532645052628,
-          "key": "VGhpcyBzaG91bGQgYmUgeW91ciBvbGQga2V5J3MgZWQyNTUxOSBwYXlsb2FkLg"
-        }
-      }
       properties:
         expired_ts:
           type: integer
@@ -73,6 +67,12 @@ properties:
           description: The [Unpadded base64](/appendices/#unpadded-base64) encoded key.
           example: "VGhpcyBzaG91bGQgYmUgeW91ciBvbGQga2V5J3MgZWQyNTUxOSBwYXlsb2FkLg"
       required: ["expired_ts", "key"]
+    example: {
+      "ed25519:0ldK3y": {
+        "expired_ts": 1532645052628,
+        "key": "VGhpcyBzaG91bGQgYmUgeW91ciBvbGQga2V5J3MgZWQyNTUxOSBwYXlsb2FkLg"
+      }
+    }
   signatures:
     type: object
     description: |-


### PR DESCRIPTION
Although the examples are for the entire object, they were set on the object under `additionalProperties`.

Signed-off-by: Kévin Commaille <zecakeh@tedomum.fr>




<!-- Replace -->
Preview: https://pr1560--matrix-spec-previews.netlify.app
<!-- Replace -->
