### PR TITLE
add "case sensitive" to `/publicRooms`

### DIFF
--- a/changelogs/client_server/newsfragments/1638.feature
+++ b/changelogs/client_server/newsfragments/1638.feature
@@ -1,1 +1,1 @@
-Adds "case sensitive" to the /publicRooms 
+Add a note to the `/publicRooms` API that the server name is case sensitive. 

--- a/changelogs/client_server/newsfragments/1638.feature
+++ b/changelogs/client_server/newsfragments/1638.feature
@@ -1,0 +1,1 @@
+Adds "case sensitive" to the /publicRooms 

--- a/data/api/client-server/list_public_rooms.yaml
+++ b/data/api/client-server/list_public_rooms.yaml
@@ -154,7 +154,7 @@ paths:
           name: server
           description: |-
             The server to fetch the public room lists from. Defaults to the
-            local server.
+            local server. Case sensitive.
           schema:
             type: string
       responses:
@@ -181,7 +181,7 @@ paths:
           name: server
           description: |-
             The server to fetch the public room lists from. Defaults to the
-            local server.
+            local server. Case sensitive.
           schema:
             type: string
       requestBody:


### PR DESCRIPTION
Fixes #1619 

This PR add the "case sensitive" to the server specs of /publicRooms so that client should lowercase it before sending.

<img width="398" alt="Screenshot 2023-09-14 233219" src="https://github.com/matrix-org/matrix-spec/assets/85980940/889b8d0a-dd50-4855-88c1-94d73ffb18a6">





<!-- Replace -->
Preview: https://pr1638--matrix-spec-previews.netlify.app
<!-- Replace -->
