### PR TITLE
Allow `null` in `room_types` for `POST /publicRooms` endpoints

### DIFF
--- a/changelogs/client_server/newsfragments/1564.clarification
+++ b/changelogs/client_server/newsfragments/1564.clarification
@@ -1,0 +1,1 @@
+Allow `null` in `room_types` in `POST /publicRooms` endpoints schemas.

--- a/changelogs/server_server/newsfragments/1564.clarification
+++ b/changelogs/server_server/newsfragments/1564.clarification
@@ -1,0 +1,1 @@
+Allow `null` in `room_types` in `POST /publicRooms` endpoints schemas.

--- a/data/api/client-server/list_public_rooms.yaml
+++ b/data/api/client-server/list_public_rooms.yaml
@@ -214,7 +214,7 @@ paths:
                       type: array
                       x-addedInMatrixVersion: "1.4"
                       items:
-                        type: string
+                        type: ["string", "null"]
                       description: |-
                         An optional list of [room types](/client-server-api/#types) to search
                         for. To include rooms without a room type, specify `null` within this

--- a/data/api/server-server/public_rooms.yaml
+++ b/data/api/server-server/public_rooms.yaml
@@ -107,7 +107,7 @@ paths:
                       type: array
                       x-addedInMatrixVersion: "1.4"
                       items:
-                        type: string
+                        type: ["string", "null"]
                       description: |-
                         An optional list of [room types](/client-server-api/#types) to search
                         for. To include rooms without a room type, specify `null` within this

--- a/layouts/partials/openapi/render-object-table.html
+++ b/layouts/partials/openapi/render-object-table.html
@@ -102,8 +102,21 @@
             internal structure, handle this with a bit of recursion
         */}}
         {{ $type = delimit (slice "{string: " (partial "type-or-title" .additionalProperties) "}" ) "" }}
-    {{ else if and .oneOf (reflect.IsSlice .oneOf) }}
+    {{ else if reflect.IsSlice .type }}
         {{/* It's legal to specify an array of types. Join them together in that case */}}
+
+        {{ $types := slice }}
+
+        {{ range .type }}
+            {{ $types = $types | append . }}
+        {{ end }}
+
+        {{ $type = delimit $types "|" }}
+    {{ else if and .oneOf (reflect.IsSlice .oneOf) }}
+        {{/*
+            This is like an array of types except some of the types probably have a schema.
+            Join them together too.
+        */}}
 
         {{ $types := slice }}
 


### PR DESCRIPTION
Also fixes rendering of `type` as an array.

Note that this will probably conflict with #1559, as it edits a similar area of `partials/openapi/render-object-table.html`.

<!-- Replace -->
Preview: https://pr1564--matrix-spec-previews.netlify.app
<!-- Replace -->
