### PR TITLE
Allow `/versions` to optionally accept authentication

### DIFF
--- a/changelogs/client_server/newsfragments/1728.feature
+++ b/changelogs/client_server/newsfragments/1728.feature
@@ -1,0 +1,1 @@
+Allow `/versions` to optionally accept authentication, as per [MSC4026](https://github.com/matrix-org/matrix-spec-proposals/pull/4026).

--- a/data/api/client-server/versions.yaml
+++ b/data/api/client-server/versions.yaml
@@ -34,11 +34,21 @@ paths:
         which has not yet landed in the spec. For example, a feature currently
         undergoing the proposal process may appear here and eventually be taken
         off this list once the feature lands in the spec and the server deems it
-        reasonable to do so. Servers may wish to keep advertising features here
-        after they've been released into the spec to give clients a chance to
-        upgrade appropriately. Additionally, clients should avoid using unstable
-        features in their stable releases.
+        reasonable to do so. Servers can choose to enable some features only for
+        some users, so clients should include authentication in the request to
+        get all the features available for the logged-in user. If no
+        authentication is provided, the server should only return the features
+        available to all users. Servers may wish to keep advertising features
+        here after they've been released into the spec to give clients a chance
+        to upgrade appropriately. Additionally, clients should avoid using
+        unstable features in their stable releases.
       operationId: getVersions
+      security:
+        - {}
+        - accessToken: []
+      x-changedInMatrixVersion:
+        "1.10": |
+          This endpoint can behave differently when authentication is provided.
       responses:
         "200":
           description: The versions supported by the server.
@@ -89,3 +99,6 @@ servers:
         default: localhost:8008
       basePath:
         default: /_matrix/client
+components:
+  securitySchemes:
+    $ref: definitions/security.yaml

--- a/layouts/partials/openapi/render-operation.html
+++ b/layouts/partials/openapi/render-operation.html
@@ -60,21 +60,22 @@
  <tr>
   <th>Requires authentication:</th>
   {{/*
-    Authentication is optional if one of these is true:
-      - the security key is not set
-      - the security value contains an empty object
+    Authentication is defined with the `security` key. We assume that the
+    key is not set if no authentication is necessary. If the key is set,
+    authentication is required unless it contains an item that is an empty
+    object.
   */}}
-  {{ $requires_authentication := 1 }}
+  {{ $requires_authentication := "Yes" }}
   {{ if $operation_data.security }}
     {{ range $operation_data.security }}
       {{ if eq (len (index $operation_data.security 0)) 0 }}
-        {{ $requires_authentication = 0 }}
+        {{ $requires_authentication = "Optional" }}
       {{ end }}
     {{ end }}
   {{ else }}
-    {{ $requires_authentication = 0 }}
+    {{ $requires_authentication = "No" }}
   {{ end }}
-  <td>{{ if $requires_authentication }}Yes{{ else }}No{{ end }}</td>
+  <td>{{ $requires_authentication }}</td>
  </tr>
 </table>
 

--- a/layouts/partials/openapi/render-operation.html
+++ b/layouts/partials/openapi/render-operation.html
@@ -59,7 +59,22 @@
   </tr>
  <tr>
   <th>Requires authentication:</th>
-  <td>{{ if $operation_data.security }}Yes{{ else }}No{{ end }}</td>
+  {{/*
+    Authentication is optional if one of these is true:
+      - the security key is not set
+      - the security value contains an empty object
+  */}}
+  {{ $requires_authentication := 1 }}
+  {{ if $operation_data.security }}
+    {{ range $operation_data.security }}
+      {{ if eq (len (index $operation_data.security 0)) 0 }}
+        {{ $requires_authentication = 0 }}
+      {{ end }}
+    {{ end }}
+  {{ else }}
+    {{ $requires_authentication = 0 }}
+  {{ end }}
+  <td>{{ if $requires_authentication }}Yes{{ else }}No{{ end }}</td>
  </tr>
 </table>
 


### PR DESCRIPTION
According to [MSC4026](https://github.com/matrix-org/matrix-spec-proposals/pull/4026).

I followed the [OpenAPI 3.1 spec](https://spec.openapis.org/oas/v3.1.0#operation-object) to declare that the authentication is optional, so I also had to adapt the partials to not show `Requires authentication: Yes`.







<!-- Replace -->
Preview: https://pr1728--matrix-spec-previews.netlify.app
<!-- Replace -->
