### PR TITLE
Disambiguate uses of `PublicRoomsChunk`

### DIFF
--- a/changelogs/client_server/newsfragments/1740.clarification
+++ b/changelogs/client_server/newsfragments/1740.clarification
@@ -1,0 +1,1 @@
+Disambiguate uses of `PublicRoomsChunk` in the `GET /hierarchy` endpoint.

--- a/changelogs/server_server/newsfragments/1740.clarification
+++ b/changelogs/server_server/newsfragments/1740.clarification
@@ -1,0 +1,1 @@
+Disambiguate uses of `PublicRoomsChunk` in the `GET /hierarchy` endpoint.

--- a/data/api/client-server/space_hierarchy.yaml
+++ b/data/api/client-server/space_hierarchy.yaml
@@ -92,7 +92,7 @@ paths:
                       allOf:
                         - $ref: definitions/public_rooms_chunk.yaml
                         - type: object
-                          title: ChildRoomsChunk
+                          title: SpaceHierarchyRoomsChunk
                           properties:
                             room_type:
                               type: string

--- a/data/api/server-server/space_hierarchy.yaml
+++ b/data/api/server-server/space_hierarchy.yaml
@@ -63,6 +63,7 @@ paths:
                     allOf:
                       - $ref: ../client-server/definitions/public_rooms_chunk.yaml
                       - type: object
+                        title: SpaceHierarchyParentRoom
                         properties:
                           room_type:
                             type: string
@@ -106,6 +107,7 @@ paths:
                       allOf:
                         - $ref: ../client-server/definitions/public_rooms_chunk.yaml
                         - type: object
+                          title: SpaceHierarchyChildRoomsChunk
                           properties:
                             room_type:
                               type: string


### PR DESCRIPTION
Make sure that different objects don't share the same title.

Also make sure that the titles are not confusing: in the Client-Server API, the items in the space hierarchy response were named `ChildRoomsChunk`, but the first item returned should actually be the parent.

Fixes #1729.




<!-- Replace -->
Preview: https://pr1740--matrix-spec-previews.netlify.app
<!-- Replace -->
