### PR TITLE
Remove required 'fieldname' in Protocol definition

### DIFF
--- a/changelogs/application_service/newsfragments/1646.clarification
+++ b/changelogs/application_service/newsfragments/1646.clarification
@@ -1,0 +1,1 @@
+Remove required `fieldname` in Protocol definition.

--- a/data/api/application-service/definitions/protocol.yaml
+++ b/data/api/application-service/definitions/protocol.yaml
@@ -64,7 +64,6 @@ properties:
           description: An placeholder serving as a valid example of the field value.
           type: string
       required: ['regexp', 'placeholder']
-    required: ['fieldname']
     example: {
       "network": {
         "regexp": "([a-z0-9]+\\.)*[a-z0-9]+",


### PR DESCRIPTION
This field does not exist and makes example validation fail. It does not change anything in the rendered spec.

My guess is that it was trying to mean that for every field in `user_fields` and `location_fields`, there should be an entry in `field_types`. It might be interesting to see if it is possible to define that using JSON schema.




<!-- Replace -->
Preview: https://pr1646--matrix-spec-previews.netlify.app
<!-- Replace -->
