### PR TITLE
Clarify secret storage format

### DIFF
--- a/changelogs/client_server/newsfragments/1695.clarification
+++ b/changelogs/client_server/newsfragments/1695.clarification
@@ -1,0 +1,1 @@
+Clarify the format of account data objects for secret storage.


### PR DESCRIPTION
I found the description of how the `m.secret_storage.key.[key ID]` account data object is calculated extremely confusing.