### PR TITLE
Note that /logout doesn't take a body

### DIFF
--- a/changelogs/client_server/newsfragments/1644.clarification
+++ b/changelogs/client_server/newsfragments/1644.clarification
@@ -1,0 +1,1 @@
+Clarify specification by adding `/logout` to the overview list of endpoints that don't take a request body.

--- a/changelogs/client_server/newsfragments/1644.clarification
+++ b/changelogs/client_server/newsfragments/1644.clarification
@@ -1,1 +1,1 @@
-Clarify specification by adding `/logout` to the overview list of endpoints that don't take a request body.
+Clarify specification by adding `/logout` to the overview list of endpoints that don't take a JSON request body.

--- a/content/client-server-api/_index.md
+++ b/content/client-server-api/_index.md
@@ -29,12 +29,12 @@ JSON object.  Clients should supply a `Content-Type` header of
 
 The exceptions are:
 
-- [`POST /_matrix/media/v3/upload`](#post_matrixmediav3upload),
-  which takes any type of request body depending on what type of media is to be uploaded.
-- [`PUT /_matrix/media/v3/upload/{serverName}/{mediaId}`](#put_matrixmediav3uploadservernamemediaid),
-  which takes any type of request body depending on what type of media is to be uploaded.
-- [`POST /_matrix/client/v3/logout`](#post_matrixclientv3logout),
-  which does not take any request body.
+- [`POST /_matrix/media/v3/upload`](#post_matrixmediav3upload) and 
+  [`PUT /_matrix/media/v3/upload/{serverName}/{mediaId}`](#put_matrixmediav3uploadservernamemediaid),
+  both of which take the uploaded media as the request body.
+- [`POST /_matrix/client/v3/logout`](#post_matrixclientv3logout) and
+  [`POST /_matrix/client/v3/logout/all`](#post_matrixclientv3logoutall),
+  which take an empty request body.
 
 Similarly, all endpoints require the server to return a JSON object,
 with the exception of 200 responses to

--- a/content/client-server-api/_index.md
+++ b/content/client-server-api/_index.md
@@ -22,13 +22,19 @@ recommended outside test environments.
 Clients are authenticated using opaque `access_token` strings (see [Client
 Authentication](#client-authentication) for details).
 
-All `POST` and `PUT` endpoints, with the exception of [`POST
-/_matrix/media/v3/upload`](#post_matrixmediav3upload), [`PUT
-/_matrix/media/v3/upload/{serverName}/{mediaId}`](#put_matrixmediav3uploadservernamemediaid)
-and [`POST /_matrix/client/v3/logout`](#post_matrixclientv3logout),
+All `POST` and `PUT` endpoints, with the exception of those listed below,
 require the client to supply a request body containing a (potentially empty)
 JSON object.  Clients should supply a `Content-Type` header of
 `application/json` for all requests with JSON bodies, but this is not required.
+
+The exceptions are:
+
+- [`POST /_matrix/media/v3/upload`](#post_matrixmediav3upload),
+  which takes any type of request body depending on what type of media is to be uploaded.
+- [`PUT /_matrix/media/v3/upload/{serverName}/{mediaId}`](#put_matrixmediav3uploadservernamemediaid),
+  which takes any type of request body depending on what type of media is to be uploaded.
+- [`POST /_matrix/client/v3/logout`](#post_matrixclientv3logout),
+  which does not take any request body.
 
 Similarly, all endpoints require the server to return a JSON object,
 with the exception of 200 responses to

--- a/content/client-server-api/_index.md
+++ b/content/client-server-api/_index.md
@@ -23,8 +23,9 @@ Clients are authenticated using opaque `access_token` strings (see [Client
 Authentication](#client-authentication) for details).
 
 All `POST` and `PUT` endpoints, with the exception of [`POST
-/_matrix/media/v3/upload`](#post_matrixmediav3upload) and [`PUT
-/_matrix/media/v3/upload/{serverName}/{mediaId}`](#put_matrixmediav3uploadservernamemediaid),
+/_matrix/media/v3/upload`](#post_matrixmediav3upload), [`PUT
+/_matrix/media/v3/upload/{serverName}/{mediaId}`](#put_matrixmediav3uploadservernamemediaid)
+and [`POST /_matrix/client/v3/logout`](#post_matrixclientv3logout),
 require the client to supply a request body containing a (potentially empty)
 JSON object.  Clients should supply a `Content-Type` header of
 `application/json` for all requests with JSON bodies, but this is not required.


### PR DESCRIPTION
`/logout` says it does not take a request body[^1], so add it to the list of exceptions at the top.

I note that Complement does not send a request body for this endpoint, so that must mean Synapse and Dendrite allow that.

[^1]: https://spec.matrix.org/v1.8/client-server-api/#post_matrixclientv3logout










<!-- Replace -->
Preview: https://pr1644--matrix-spec-previews.netlify.app
<!-- Replace -->
