### PR TITLE
clarify otk and fallback key types in examples

### DIFF
--- a/changelogs/client_server/newsfragments/1715.clarification
+++ b/changelogs/client_server/newsfragments/1715.clarification
@@ -1,0 +1,1 @@
+Clarify one-time key and fallback key types in examples.

--- a/content/client-server-api/modules/end_to_end_encryption.md
+++ b/content/client-server-api/modules/end_to_end_encryption.md
@@ -1776,9 +1776,9 @@ Example response:
     ],
   },
   "device_one_time_keys_count": {
-    "curve25519": 10,
     "signed_curve25519": 20
-  }
+  },
+  "device_unused_fallback_key_types": ["signed_curve25519"]
 }
 ```
 

--- a/data/api/client-server/keys.yaml
+++ b/data/api/client-server/keys.yaml
@@ -52,7 +52,6 @@ paths:
 
                     May be absent if no new one-time keys are required.
                   example:
-                    curve25519:AAAAAQ: /qyvZvwjiTxGdGU0RCguDCLeR+nmsb3FfNG3/Ve4vU8
                     signed_curve25519:AAAAHg:
                       key: zKbLg+NrIjpnagy+pIY6uPL4ZwEG2v+8F9lmgsnlZzs
                       signatures:
@@ -84,7 +83,6 @@ paths:
 
                     May be absent if a new fallback key is not required.
                   example:
-                    curve25519:AAAAAG: /qyvZvwjiTxGdGU0RCguDCLeR+nmsb3FfNG3/Ve4vU8
                     signed_curve25519:AAAAGj:
                       key: zKbLg+NrIjpnagy+pIY6uPL4ZwEG2v+8F9lmgsnlZzs
                       fallback: true
@@ -111,7 +109,6 @@ paths:
                       If an algorithm is not listed, the count for that algorithm
                       is to be assumed zero.
                     example:
-                      curve25519: 10
                       signed_curve25519: 20
                 required:
                   - one_time_key_counts


### PR DESCRIPTION
- remove unsigned curve25519 keys from examples because we don't use those for otks and fallback keys
- add missing `device_unused_fallback_key_types` property, which is required




<!-- Replace -->
Preview: https://pr1715--matrix-spec-previews.netlify.app
<!-- Replace -->
