### PR TITLE
Bump hugo version used for the build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -148,7 +148,7 @@ jobs:
       - name: "➕ Setup Hugo"
         uses: peaceiris/actions-hugo@c03b5dbed22245418539b65eb9a3b1d5fdd9a0a6
         with:
-          hugo-version: '0.93.3'
+          hugo-version: '0.113.0'
           extended: true
       - name: "📥 Source checkout"
         uses: actions/checkout@v2

--- a/changelogs/internal/newsfragments/1591.clarification
+++ b/changelogs/internal/newsfragments/1591.clarification
@@ -1,0 +1,1 @@
+Update the version of Hugo used to render the spec to v0.113.0.


### PR DESCRIPTION
Since https://github.com/matrix-org/matrix-spec/issues/1544 is fixed, we can use a modern hugo.

<!-- Replace -->
Preview: https://pr1591--matrix-spec-previews.netlify.app
<!-- Replace -->
