### PR TITLE
Make clear the thread root is not in the thread

### DIFF
--- a/changelogs/client_server/newsfragments/1677.clarification
+++ b/changelogs/client_server/newsfragments/1677.clarification
@@ -1,0 +1,1 @@
+Clarify that thread roots are not considered within the thread.

--- a/content/client-server-api/modules/push.md
+++ b/content/client-server-api/modules/push.md
@@ -1070,16 +1070,16 @@ ahead), however if the `m.read.private` receipt were to be updated to
 event D then the user has read up to D (the `m.read` receipt is now
 behind the `m.read.private` receipt).
 
-{{< added-in v="1.4" >}} When handling threaded read receipts, the server
-is to partition the notification count to each thread (with the main timeline
-being its own thread). To determine if an event is part of a thread the
-server follows the [event relationship](#forming-relationships-between-events)
-until it finds a thread root (as specified by the [threading module](#threading)),
-however it is not recommended that the server traverse infinitely. Instead,
-implementations are encouraged to do a maximum of 3 hops to find a thread
-before deciding that the event does not belong to a thread. This is primarily
-to ensure that future events, like `m.reaction`, are correctly considered
-"part of" a given thread.
+{{< added-in v="1.4" >}} When handling threaded read receipts, the server is to
+partition the notification count to each thread (with the main timeline being
+its own thread). To determine if an event is part of a thread the server follows
+the [event relationship](#forming-relationships-between-events) until it finds a
+thread root via an `m.thread` relation (as specified by the [threading
+module](#threading)), however it is not recommended that the server traverse
+infinitely. Instead, implementations are encouraged to do a maximum of 3 hops to
+find a thread before deciding that the event does not belong to a thread. This
+is primarily to ensure that future events, like `m.reaction`, are correctly
+considered "part of" a given thread.
 
 #### Server behaviour
 

--- a/content/client-server-api/modules/receipts.md
+++ b/content/client-server-api/modules/receipts.md
@@ -137,16 +137,22 @@ either a thread root's event ID or `main` for the main timeline.
 
 Threading introduces a concept of multiple conversations being held in the same
 room and thus deserve their own read receipts and notification counts. An event is
-considered to be "in a thread" if it meets any of the following criteria:
-* It has a `rel_type` of `m.thread`.
-* It has child events with a `rel_type` of `m.thread` (in which case it'd be the
-  thread root).
-* Following the event relationships, it has a parent event which qualifies for
-  one of the above. Implementations should not recurse infinitely, though: a
-  maximum of 3 hops is recommended to cover indirect relationships.
+considered to be "in a thread" if:
 
-Events not in a thread but still in the room are considered to be part of the
-"main timeline", or a special thread with an ID of `main`.
+* It has a rel_type of m.thread, or
+* It has a parent event with this rel_type, or a parent of a parent, or further
+  up the chain of relations. (Implementations should not recurse to arbitrary
+  depth: a maximum of 3 hops is recommended to cover indirect relationships.)
+
+Events not in a thread but still in the room are considered to be in the "main
+timeline". Threaded receipts for the main timeine use a special thread ID of
+`main`.
+
+Thread roots are considered to be in the main timeline, as are events that are
+related to a thread root via non-thread relations. Note that clients providing a
+single-thread view will probably want to include thread roots and some of their
+child events (e.g. reactions) in that view, even though from a receipt point of
+view they are not part of that thread.
 
 The following is an example DAG for a room, with dotted lines showing event
 relationships and solid lines showing topological ordering.

--- a/content/client-server-api/modules/receipts.md
+++ b/content/client-server-api/modules/receipts.md
@@ -150,10 +150,7 @@ timeline". When referring to the main timeline as a thread (e.g. in receipts
 and notifications counts) a special thread ID of `main` is used.
 
 Thread roots are considered to be in the main timeline, as are events that are
-related to a thread root via non-thread relations. Note that clients providing a
-single-thread view will probably want to include thread roots and some of their
-child events (e.g. reactions) in that view, even though from a receipt point of
-view they are not part of that thread.
+related to a thread root via non-thread relations.
 
 The following is an example DAG for a room, with dotted lines showing event
 relationships and solid lines showing topological ordering.

--- a/content/client-server-api/modules/receipts.md
+++ b/content/client-server-api/modules/receipts.md
@@ -145,8 +145,8 @@ considered to be "in a thread" if:
   depth: a maximum of 3 hops is recommended to cover indirect relationships.)
 
 Events not in a thread but still in the room are considered to be in the "main
-timeline". Threaded receipts for the main timeline use a special thread ID of
-`main`.
+timeline". When referring to the main timeline as a thread (e.g. in receipts
+and notifications counts) a special thread ID of `main` is used.
 
 Thread roots are considered to be in the main timeline, as are events that are
 related to a thread root via non-thread relations. Note that clients providing a

--- a/content/client-server-api/modules/receipts.md
+++ b/content/client-server-api/modules/receipts.md
@@ -145,7 +145,7 @@ considered to be "in a thread" if:
   depth: a maximum of 3 hops is recommended to cover indirect relationships.)
 
 Events not in a thread but still in the room are considered to be in the "main
-timeline". Threaded receipts for the main timeine use a special thread ID of
+timeline". Threaded receipts for the main timeline use a special thread ID of
 `main`.
 
 Thread roots are considered to be in the main timeline, as are events that are

--- a/content/client-server-api/modules/receipts.md
+++ b/content/client-server-api/modules/receipts.md
@@ -139,8 +139,8 @@ Threading introduces a concept of multiple conversations being held in the same
 room and thus deserve their own read receipts and notification counts. An event is
 considered to be "in a thread" if:
 
-* It has a rel_type of m.thread, or
-* It has a parent event with this rel_type, or a parent of a parent, or further
+* It has a `rel_type` of `m.thread`, or
+* It has a parent event with this `rel_type`, or a parent of a parent, or further
   up the chain of relations. (Implementations should not recurse to arbitrary
   depth: a maximum of 3 hops is recommended to cover indirect relationships.)
 

--- a/content/client-server-api/modules/receipts.md
+++ b/content/client-server-api/modules/receipts.md
@@ -140,9 +140,10 @@ room and thus deserve their own read receipts and notification counts. An event 
 considered to be "in a thread" if:
 
 * It has a `rel_type` of `m.thread`, or
-* It has a parent event with this `rel_type`, or a parent of a parent, or further
-  up the chain of relations. (Implementations should not recurse to arbitrary
-  depth: a maximum of 3 hops is recommended to cover indirect relationships.)
+* Following the event relationships, it has a parent event which references
+  the thread root with a `rel_type` of `m.thread`. Implementations should
+  not recurse infinitely, though: a maximum of 3 hops is recommended to
+  cover indirect relationships.
 
 Events not in a thread but still in the room are considered to be in the "main
 timeline". When referring to the main timeline as a thread (e.g. in receipts

--- a/content/client-server-api/modules/threading.md
+++ b/content/client-server-api/modules/threading.md
@@ -12,7 +12,7 @@ as by providing some context to what is going on in the thread but keeping the f
 history behind a disclosure.
 
 Threads are established using a `rel_type` of `m.thread` and reference the
-*thread root*. It is not possible to create a thread from an event which itself
+*thread root* (the main timeline event to which the thread events refer). It is not possible to create a thread from an event which itself
 is the child of an event relationship (i.e., one with an `m.relates_to`
 property). It is therefore also not possible to nest threads. All events in a
 thread reference the thread root instead of the most recent message, unlike rich

--- a/content/client-server-api/modules/threading.md
+++ b/content/client-server-api/modules/threading.md
@@ -12,11 +12,11 @@ as by providing some context to what is going on in the thread but keeping the f
 history behind a disclosure.
 
 Threads are established using a `rel_type` of `m.thread` and reference the
-*thread root* (the first event in a thread). It is not possible to create a
-thread from an event which itself is the child of an event relationship (i.e.,
-one with an `m.relates_to` property). It is therefore also not possible to nest
-threads. All events in a thread reference the thread root instead of the
-most recent message, unlike rich reply chains.
+*thread root*. It is not possible to create a thread from an event which itself
+is the child of an event relationship (i.e., one with an `m.relates_to`
+property). It is therefore also not possible to nest threads. All events in a
+thread reference the thread root instead of the most recent message, unlike rich
+reply chains.
 
 As a worked example, the following represents a thread and how it would be formed:
 


### PR DESCRIPTION
This was originally written up as [MSC4037](https://github.com/matrix-org/matrix-spec-proposals/pull/4037), but discussion there concluded that a spec PR was more appropriate.

Quoting @turt2live in that discussion:

> [MSC3771](https://github.com/matrix-org/matrix-spec-proposals/blob/main/proposals/3771-read-receipts-for-threads.md) (merged) originally introduced the threaded receipts behaviour into the spec in v1.4, but did not describe what actually constitutes what is "in a thread". Though, the implied wording of MSC3771 does *not* include the thread root in the thread for purposes of notifications. This is further backed up by Synapse being the primary cited implementation proof for MSC3771, which is backed up by this proposal's text in the above paragraph.

This PR modifies the spec to make clear that thread roots and their non-thread children are not "in the thread" for the purposes of receipt handling and unreadness.

* [Synapse](https://github.com/matrix-org/synapse/blob/v1.87.0/synapse/rest/client/receipts.py#L116-L154) has the behaviour specified in this PR.

* [matrix-js-sdk](https://github.com/matrix-org/matrix-js-sdk/blob/develop/src/client.ts#L5004) was recently fixed to match the behaviour required by this PR, as a bug fix for stuck notifications bugs resulting from inconsistency between Synapse and Element Web.

Signed-off-by: Andy Balaam <andy.balaam@matrix.org>

<!-- Replace -->
Preview: https://pr1677--matrix-spec-previews.netlify.app
<!-- Replace -->
