### PR TITLE
Clarify that an `m.room.name` event with an absent `name` field is not expected behavior

### DIFF
--- a/changelogs/client_server/newsfragments/1639.clarification
+++ b/changelogs/client_server/newsfragments/1639.clarification
@@ -1,0 +1,1 @@
+Clarify that an `m.room.name` event with an absent `name` field is not expected behavior.

--- a/data/event-schemas/schema/m.room.name.yaml
+++ b/data/event-schemas/schema/m.room.name.yaml
@@ -7,9 +7,8 @@ description: |-
     is a human-friendly string designed to be displayed to the end-user. The
     room name is not unique, as multiple rooms can have the same room name set.
 
-    A room with an `m.room.name` event with an absent, null, or empty
-    `name` field should be treated the same as a room with no `m.room.name`
-    event.
+    If a room has an `m.room.name` event with an absent, null, or empty `name`
+    field, it should be treated the same as a room with no `m.room.name` event.
 
     An event of this type is automatically created when creating a room using
     `/createRoom` with the `name` key.


### PR DESCRIPTION
Fixes #1632

For me the "if" makes a lot of difference in understanding that the paragraph does not mean that it should be the expected behavior.




<!-- Replace -->
Preview: https://pr1639--matrix-spec-previews.netlify.app
<!-- Replace -->
