### PR TITLE
Clarification: the state and not the events are overwritten

### DIFF
--- a/data/api/client-server/room_state.yaml
+++ b/data/api/client-server/room_state.yaml
@@ -20,7 +20,7 @@ paths:
     put:
       summary: Send a state event to the given room.
       description: |
-        State events can be sent using this endpoint.  These events will be appended
+        State events can be sent using this endpoint.  These events will be processed
         and the state overwritten if `<room id>`, `<event type>` and `<state key>` all
         match.
 

--- a/data/api/client-server/room_state.yaml
+++ b/data/api/client-server/room_state.yaml
@@ -20,8 +20,8 @@ paths:
     put:
       summary: Send a state event to the given room.
       description: |
-        State events can be sent using this endpoint.  These events will be
-        overwritten if `<room id>`, `<event type>` and `<state key>` all
+        State events can be sent using this endpoint.  These events will be appended
+        and the state overwritten if `<room id>`, `<event type>` and `<state key>` all
         match.
 
         Requests to this endpoint **cannot use transaction IDs**


### PR DESCRIPTION
The history of events remains / the event is appended and only the state is overwritten

<!-- Replace -->
Preview: https://pr1689--matrix-spec-previews.netlify.app
<!-- Replace -->

Fixes: #1686
