### PR TITLE
Clarify that the key backup MAC is implemented incorrectly

### DIFF
--- a/changelogs/client_server/newsfragments/1712.clarification
+++ b/changelogs/client_server/newsfragments/1712.clarification
@@ -1,0 +1,1 @@
+Clarify that the key backup MAC is implemented incorrectly and does not pass the ciphertext through HMAC-SHA-256.

--- a/content/client-server-api/modules/end_to_end_encryption.md
+++ b/content/client-server-api/modules/end_to_end_encryption.md
@@ -1368,14 +1368,14 @@ The `session_data` field in the backups is constructed as follows:
     The first 8 bytes of the resulting MAC are base64-encoded, and become the
     `mac` property of the `session_data`.
 
-    {{% boxes/warning %}}
-    This was intended to pass the raw encrypted data, but due to a bug in
-    libolm, all implementations have since passed an empty string instead.
+{{% boxes/warning %}}
+Step 5 was intended to pass the raw encrypted data, but due to a bug in libolm,
+all implementations have since passed an empty string instead.
 
-    Future versions of the spec will fix this problem. See
-    [MSC4048](https://github.com/matrix-org/matrix-spec-proposals/pull/4048)
-    for a potential new key backup algorithm version that would fix this issue.
-    {{% /boxes/warning %}}
+Future versions of the spec will fix this problem. See
+[MSC4048](https://github.com/matrix-org/matrix-spec-proposals/pull/4048) for a
+potential new key backup algorithm version that would fix this issue.
+{{% /boxes/warning %}}
 
 {{% definition path="api/client-server/definitions/key_backup_session_data" %}}
 

--- a/content/client-server-api/modules/end_to_end_encryption.md
+++ b/content/client-server-api/modules/end_to_end_encryption.md
@@ -1364,10 +1364,18 @@ The `session_data` field in the backups is constructed as follows:
     PKCS\#7 padding. This encrypted data, encoded using unpadded base64,
     becomes the `ciphertext` property of the `session_data`.
 
-5.  Pass the raw encrypted data (prior to base64 encoding) through
-    HMAC-SHA-256 using the MAC key generated above. The first 8 bytes of
-    the resulting MAC are base64-encoded, and become the `mac` property
-    of the `session_data`.
+5.  Pass an empty string through HMAC-SHA-256 using the MAC key generated above.
+    The first 8 bytes of the resulting MAC are base64-encoded, and become the
+    `mac` property of the `session_data`.
+
+    {{% boxes/warning %}}
+    This was intended to pass the raw encrypted data, but due to a bug in
+    libolm, all implementations have since passed an empty string instead.
+
+    Future versions of the spec will fix this problem. See
+    [MSC4048](https://github.com/matrix-org/matrix-spec-proposals/pull/4048)
+    for a potential new key backup algorithm version that would fix this issue.
+    {{% /boxes/warning %}}
 
 {{% definition path="api/client-server/definitions/key_backup_session_data" %}}
 


### PR DESCRIPTION
---
name: Clarify that the key backup MAC is implemented incorrectly
about: Clarify that the key backup MAC is implemented incorrectly
title: Clarify that the key backup MAC is implemented incorrectly
labels: ''
assignees: ''

---

Due to a bug in libolm, all implementations of the
m.megolm_backup.v1.curve25519-aes-sha2 key backup algorithm incorrectly
pass an empty string through HMAC-SHA-256 to generate the `mac` property
of the `session_data`.

It was intended for the entire raw encrypted data to be passed through
HMAC-SHA-256, but the issue was caught too late in the process, and thus
we are stuck with this until a new key backup algorithm is introduced.

This commit clarifies the real-world behavior of all current
implementations.

Signed-off-by: Sumner Evans <sumner@beeper.com>

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)





<!-- Replace -->
Preview: https://pr1712--matrix-spec-previews.netlify.app
<!-- Replace -->
