### PR TITLE
Deprecate the `font` HTML tag

### DIFF
--- a/changelogs/client_server/newsfragments/1739.clarification
+++ b/changelogs/client_server/newsfragments/1739.clarification
@@ -1,0 +1,1 @@
+The [font](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/font) element is deprecated in the HTML spec. Clients should prefer [span](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span) with the `data-mx-bg-color` and `data-mx-color` attributes instead.

--- a/content/client-server-api/modules/instant_messaging.md
+++ b/content/client-server-api/modules/instant_messaging.md
@@ -55,6 +55,14 @@ requiring a [Spec Change Proposal](/proposals) when they are deprecated in the
 [WHATWG HTML Living Standard](https://html.spec.whatwg.org/multipage/).
 {{% /boxes/note %}}
 
+{{% boxes/note %}}
+{{% changed-in v="1.10" %}}
+In previous versions of the specification, the `font` tag was suggested with the
+`data-mx-bg-color`, `data-mx-color` and `color` attributes. This tag is now
+deprecated in favor of the `span` tag with the `data-mx-bg-color` and
+`data-mx-color` attributes in new messages.
+{{% /boxes/note %}}
+
 Not all attributes on those tags should be permitted as they may be
 avenues for other disruption attempts, such as adding `onclick` handlers
 or excessively large text. Clients should only permit the attributes

--- a/content/client-server-api/modules/instant_messaging.md
+++ b/content/client-server-api/modules/instant_messaging.md
@@ -43,10 +43,10 @@ were limited to `m.text`, `m.emote`, `m.notice`, and
 Clients should limit the HTML they render to avoid Cross-Site Scripting,
 HTML injection, and similar attacks. The strongly suggested set of HTML
 tags to permit, denying the use and rendering of anything else, is:
-`font`, `del`, `h1`, `h2`, `h3`, `h4`, `h5`, `h6`, `blockquote`, `p`,
-`a`, `ul`, `ol`, `sup`, `sub`, `li`, `b`, `i`, `u`, `strong`, `em`,
-`s`, `code`, `hr`, `br`, `div`, `table`, `thead`, `tbody`, `tr`,
-`th`, `td`, `caption`, `pre`, `span`, `img`, `details`, `summary`.
+`del`, `h1`, `h2`, `h3`, `h4`, `h5`, `h6`, `blockquote`, `p`, `a`, `ul`,
+`ol`, `sup`, `sub`, `li`, `b`, `i`, `u`, `strong`, `em`, `s`, `code`,
+`hr`, `br`, `div`, `table`, `thead`, `tbody`, `tr`, `th`, `td`,
+`caption`, `pre`, `span`, `img`, `details`, `summary`.
 
 {{% boxes/note %}}
 {{% added-in v="1.10" %}}
@@ -65,7 +65,6 @@ the tag.
 
 | Tag    | Permitted Attributes                                                                                                                       |
 |--------|--------------------------------------------------------------------------------------------------------------------------------------------|
-| `font` | `data-mx-bg-color`, `data-mx-color`, `color`                                                                                               |
 | `span` | `data-mx-bg-color`, `data-mx-color`, `data-mx-spoiler` (see [spoiler messages](#spoiler-messages))                                         |
 | `a`    | `name`, `target`, `href` (provided the value is not relative and has a scheme matching one of: `https`, `http`, `ftp`, `mailto`, `magnet`) |
 | `img`  | `width`, `height`, `alt`, `title`, `src` (provided it is a [Matrix Content (`mxc://`) URI](#matrix-content-mxc-uris))                      |


### PR DESCRIPTION
#### Rationale:

MSC4077 allows to deprecate HTML tags that are deprecated in the WHATWG standard without requiring an MSC, if they can be replaced by tags with the same feature.

[`font` is deprecated](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/font) and can be replaced by `span` with the `data-mx-bg-color` and `data-mx-color` attributes.

So, HTML like this:

```html
<font data-mx-bg-color="#FF0000" color="#00FF00">Some green text on a red background</font>
```

Can also be written like this:

```html
<span data-mx-bg-color="#FF0000" data-mx-color="#00FF00">Some green text on a red background</span>
```








<!-- Replace -->
Preview: https://pr1739--matrix-spec-previews.netlify.app
<!-- Replace -->
