### PR TITLE
Remove unnecessary `oneOf`s in JSON schemas

### DIFF
--- a/changelogs/client_server/newsfragments/1585.clarification
+++ b/changelogs/client_server/newsfragments/1585.clarification
@@ -1,0 +1,1 @@
+Remove unnecessary `oneOf`s in JSON schemas.

--- a/data/api/client-server/definitions/push_rule.yaml
+++ b/data/api/client-server/definitions/push_rule.yaml
@@ -17,9 +17,7 @@ type: object
 properties:
   actions:
     items:
-      oneOf:
-      - type: object
-      - type: string
+      type: ["string", "object"]
     type: array
     description: |-
       The actions to perform when this rule is matched.

--- a/data/api/client-server/notifications.yaml
+++ b/data/api/client-server/notifications.yaml
@@ -86,9 +86,7 @@ paths:
                             The action(s) to perform when the conditions for this rule are met.
                             See [Push Rules: API](/client-server-api/#push-rules-api).
                           items:
-                            oneOf:
-                              - type: object
-                              - type: string
+                            type: ["object", "string"]
                         event:
                           title: Event
                           description: The Event object for the event that triggered the notification.

--- a/data/api/client-server/pushrules.yaml
+++ b/data/api/client-server/pushrules.yaml
@@ -458,9 +458,7 @@ paths:
                   type: array
                   description: The action(s) to perform when the conditions for this rule are met.
                   items:
-                    oneOf:
-                      - type: string
-                      - type: object
+                    type: ["string", "object"]
                 conditions:
                   type: array
                   description: |-
@@ -723,9 +721,7 @@ paths:
                     type: array
                     description: The action(s) to perform for this rule.
                     items:
-                      oneOf:
-                        - type: string
-                        - type: object
+                      type: ["string", "object"]
                 required:
                   - actions
               examples:
@@ -801,9 +797,7 @@ paths:
                   type: array
                   description: The action(s) to perform for this rule.
                   items:
-                    oneOf:
-                      - type: string
-                      - type: object
+                    type: ["string", "object"]
               required:
                 - actions
               example: {


### PR DESCRIPTION
`oneOf` is only necessary if there are more fields than the `type`.




<!-- Replace -->
Preview: https://pr1585--matrix-spec-previews.netlify.app
<!-- Replace -->
