### PR TITLE
Make clearer in the example that the fallback prefix sequence should be repeated for each line

### DIFF
--- a/changelogs/client_server/newsfragments/1690.clarification
+++ b/changelogs/client_server/newsfragments/1690.clarification
@@ -1,1 +1,1 @@
-Make clearer in the example that the fallback prefix sequence should be repeated for each line.
+Make clearer in the example for reply fallbacks that the prefix sequence should be repeated for each line.

--- a/changelogs/client_server/newsfragments/1690.clarification
+++ b/changelogs/client_server/newsfragments/1690.clarification
@@ -1,0 +1,1 @@
+Make clearer in the example that the fallback prefix sequence should be repeated for each line.

--- a/content/client-server-api/modules/rich_replies.md
+++ b/content/client-server-api/modules/rich_replies.md
@@ -60,7 +60,8 @@ specific fallback text is different for each `msgtype`, however the
 general format for the `body` is:
 
 ```text
-> <@alice:example.org> This is the original body
+> <@alice:example.org> This is the first line of the original body
+> This is the second line
 
 This is where the reply goes
 ```


### PR DESCRIPTION
I needed to read the spec twice to make sure it was the case.

Also, I encountered an implementation of matrix that added the sequence only for the first line.

I believe that making the first example of the chapter show several lines will make less likely such mistakes in the future.




<!-- Replace -->
Preview: https://pr1690--matrix-spec-previews.netlify.app
<!-- Replace -->
