### PR TITLE
Fix schema of `m.mentions` object

### DIFF
--- a/changelogs/internal/newsfragments/1635.clarification
+++ b/changelogs/internal/newsfragments/1635.clarification
@@ -1,0 +1,1 @@
+Fix schema of `m.mentions` object.

--- a/content/client-server-api/modules/mentions.md
+++ b/content/client-server-api/modules/mentions.md
@@ -13,6 +13,20 @@ the event to reference the entity being mentioned.
 
 {{% definition path="api/client-server/definitions/m.mentions" %}}
 
+An event's content will then look like this:
+
+```json
+{
+    "body": "Hello Alice!",
+    "msgtype": "m.text",
+    "format": "org.matrix.custom.html",
+    "formatted_body": "Hello <a href='https://matrix.to/#/@alice:example.org'>Alice</a>!",
+    "m.mentions": {
+        "user_ids": ["@alice:example.org"]
+    }
+}
+```
+
 Additionally, see the [`.m.rule.is_user_mention`](#_m_rule_is_user_mention) and
 [`.m.rule.is_room_mention`](#_m_rule_is_room_mention) push rules.
 Users should not add their own Matrix ID to the `m.mentions` property as outgoing

--- a/data/api/client-server/definitions/m.mentions.yaml
+++ b/data/api/client-server/definitions/m.mentions.yaml
@@ -28,7 +28,9 @@ example: {
 }
 properties:
   user_ids:
-    type: string[]
+    type: array
+    items:
+      type: string
     description: A list of Matrix IDs of mentioned users.
   room:
     type: boolean

--- a/data/api/client-server/definitions/m.mentions.yaml
+++ b/data/api/client-server/definitions/m.mentions.yaml
@@ -18,13 +18,7 @@ description: |-
   Describes whether the event mentions other users or the room. This is contained
   within the event's `content` alongside other fields for the relevant event type.
 example: {
-    "body": "Hello Alice!",
-    "msgtype": "m.text",
-    "format": "org.matrix.custom.html",
-    "formatted_body": "Hello <a href='https://matrix.to/#/@alice:example.org'>Alice</a>!",
-    "m.mentions": {
-        "user_ids": ["@alice:example.org"]
-    }
+    "user_ids": ["@alice:example.org"]
 }
 properties:
   user_ids:


### PR DESCRIPTION
That was not how a string of arrays is declared. Also the example was for a full event, instead of just the `m.mentions` object.







<!-- Replace -->
Preview: https://pr1635--matrix-spec-previews.netlify.app
<!-- Replace -->
