### PR TITLE
Use tag name as the OpenAPI definition version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,18 +93,26 @@ jobs:
           pip install -r scripts/requirements.txt
       - name: "📦 Asset creation"
         run: |
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            export RELEASE="${GITHUB_REF/refs\/tags\//}"
+          else
+            export RELEASE="unstable"
+          fi
           # The output path matches the final deployment path at spec.matrix.org
           scripts/dump-swagger.py \
             --base-url "https://spec.matrix.org${{ needs.calculate-baseurl.outputs.baseURL }}" \
             --api application-service \
+            -r "$RELEASE" \
             -o spec/application-service-api/api.json
           scripts/dump-swagger.py \
             --base-url "https://spec.matrix.org${{ needs.calculate-baseurl.outputs.baseURL }}" \
             --api client-server \
+            -r "$RELEASE" \
             -o spec/client-server-api/api.json
           scripts/dump-swagger.py \
             --base-url "https://spec.matrix.org${{ needs.calculate-baseurl.outputs.baseURL }}" \
             --api push-gateway \
+            -r "$RELEASE" \
             -o spec/push-gateway-api/api.json
           tar -czf openapi.tar.gz spec
       - name: "📤 Artifact upload"

--- a/changelogs/internal/newsfragments/1561.clarification
+++ b/changelogs/internal/newsfragments/1561.clarification
@@ -1,0 +1,1 @@
+Use tag name as the OpenAPI definition version.


### PR DESCRIPTION
I wanted to fix the spec version displayed in the [Matrix API Viewer](https://matrix.org/docs/api/#overview), which is set to "unstable" although I'm pretty sure it is only deployed for releases.

However I'm not sure how the OpenAPI definitions are deployed. My guess is that they use the artifact from the job triggered by tagging the release so this changes the CI script to use the tag name as the version, when it is available.

It might not fix what I want but at least it's not wrong :slightly_smiling_face:.




<!-- Replace -->
Preview: https://pr1561--matrix-spec-previews.netlify.app
<!-- Replace -->
