### PR TITLE
Use auto table-layout on desktop

### DIFF
--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -355,7 +355,7 @@ footer {
        * results in annoying horizontal scrolling on mobile, so we instead
        * switch to a fixed table layout on a narrow browser width.
        * (On a wider width the default auto table-layout provides better readability.)
-      *
+       *
        * Docsy makes all tables "responsive tables", which causes Bootstrap 4 to create
        * tables with a "display" property of "block".
        * However, for "table-layout: fixed" to be effective, an element must have a

--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -355,7 +355,7 @@ footer {
        * results in annoying horizontal scrolling on mobile, so we instead
        * switch to a fixed table layout on a narrow browser width.
        * (On a wider width the default auto table-layout provides better readability.)
-
+      *
        * Docsy makes all tables "responsive tables", which causes Bootstrap 4 to create
        * tables with a "display" property of "block".
        * However, for "table-layout: fixed" to be effective, an element must have a

--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -350,19 +350,37 @@ footer {
   }
 
   table {
-    /* Docsy makes all tables "responsive tables", which causes Bootstrap 4 to create
-     * tables with a "display" property of "block".
-     *
-     * However, for "table-layout: fixed" to be effective, an element must have a
-     * "display" property of "table".
-     *
-     * Thus, we override the "display" property here. This may no longer be necessary once
-     * Docsy updates to Bootstrap v5+: https://github.com/google/docsy/issues/470.
-     * For more details, see
-     * https://github.com/matrix-org/matrix-spec/pull/1295/files#r1010759688 */
-    display: table;
-    table-layout: fixed;
-    width: 100%;
+    @media (max-width: 800px) {
+      /* Docsy by default applies `overflow-x: auto;` to tables, which
+       * results in annoying horizontal scrolling on mobile, so we instead
+       * switch to a fixed table layout on a narrow browser width.
+       * (On a wider width the default auto table-layout provides better readability.)
+
+       * Docsy makes all tables "responsive tables", which causes Bootstrap 4 to create
+       * tables with a "display" property of "block".
+       * However, for "table-layout: fixed" to be effective, an element must have a
+       * "display" property of "table".
+       *
+       * Thus, we override the "display" property here. This may no longer be necessary once
+       * Docsy updates to Bootstrap v5+: https://github.com/google/docsy/issues/470.
+       * For more details, see
+       * https://github.com/matrix-org/matrix-spec/pull/1295/files#r1010759688 */
+      display: table;
+      table-layout: fixed;
+      width: 100%;
+
+      .col-name, .col-type, .col-status {
+        width: 25%;
+      }
+
+      .col-description {
+        width: 50%;
+      }
+
+      .col-status-description {
+        width: 75%;
+      }
+    }
 
     // add some space between two tables when they are right next to each other
     & + table {
@@ -409,19 +427,6 @@ footer {
     &.basic-info th {
       width: 15rem;
     }
-
-    .col-name, .col-type, .col-status {
-      width: 25%;
-    }
-
-    .col-description {
-      width: 50%;
-    }
-
-    .col-status-description {
-      width: 75%;
-    }
-
   }
 
   pre {

--- a/changelogs/internal/newsfragments/1601.clarification
+++ b/changelogs/internal/newsfragments/1601.clarification
@@ -1,0 +1,1 @@
+Improve the layout of tables on desktop.

--- a/changelogs/internal/newsfragments/1601.clarification
+++ b/changelogs/internal/newsfragments/1601.clarification
@@ -1,1 +1,1 @@
-Improve the layout of tables on desktop.
+Improve the layout of tables on desktop displays. Contributed by @not-my-profile.


### PR DESCRIPTION
On desktop the tables in the specification currently have quite awkward column widths, making them harder to read.

| Before | After |
|--|--|
|![image](https://github.com/matrix-org/matrix-spec/assets/73739153/36dff389-98a7-4192-af24-05561fe71003) | ![image](https://github.com/matrix-org/matrix-spec/assets/73739153/cc01aff7-5910-4a5a-8b05-4a2a34278feb)

While the fixed table-layout does have an advantage on mobile since it avoids unnecessary horizontal scrolling in the tables, we can just use it on narrow browser widths via a media query, while still using the more readable auto layout on desktop.







<!-- Replace -->
Preview: https://pr1601--matrix-spec-previews.netlify.app
<!-- Replace -->
