### PR TITLE
Specify that appservice login and register fail on incorrect as_tokens

### DIFF
--- a/changelogs/application_service/newsfragments/1744.clarification
+++ b/changelogs/application_service/newsfragments/1744.clarification
@@ -1,0 +1,1 @@
+Clarify that the `/login` and `/register` endpoints should fail when using the `m.login.application_service` login type without a valid `as_token`.

--- a/content/application-service-api.md
+++ b/content/application-service-api.md
@@ -437,8 +437,8 @@ an application service-defined namespace will receive the same
 defined the namespace as `exclusive`.
 
 If either endpoint is called with the `m.login.application_service` login type,
-but without a valid `as_token`, the endpoints will return `M_MISSING_TOKEN` or
-`M_UNKNOWN_TOKEN`.
+but without a valid `as_token`, the endpoints will return an error with the
+`M_MISSING_TOKEN` or `M_UNKNOWN_TOKEN` error code.
 
 #### Pinging
 

--- a/content/application-service-api.md
+++ b/content/application-service-api.md
@@ -436,6 +436,10 @@ an application service-defined namespace will receive the same
 `M_EXCLUSIVE` error code, but only if the application service has
 defined the namespace as `exclusive`.
 
+If either endpoint is called with the `m.login.application_service` login type,
+but without a valid `as_token`, the endpoints will return `M_MISSING_TOKEN` or
+`M_UNKNOWN_TOKEN`.
+
 #### Pinging
 
 {{% added-in v="1.7" %}}

--- a/content/application-service-api.md
+++ b/content/application-service-api.md
@@ -436,9 +436,11 @@ an application service-defined namespace will receive the same
 `M_EXCLUSIVE` error code, but only if the application service has
 defined the namespace as `exclusive`.
 
-If either endpoint is called with the `m.login.application_service` login type,
-but without a valid `as_token`, the endpoints will return an error with the
-`M_MISSING_TOKEN` or `M_UNKNOWN_TOKEN` error code.
+If `/register` or `/login` is called with the `m.login.application_service`
+login type, but without a valid `as_token`, the endpoints will return an error
+with the `M_MISSING_TOKEN` or `M_UNKNOWN_TOKEN` error code and 401 as the HTTP
+status code. This is the same behavior as invalid auth in the client-server API
+(see [Using access tokens](/client-server-api/#using-access-tokens)).
 
 #### Pinging
 


### PR DESCRIPTION
This is implemented in both Synapse and Dendrite, but it turned out Conduit falls back to UIA if it doesn't recognize the `as_token`







<!-- Replace -->
Preview: https://pr1744--matrix-spec-previews.netlify.app
<!-- Replace -->
