### PR TITLE
Clarify that `via` is required for `m.space.parent` and `m.space.child` as per MSC1772.

### DIFF
--- a/changelogs/client_server/newsfragments/1618.clarification
+++ b/changelogs/client_server/newsfragments/1618.clarification
@@ -1,0 +1,1 @@
+Clarify that `via` property is required for `m.space.parent` and `m.space.child` as per MSC1772. Contributed by @PaarthShah

--- a/changelogs/client_server/newsfragments/1618.clarification
+++ b/changelogs/client_server/newsfragments/1618.clarification
@@ -1,1 +1,1 @@
-Clarify that `via` property is required for `m.space.parent` and `m.space.child` as per MSC1772. Contributed by @PaarthShah
+Clarify that the `via` property is required for `m.space.parent` and `m.space.child` as per MSC1772. Contributed by @PaarthShah.

--- a/data/event-schemas/schema/m.space.child.yaml
+++ b/data/event-schemas/schema/m.space.child.yaml
@@ -9,6 +9,8 @@ properties:
         type: array
         description: |-
           A list of servers to try and join through. See also: [Routing](/appendices/#routing).
+
+          When not present or invalid, the child room is not considered to be part of the space.
         items:
           type: string
       order:

--- a/data/event-schemas/schema/m.space.child.yaml
+++ b/data/event-schemas/schema/m.space.child.yaml
@@ -9,8 +9,6 @@ properties:
         type: array
         description: |-
           A list of servers to try and join through. See also: [Routing](/appendices/#routing).
-
-          When not present or invalid, the child room is not considered to be part of the space.
         items:
           type: string
       order:
@@ -34,6 +32,8 @@ properties:
           Optional (default `false`) flag to denote whether the child is "suggested" or of interest
           to members of the space. This is primarily intended as a rendering hint for clients to
           display the room differently, such as eagerly rendering them in the room list.
+    required:
+      - via
     type: object
   state_key:
     description: The child room ID being described.

--- a/data/event-schemas/schema/m.space.parent.yaml
+++ b/data/event-schemas/schema/m.space.parent.yaml
@@ -9,8 +9,6 @@ properties:
         type: array
         description: |-
           A list of servers to try and join through. See also: [Routing](/appendices/#routing).
-
-          When not present or invalid, the room is not considered to be part of the parent space.
         items:
           type: string
       canonical:
@@ -20,6 +18,8 @@ properties:
 
           When multiple `canonical` parents are found, the lowest parent when ordering by room ID
           lexicographically by Unicode code-points should be used.
+    required:
+      - via
     type: object
   state_key:
     description: The parent room ID.

--- a/data/event-schemas/schema/m.space.parent.yaml
+++ b/data/event-schemas/schema/m.space.parent.yaml
@@ -9,6 +9,8 @@ properties:
         type: array
         description: |-
           A list of servers to try and join through. See also: [Routing](/appendices/#routing).
+
+          When not present or invalid, the room is not considered to be part of the parent space.
         items:
           type: string
       canonical:


### PR DESCRIPTION
Per [MSC1772](https://github.com/matrix-org/matrix-spec-proposals/blob/6a3ab1d64cdf9f429a86b0e9d4df927dd36f0280/proposals/1772-groups-as-rooms.md) (emphasis mine):

- `m.space.child`
> The admins of a space can advertise rooms and subspaces for their space by setting m.space.child state events. The state_key is the ID of a child room or space, and the content **_must_** contain a via key which gives a list of candidate servers that can be used to join the room.

- `m.space.parent`
> Similar to m.space.child, the state_key is the ID of the parent space, and the content **_must_** contain a via key which gives a list of candidate servers that can be used to join the parent.

I was made aware of this by [this issue](https://github.com/poljar/matrix-nio/issues/433).







<!-- Replace -->
Preview: https://pr1618--matrix-spec-previews.netlify.app
<!-- Replace -->
