### PR TITLE
Clarify that extra fields of space hierarchy children are not required

### DIFF
--- a/changelogs/server_server/newsfragments/1741.clarification
+++ b/changelogs/server_server/newsfragments/1741.clarification
@@ -1,0 +1,1 @@
+Clarify that the `children_state`, `room_type` and `allowed_room_ids` properties in the items of the `children` array of the response of the `GET /hierarchy` endpoint are not required.

--- a/data/api/server-server/space_hierarchy.yaml
+++ b/data/api/server-server/space_hierarchy.yaml
@@ -119,10 +119,6 @@ paths:
                               description: |-
                                 If the room is a [restricted room](#restricted-rooms), these are the room IDs which
                                 are specified by the join rules. Empty or omitted otherwise.
-                          required:
-                            - room_type
-                            - allowed_room_ids
-                            - children_state
                   inaccessible_children:
                     type: array
                     items:


### PR DESCRIPTION
There is no `children_state` field, the `room_type` is only set for spaces and the description of `allowed_room_ids` says that the field can be omitted.




<!-- Replace -->
Preview: https://pr1741--matrix-spec-previews.netlify.app
<!-- Replace -->
