### PR TITLE
Fix rendered changelog with new version of towncrier

### DIFF
--- a/changelogs/internal/newsfragments/1598.clarification
+++ b/changelogs/internal/newsfragments/1598.clarification
@@ -1,0 +1,1 @@
+Fix rendered changelog with new version of towncrier.

--- a/changelogs/pyproject.toml
+++ b/changelogs/pyproject.toml
@@ -1,39 +1,34 @@
 [tool.towncrier]
     version = "unused"
     filename = "../rendered.md"
-    issue_format = "[#{issue}](https://github.com/matrix-org/matrix-spec/issues/{issue})"
-    title_format = "### {name}"  # Matches rendered spec, even if awkward
-    underlines = "   "  # 3 spaces intentionally to hide RST headings
-
-    # Note: The names below have the <strong> tag built-in so the rendered spec *and* the generated
-    # changelog can benefit from sane headings.
+    template = "template.md.jinja"
 
     [[tool.towncrier.type]]
         directory = "breaking"
-        name = "<strong>Breaking Changes</strong>"
+        name = "Breaking Changes"
         showcontent = true
 
     [[tool.towncrier.type]]
         directory = "deprecation"
-        name = "<strong>Deprecations</strong>"
+        name = "Deprecations"
         showcontent = true
 
     [[tool.towncrier.type]]
         directory = "new"
-        name = "<strong>New Endpoints</strong>"
+        name = "New Endpoints"
         showcontent = true
 
     [[tool.towncrier.type]]
         directory = "removal"
-        name = "<strong>Removed Endpoints</strong>"
+        name = "Removed Endpoints"
         showcontent = true
 
     [[tool.towncrier.type]]
         directory = "feature"
-        name = "<strong>Backwards Compatible Changes</strong>"
+        name = "Backwards Compatible Changes"
         showcontent = true
 
     [[tool.towncrier.type]]
         directory = "clarification"
-        name = "<strong>Spec Clarifications</strong>"
+        name = "Spec Clarifications"
         showcontent = true

--- a/changelogs/pyproject.toml
+++ b/changelogs/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.towncrier]
     version = "unused"
-    filename = "../rendered.md"
+    filename = "rendered.md"
     template = "template.md.jinja"
 
     [[tool.towncrier.type]]
@@ -32,3 +32,35 @@
         directory = "clarification"
         name = "Spec Clarifications"
         showcontent = true
+
+    [[tool.towncrier.section]]
+        name = "Client-Server API"
+        path = "client_server"
+
+    [[tool.towncrier.section]]
+        name = "Server-Server API"
+        path = "server_server"
+    
+    [[tool.towncrier.section]]
+        name = "Application Service API"
+        path = "application_service"
+
+    [[tool.towncrier.section]]
+        name = "Identity Service API"
+        path = "identity_service"
+    
+    [[tool.towncrier.section]]
+        name = "Push Gateway API"
+        path = "push_gateway"
+    
+    [[tool.towncrier.section]]
+        name = "Room Versions"
+        path = "room_versions"
+    
+    [[tool.towncrier.section]]
+        name = "Appendices"
+        path = "appendices"
+
+    [[tool.towncrier.section]]
+        name = "Internal Changes/Tooling"
+        path = "internal"

--- a/changelogs/template.md.jinja
+++ b/changelogs/template.md.jinja
@@ -1,0 +1,27 @@
+{% if versiondata.name %}
+### {{ versiondata.name }}
+{% endif %}
+{% for section_name, section in sections.items() %}
+{% if section_name %}
+
+### {{section_name}}
+{% endif %}
+
+{% if section %}
+{% for category, val in definitions.items() if category in section %}
+**{{ definitions[category]['name'] }}**
+
+{% for content, issues in section[category].items() %}
+- {{ content }} (
+{%- for issue in issues %}
+[{{issue}}](https://github.com/matrix-org/matrix-spec/issues/{{issue|trim('#')}}){% if not loop.last %}, {% endif %}
+{%- endfor %}
+)
+{% endfor %}
+
+{% endfor %}
+{% else %}
+No significant changes.
+
+{% endif %}
+{% endfor %}

--- a/changelogs/template.md.jinja
+++ b/changelogs/template.md.jinja
@@ -1,6 +1,3 @@
-{% if versiondata.name %}
-### {{ versiondata.name }}
-{% endif %}
 {% for section_name, section in sections.items() %}
 {% if section_name %}
 

--- a/scripts/generate-changelog.sh
+++ b/scripts/generate-changelog.sh
@@ -13,15 +13,8 @@ cd `dirname $0`/../changelogs
 # Pre-cleanup just in case it wasn't done on the last run
 rm -f rendered.md
 
-# Reversed order so that room versions ends up on the bottom
-towncrier --name "Internal Changes/Tooling" --dir "./internal" --config "./pyproject.toml" --yes
-towncrier --name "Appendices" --dir "./appendices" --config "./pyproject.toml" --yes
-towncrier --name "Room Versions" --dir "./room_versions" --config "./pyproject.toml" --yes
-towncrier --name "Push Gateway API" --dir "./push_gateway" --config "./pyproject.toml" --yes
-towncrier --name "Identity Service API" --dir "./identity_service" --config "./pyproject.toml" --yes
-towncrier --name "Application Service API" --dir "./application_service" --config "./pyproject.toml" --yes
-towncrier --name "Server-Server API" --dir "./server_server" --config "./pyproject.toml" --yes
-towncrier --name "Client-Server API" --dir "./client_server" --config "./pyproject.toml" --yes
+# Generate changelog
+towncrier --yes
 
 {
     # Prepare the header

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -2,7 +2,7 @@
 # current at the time of writing
 
 # we need at least version 4.0.0 for support of JSON Schema Draft 2020-12.
-jsonschema >= 4.0.0
+jsonschema == 4.17.3
 
 PyYAML >= 3.12
 requests >= 2.18.4

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -6,4 +6,4 @@ jsonschema >= 4.0.0
 
 PyYAML >= 3.12
 requests >= 2.18.4
-towncrier == 21.9.0rc1
+towncrier == 23.6.0


### PR DESCRIPTION
The version of towncrier is not pinned in CI so lately the rendering of the changelog is broken in the unstable version (note the changelog categories that are now numbered titles):

![image](https://github.com/matrix-org/matrix-spec/assets/76261501/cd11e185-4dbb-47fc-84bc-63f1f0fd0e96)

This is due to https://github.com/twisted/towncrier/pull/483 that is included in towncrier 23.6.0.

The first commit fixes that by replacing the default template by a custom one. It also allows to put formatting in the template only rather than in the config file.

The second commit allows to simplify the `generate-changelog.sh` script by using the built-in [sections](https://towncrier.readthedocs.io/en/stable/configuration.html#sections) feature of towncrier, instead of generating the changelog for each section separately.

This is the result, which should be the same as before:
![image](https://github.com/matrix-org/matrix-spec/assets/76261501/36cefeed-03fb-4991-988c-558aaed6d8b0)

We could almost get rid of the `header.md` file except we cannot format the release date.

<!-- Replace -->
Preview: https://pr1598--matrix-spec-previews.netlify.app
<!-- Replace -->
