### PR TITLE
Readme: Be specific about requiring Hugo 0.113.0 to build the spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ Additionally, the following directories may be of interest:
 Please read [CONTRIBUTING.rst](./CONTRIBUTING.rst) before authoring a change to the spec. Note that spec authoring takes
 place after an MSC has been accepted, not as part of a proposal itself.
 
-1. Install the extended version (often the OS default) of Hugo in version 0.93:
-   <https://github.com/gohugoio/hugo/releases/tag/v0.93.3>
+1. Install the extended version (often the OS default) of Hugo in version 0.113:
+   <https://github.com/gohugoio/hugo/releases/tag/v0.113.0>
    Download the right `hugo_extended_*` for your platform and put it in your file path or the root directory and
    remember to execute it from there.
-   Note that currently the spec won't build in Hugo v0.114+.
+   Note that currently the spec won't build in Hugo v0.114+ (see [#1586](https://github.com/matrix-org/matrix-spec/issues/1586)).
 
    Alternatively, use the Docker image at
    https://hub.docker.com/r/klakegg/hugo/. (The "extended edition" is required

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ place after an MSC has been accepted, not as part of a proposal itself.
 1. Install the extended version (often the OS default) of Hugo in version 0.93:
    <https://github.com/gohugoio/hugo/releases/tag/v0.93.3>
    Download the right `hugo_extended_*` for your platform and put it in your file path or the root directory and
-   remember to execute it from there). Note that currently the spec won't build in newer Hugo versions.
+   remember to execute it from there.
+   Note that currently the spec won't build in Hugo v0.114+.
 
    Alternatively, use the Docker image at
    https://hub.docker.com/r/klakegg/hugo/. (The "extended edition" is required

--- a/README.md
+++ b/README.md
@@ -58,22 +58,23 @@ Additionally, the following directories may be of interest:
 Please read [CONTRIBUTING.rst](./CONTRIBUTING.rst) before authoring a change to the spec. Note that spec authoring takes
 place after an MSC has been accepted, not as part of a proposal itself.
 
-1. Install the extended version (often the OS default) of Hugo:
-   <https://gohugo.io/getting-started/installing>. Note that at least Hugo
-   v0.93.0 is required.
+1. Install the extended version (often the OS default) of Hugo in version 0.93:
+   <https://github.com/gohugoio/hugo/releases/tag/v0.93.3>
+   Download the right `hugo_extended_*` for your platform and put it in your file path or the root directory and
+   remember to execute it from there). Note that currently the spec won't build in newer Hugo versions.
 
    Alternatively, use the Docker image at
    https://hub.docker.com/r/klakegg/hugo/. (The "extended edition" is required
    to process the SCSS.)
-2. Run `npm i` to install the dependencies and fetch the docsy git submodule.
+3. Run `npm i` to install the dependencies and fetch the docsy git submodule.
    Note that this will require NodeJS to be installed.
-3. Run `npm run get-proposals` to seed proposal data. This is merely for populating the content of the "Spec Change Proposals"
+4. Run `npm run get-proposals` to seed proposal data. This is merely for populating the content of the "Spec Change Proposals"
    page and is not required.
-4. Run `hugo serve` (or `docker run --rm -it -v $(pwd):/src -p 1313:1313
+5. Run `hugo serve` (or `docker run --rm -it -v $(pwd):/src -p 1313:1313
    klakegg/hugo:ext serve`) to run a local webserver which builds whenever a file
    change is detected. If watching doesn't appear to be working for you, try
    adding `--disableFastRender` to the commandline.
-5. Edit the specification 🙂
+6. Edit the specification 🙂
 
 We use a highly customized [Docsy](https://www.docsy.dev/) theme for our generated site, which uses Bootstrap and Font
 Awesome. If you're looking at making design-related changes to the spec site, please coordinate with us in

--- a/README.md
+++ b/README.md
@@ -66,15 +66,15 @@ place after an MSC has been accepted, not as part of a proposal itself.
    Alternatively, use the Docker image at
    https://hub.docker.com/r/klakegg/hugo/. (The "extended edition" is required
    to process the SCSS.)
-3. Run `npm i` to install the dependencies and fetch the docsy git submodule.
+2. Run `npm i` to install the dependencies and fetch the docsy git submodule.
    Note that this will require NodeJS to be installed.
-4. Run `npm run get-proposals` to seed proposal data. This is merely for populating the content of the "Spec Change Proposals"
+3. Run `npm run get-proposals` to seed proposal data. This is merely for populating the content of the "Spec Change Proposals"
    page and is not required.
-5. Run `hugo serve` (or `docker run --rm -it -v $(pwd):/src -p 1313:1313
+4. Run `hugo serve` (or `docker run --rm -it -v $(pwd):/src -p 1313:1313
    klakegg/hugo:ext serve`) to run a local webserver which builds whenever a file
    change is detected. If watching doesn't appear to be working for you, try
    adding `--disableFastRender` to the commandline.
-6. Edit the specification 🙂
+5. Edit the specification 🙂
 
 We use a highly customized [Docsy](https://www.docsy.dev/) theme for our generated site, which uses Bootstrap and Font
 Awesome. If you're looking at making design-related changes to the spec site, please coordinate with us in


### PR DESCRIPTION
The GHA workflow is [pinned at 0.93.3](https://github.com/matrix-org/matrix-spec/blob/fbb8a789f605a304e53b79e96b700b7f154aafcd/.github/workflows/main.yml#L150) and the spec won't build in recent versions of Hugo, see #1586.

Until that error is resolved in modern versions, the building instructions should guide contributors to be able to build a working version and not run into errors when trying to build it.

While building the spec in more modern hugo versions than 0.93.3 is possibe (I successfully tested with 0.113, see #1586), the build process with that version is proven through the Github Actions and thus reflects the currently safest path to get the spec built locally (without using docker). There is at least one known issue with newer versions (#1544).

Signed-off-by: `Alex Kirk <akirk@users.noreply.github.com>`

<!-- Replace -->
Preview: https://pr1587--matrix-spec-previews.netlify.app
<!-- Replace -->
