### PR TITLE
strike element is deprecated, s replaces it

### DIFF
--- a/changelogs/client_server/newsfragments/1629.clarification
+++ b/changelogs/client_server/newsfragments/1629.clarification
@@ -1,0 +1,1 @@
+The [strike](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/strike) element is deprecated in the HTML spec. Clients should prefer [s](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/s) instead.

--- a/content/client-server-api/modules/instant_messaging.md
+++ b/content/client-server-api/modules/instant_messaging.md
@@ -37,7 +37,7 @@ HTML injection, and similar attacks. The strongly suggested set of HTML
 tags to permit, denying the use and rendering of anything else, is:
 `font`, `del`, `h1`, `h2`, `h3`, `h4`, `h5`, `h6`, `blockquote`, `p`,
 `a`, `ul`, `ol`, `sup`, `sub`, `li`, `b`, `i`, `u`, `strong`, `em`,
-`strike`, `code`, `hr`, `br`, `div`, `table`, `thead`, `tbody`, `tr`,
+`s`, `code`, `hr`, `br`, `div`, `table`, `thead`, `tbody`, `tr`,
 `th`, `td`, `caption`, `pre`, `span`, `img`, `details`, `summary`.
 
 Not all attributes on those tags should be permitted as they may be


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)

### Description

The [strike](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/strike) element is deprecated in the HTML spec. Clients should prefer [s](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/s) instead if they wish to mark text with strikethrough without semantic meaning.

As far as I am aware, no client actually supports sending messages with strikethrough formatting, so this shouldn't affect current compatibility.

I hope I filled out this PR template correctly :)

Signed-off-by: Cadence Ember <cadence@disroot.org>

<!-- Replace -->
Preview: https://pr1629--matrix-spec-previews.netlify.app
<!-- Replace -->
