### PR TITLE
Use a POST request in Federation request signing example

### DIFF
--- a/changelogs/server_server/newsfragments/1721.clarification
+++ b/changelogs/server_server/newsfragments/1721.clarification
@@ -1,0 +1,1 @@
+Clarify Server-Server API request signing example by using the `POST` HTTP method, as `GET` requests don't have request bodies.

--- a/content/server-server-api.md
+++ b/content/server-server-api.md
@@ -290,7 +290,7 @@ Step 1 sign JSON:
 
 ```
 {
-    "method": "GET",
+    "method": "POST",
     "uri": "/target",
     "origin": "origin.hs.example.com",
     "destination": "destination.hs.example.com",
@@ -311,7 +311,7 @@ condition applies throughout the request signing process.
 
 Step 2 add Authorization header:
 
-    GET /target HTTP/1.1
+    POST /target HTTP/1.1
     Authorization: X-Matrix origin="origin.hs.example.com",destination="destination.hs.example.com",key="ed25519:key1",sig="ABCDEF..."
     Content-Type: application/json
 


### PR DESCRIPTION
Otherwise the GET request having a body is confusing, since it is not valid HTTP




<!-- Replace -->
Preview: https://pr1721--matrix-spec-previews.netlify.app
<!-- Replace -->
