### PR TITLE
Fix schemas used for account data and presence events in `GET /initialSync`

### DIFF
--- a/changelogs/client_server/newsfragments/1647.clarification
+++ b/changelogs/client_server/newsfragments/1647.clarification
@@ -1,0 +1,1 @@
+Fix schemas used for account data and presence events in `GET /initialSync`.

--- a/data/api/client-server/old_sync.yaml
+++ b/data/api/client-server/old_sync.yaml
@@ -137,7 +137,7 @@ paths:
                     type: array
                     description: A list of presence events.
                     items:
-                      $ref: definitions/client_event.yaml
+                      $ref: ../../event-schemas/schema/core-event-schema/event.yaml
                   rooms:
                     type: array
                     items:
@@ -219,7 +219,7 @@ paths:
                             The private data that this user has attached to
                             this room.
                           items:
-                            $ref: definitions/client_event.yaml
+                            $ref: ../../event-schemas/schema/core-event-schema/event.yaml
                       required:
                         - room_id
                         - membership
@@ -227,10 +227,7 @@ paths:
                     type: array
                     description: The global private data created by this user.
                     items:
-                      title: Event
-                      type: object
-                      allOf:
-                        - $ref: ../../event-schemas/schema/core-event-schema/event.yaml
+                      $ref: ../../event-schemas/schema/core-event-schema/event.yaml
                 required:
                   - end
                   - rooms


### PR DESCRIPTION
Otherwise the example will fail to validate against the schema.

These schemas are chosen because these events don't have an event ID.


<!-- Replace -->
Preview: https://pr1647--matrix-spec-previews.netlify.app
<!-- Replace -->
