### PR TITLE
Federation requests must be for local users.

### DIFF
--- a/data/api/server-server/query.yaml
+++ b/data/api/server-server/query.yaml
@@ -121,7 +121,7 @@ paths:
       parameters:
         - in: query
           name: user_id
-          description: The user ID to query.
+          description: The user ID to query. Must be a user local to the receiving homeserver.
           required: true
           example: "@someone:example.org"
           schema:

--- a/data/api/server-server/user_keys.yaml
+++ b/data/api/server-server/user_keys.yaml
@@ -34,7 +34,8 @@ paths:
                   type: object
                   description: |-
                     The keys to be claimed. A map from user ID, to a map from
-                    device ID to algorithm name.
+                    device ID to algorithm name. Requested users must be local
+                    to the receiving homeserver.
                   additionalProperties:
                     type: object
                     additionalProperties:
@@ -121,7 +122,8 @@ paths:
                   description: |-
                     The keys to be downloaded. A map from user ID, to a list of
                     device IDs, or to an empty list to indicate all devices for the
-                    corresponding user.
+                    corresponding user.  Requested users must be local to the
+                    receiving homeserver.
                   additionalProperties:
                     type: array
                     items:


### PR DESCRIPTION
This is already mentioned for [`/user/devices`](https://spec.matrix.org/v1.8/server-server-api/#get_matrixfederationv1userdevicesuserid), but is not mentioned for [`/query/profile`](https://spec.matrix.org/v1.8/server-server-api/#get_matrixfederationv1queryprofile), [`/user/keys/claim`](https://spec.matrix.org/v1.8/server-server-api/#post_matrixfederationv1userkeysclaim), or [`/user/keys/query`](https://spec.matrix.org/v1.8/server-server-api/#post_matrixfederationv1userkeysquery).

See https://github.com/matrix-org/synapse/security/advisories/GHSA-mp92-3jfm-3575 for an issue found with this in Synapse.

@turt2live suggested this be a spec clarification as opposed to an MSC. I didn't spec *what* a homeserver should do in this case, although it is my opinion that the invalid requests should be rejected outright.