### PR TITLE
Batch receipts by thread as well as room

### DIFF
--- a/changelogs/client_server/newsfragments/1685.clarification
+++ b/changelogs/client_server/newsfragments/1685.clarification
@@ -1,1 +1,1 @@
-Separate receipt batches by thread as well as room
+Clarify that read-receipts should be batched by thread as well as room.

--- a/changelogs/client_server/newsfragments/1685.clarification
+++ b/changelogs/client_server/newsfragments/1685.clarification
@@ -1,0 +1,1 @@
+Separate receipt batches by thread as well as room

--- a/content/client-server-api/modules/receipts.md
+++ b/content/client-server-api/modules/receipts.md
@@ -208,7 +208,7 @@ event when the user expands that thread.
 
 #### Server behaviour
 
-For efficiency, receipts SHOULD be batched into one event per room
+For efficiency, receipts SHOULD be batched into one event per room and thread
 before delivering them to clients.
 
 Some receipts are sent across federation as EDUs with type `m.receipt`. The


### PR DESCRIPTION
Fixes #1684 

Avoid implying receipts for the same user+room but different threads should be batched together, since the JSON format does not allow it.




<!-- Replace -->
Preview: https://pr1685--matrix-spec-previews.netlify.app
<!-- Replace -->
