### PR TITLE
Clarify that sdpMid and sdpMLineIndex are not required in `m.call.candidates`

### DIFF
--- a/changelogs/client_server/newsfragments/1742.clarification
+++ b/changelogs/client_server/newsfragments/1742.clarification
@@ -1,0 +1,1 @@
+Clarify that `sdpMid` and `sdpMLineIndex` are not required in `m.call.candidates`.

--- a/data/event-schemas/schema/m.call.candidates.yaml
+++ b/data/event-schemas/schema/m.call.candidates.yaml
@@ -1,45 +1,40 @@
-{
-    "type": "object",
-    "description": "This event is sent by callers after sending an invite and by the callee after answering. Its purpose is to give the other party additional ICE candidates to try using to communicate.",
-    "allOf": [{
-        "$ref": "core-event-schema/room_event.yaml"
-    }],
-    "properties": {
-        "content": {
-            "type": "object",
-            "allOf": [{
-                "$ref": "core-event-schema/call_event.yaml"
-            }],
-            "properties": {
-                "candidates": {
-                    "type": "array",
-                    "description": "Array of objects describing the candidates.",
-                    "items": {
-                        "type": "object",
-                        "title": "Candidate",
-                        "properties": {
-                            "sdpMid": {
-                                "type": "string",
-                                "description": "The SDP media type this candidate is intended for."
-                            },
-                            "sdpMLineIndex": {
-                                "type": "number",
-                                "description": "The index of the SDP 'm' line this candidate is intended for."
-                            },
-                            "candidate": {
-                                "type": "string",
-                                "description": "The SDP 'a' line of the candidate."
-                            }
-                        },
-                        "required": ["candidate", "sdpMLineIndex", "sdpMid"]
-                    }
-                }
-            },
-            "required": ["candidates"]
-        },
-        "type": {
-            "type": "string",
-            "enum": ["m.call.candidates"]
-        }
-    }
-}
+type: object
+description: |-
+  This event is sent by callers after sending an invite and by the callee after
+  answering. Its purpose is to give the other party additional ICE candidates to
+  try using to communicate.
+allOf:
+  - $ref: core-event-schema/room_event.yaml
+properties:
+  content:
+    type: object
+    allOf:
+      - $ref: core-event-schema/call_event.yaml
+    properties:
+      candidates:
+        type: array
+        description: Array of objects describing the candidates.
+        items:
+          type: object
+          title: Candidate
+          properties:
+            sdpMid:
+              type: string
+              description: The SDP media type this candidate is intended for.
+            sdpMLineIndex:
+              type: number
+              description: The index of the SDP 'm' line this candidate is intended
+                for.
+            candidate:
+              type: string
+              description: The SDP 'a' line of the candidate.
+          required:
+            - candidate
+            - sdpMLineIndex
+            - sdpMid
+    required:
+      - candidates
+  type:
+    type: string
+    enum:
+      - m.call.candidates

--- a/data/event-schemas/schema/m.call.candidates.yaml
+++ b/data/event-schemas/schema/m.call.candidates.yaml
@@ -20,18 +20,26 @@ properties:
           properties:
             sdpMid:
               type: string
-              description: The SDP media type this candidate is intended for.
+              description: |-
+                The SDP media type this candidate is intended for.
+
+                At least one of `sdpMid` or `sdpMLineIndex` is required, unless
+                this an end-of-candidates candidate.
             sdpMLineIndex:
               type: number
-              description: The index of the SDP 'm' line this candidate is intended
-                for.
+              description: |-
+                The index of the SDP 'm' line this candidate is intended for.
+
+                At least one of `sdpMid` or `sdpMLineIndex` is required, unless
+                this an end-of-candidates candidate.
             candidate:
               type: string
-              description: The SDP 'a' line of the candidate.
+              description: |-
+                The SDP 'a' line of the candidate.
+
+                If this is an end-of-candidates candidate, this is empty.
           required:
             - candidate
-            - sdpMLineIndex
-            - sdpMid
     required:
       - candidates
   type:

--- a/data/event-schemas/schema/m.call.candidates.yaml
+++ b/data/event-schemas/schema/m.call.candidates.yaml
@@ -37,7 +37,8 @@ properties:
               description: |-
                 The SDP 'a' line of the candidate.
 
-                If this is an end-of-candidates candidate, this is empty.
+                If this is an [end-of-candidates](/client-server-api/#end-of-candidates)
+                candidate, this is the empty string.
           required:
             - candidate
     required:


### PR DESCRIPTION
MSC2746, merged in v1.7, introduced the [end-of-candidates candidate](https://spec.matrix.org/v1.9/client-server-api/#end-of-candidates), where only the `candidate` property is set to an empty string. However, the schema for the event was untouched in the [spec PR](https://github.com/matrix-org/matrix-spec/pull/1511).

Besides, the [WebRTC specification](https://www.w3.org/TR/webrtc/) says that [only one of those two fields is required when `candidate` is not empty](https://www.w3.org/TR/webrtc/#dom-peerconnection-addicecandidate) (step 3).

Fixes #1738 and #1078.




<!-- Replace -->
Preview: https://pr1742--matrix-spec-previews.netlify.app
<!-- Replace -->
