### PR TITLE
Document the deprecation policy of HTML tags.

### DIFF
--- a/changelogs/client_server/newsfragments/1732.clarification
+++ b/changelogs/client_server/newsfragments/1732.clarification
@@ -1,1 +1,1 @@
-Document the deprecation policy of HTML tags.
+Document the deprecation policy of HTML tags, as per [MSC4077](https://github.com/matrix-org/matrix-spec-proposals/pull/4077).

--- a/changelogs/client_server/newsfragments/1732.clarification
+++ b/changelogs/client_server/newsfragments/1732.clarification
@@ -1,0 +1,1 @@
+Document the deprecation policy of HTML tags.

--- a/changelogs/client_server/newsfragments/1732.feature
+++ b/changelogs/client_server/newsfragments/1732.feature
@@ -1,1 +1,0 @@
-Deprecate the `strike` HTML tag and introduce the `s` tag as a possible replacement.

--- a/changelogs/client_server/newsfragments/1732.feature
+++ b/changelogs/client_server/newsfragments/1732.feature
@@ -1,0 +1,1 @@
+Deprecate the `strike` HTML tag and introduce the `s` tag as a possible replacement.

--- a/content/client-server-api/modules/instant_messaging.md
+++ b/content/client-server-api/modules/instant_messaging.md
@@ -52,7 +52,7 @@ tags to permit, denying the use and rendering of anything else, is:
 {{% added-in v="1.10" %}}
 HTML features MAY be deprecated and replaced by their modern equivalent without
 requiring a [Spec Change Proposal](/proposals) when they are deprecated in the
-WHATWG HTML Living Standard.
+[WHATWG HTML Living Standard](https://html.spec.whatwg.org/multipage/).
 {{% /boxes/note %}}
 
 Not all attributes on those tags should be permitted as they may be

--- a/content/client-server-api/modules/instant_messaging.md
+++ b/content/client-server-api/modules/instant_messaging.md
@@ -48,20 +48,12 @@ tags to permit, denying the use and rendering of anything else, is:
 `s`, `code`, `hr`, `br`, `div`, `table`, `thead`, `tbody`, `tr`,
 `th`, `td`, `caption`, `pre`, `span`, `img`, `details`, `summary`.
 
-
 {{% boxes/note %}}
+{{% added-in v="1.10" %}}
 HTML features MAY be deprecated and replaced by their modern equivalent without
 requiring a [Spec Change Proposal](/proposals) when they are deprecated in the
 WHATWG HTML Living Standard.
 {{% /boxes/note %}}
-
-{{% boxes/note %}}
-{{% changed-in v="1.10" %}}
-
-The `strike` tag is deprecated. Clients MUST stop sending new messages using
-this tag and replace it with `s` or `del`.
-{{% /boxes/note %}}
-
 
 Not all attributes on those tags should be permitted as they may be
 avenues for other disruption attempts, such as adding `onclick` handlers

--- a/content/client-server-api/modules/instant_messaging.md
+++ b/content/client-server-api/modules/instant_messaging.md
@@ -37,8 +37,23 @@ HTML injection, and similar attacks. The strongly suggested set of HTML
 tags to permit, denying the use and rendering of anything else, is:
 `font`, `del`, `h1`, `h2`, `h3`, `h4`, `h5`, `h6`, `blockquote`, `p`,
 `a`, `ul`, `ol`, `sup`, `sub`, `li`, `b`, `i`, `u`, `strong`, `em`,
-`strike`, `code`, `hr`, `br`, `div`, `table`, `thead`, `tbody`, `tr`,
+`strike`, `s`, `code`, `hr`, `br`, `div`, `table`, `thead`, `tbody`, `tr`,
 `th`, `td`, `caption`, `pre`, `span`, `img`, `details`, `summary`.
+
+
+{{% boxes/note %}}
+HTML features MAY be deprecated and replaced by their modern equivalent without
+requiring a [Spec Change Proposal](/proposals) when they are deprecated in the
+WHATWG HTML Living Standard.
+{{% /boxes/note %}}
+
+{{% boxes/note %}}
+{{% changed-in v="1.10" %}}
+
+The `strike` tag is deprecated. Clients MUST stop sending new messages using
+this tag and replace it with `s` or `del`.
+{{% /boxes/note %}}
+
 
 Not all attributes on those tags should be permitted as they may be
 avenues for other disruption attempts, such as adding `onclick` handlers


### PR DESCRIPTION
~~Replace it with `s` or `del`, as per [MSC4077](https://github.com/matrix-org/matrix-spec-proposals/pull/4077).~~

It also adds an info box as suggested in https://github.com/matrix-org/matrix-spec-proposals/pull/4077#discussion_r1393595760.

~~Closes #1492.~~










<!-- Replace -->
Preview: https://pr1732--matrix-spec-previews.netlify.app
<!-- Replace -->
