### PR TITLE
Clarify that invite->knock is *not* a valid transition

### DIFF
--- a/changelogs/room_versions/newsfragments/1717.clarification
+++ b/changelogs/room_versions/newsfragments/1717.clarification
@@ -1,0 +1,1 @@
+For room versions 7 through 11: Clarify that `invite->knock` is not a legal transition.

--- a/content/rooms/fragments/v8-auth-rules.md
+++ b/content/rooms/fragments/v8-auth-rules.md
@@ -117,7 +117,8 @@ The rules are as follows:
     7. If `membership` is `knock`:
         1.  If the `join_rule` is anything other than `knock`, reject.
         2.  If `sender` does not match `state_key`, reject.
-        3.  If the `sender`'s current membership is not `ban` or `join`, allow.
+        3.  If the `sender`'s current membership is not `ban`, `invite`,
+            or `join`, allow.
         4.  Otherwise, reject.
     8.  Otherwise, the membership is unknown. Reject.
 5.  If the `sender`'s current membership state is not `join`, reject.

--- a/content/rooms/v10.md
+++ b/content/rooms/v10.md
@@ -194,7 +194,8 @@ The rules are as follows:
             If the `join_rule` is anything other than `knock` or
             `knock_restricted`, reject.
         2.  If `sender` does not match `state_key`, reject.
-        3.  If the `sender`'s current membership is not `ban` or `join`, allow.
+        3.  If the `sender`'s current membership is not `ban`, `invite`,
+            or `join`, allow.
         4.  Otherwise, reject.
     8.  Otherwise, the membership is unknown. Reject.
 5.  If the `sender`'s current membership state is not `join`, reject.

--- a/content/rooms/v11.md
+++ b/content/rooms/v11.md
@@ -200,7 +200,8 @@ The rules are as follows:
         1.  If the `join_rule` is anything other than `knock` or
             `knock_restricted`, reject.
         2.  If `sender` does not match `state_key`, reject.
-        3.  If the `sender`'s current membership is not `ban` or `join`, allow.
+        3.  If the `sender`'s current membership is not `ban`, `invite`,
+            or `join`, allow.
         4.  Otherwise, reject.
     8.  Otherwise, the membership is unknown. Reject.
 5.  If the `sender`'s current membership state is not `join`, reject.

--- a/content/rooms/v7.md
+++ b/content/rooms/v7.md
@@ -139,7 +139,8 @@ The rules are as follows:
         If `membership` is `knock`:
         1.  If the `join_rule` is anything other than `knock`, reject.
         2.  If `sender` does not match `state_key`, reject.
-        3.  If the `sender`'s current membership is not `ban` or `join`, allow.
+        3.  If the `sender`'s current membership is not `ban`, `invite`,
+            or `join`, allow.
         4.  Otherwise, reject.
     7.  Otherwise, the membership is unknown. Reject.
 5.  If the `sender`'s current membership state is not `join`, reject.


### PR DESCRIPTION
This reverts https://github.com/matrix-org/matrix-spec/pull/1175

See https://github.com/matrix-org/matrix-spec/issues/1710

Signed-off-by: Kegan Dougal <kegan@matrix.org>

<!-- Replace -->
Preview: https://pr1717--matrix-spec-previews.netlify.app
<!-- Replace -->
