### PR TITLE
Support reference objects in operation parameters

### DIFF
--- a/layouts/partials/openapi/render-api.html
+++ b/layouts/partials/openapi/render-api.html
@@ -21,7 +21,7 @@
 
     {{/* note that a `paths` entry can be a $ref */}}
 
-    {{ $params := dict "endpoint" $endpoint "path" $path "root_schema" $api_data }}
+    {{ $params := dict "endpoint" $endpoint "path" $path }}
 
     {{ with $path_data.get }}
 

--- a/layouts/partials/openapi/render-operation.html
+++ b/layouts/partials/openapi/render-operation.html
@@ -6,7 +6,6 @@
   * `endpoint`: the endpoint
   * `operation_data`: the OpenAPI data for the operation
   * `path`: the path where this definition was found, to enable us to resolve "$ref"
-  * `root_schema`: the root schema object where this definition was found, to enable us to resolve local "$ref" references
 
   This template renders the operation as a `<section>` containing:
 
@@ -23,7 +22,6 @@
 {{ $endpoint := .endpoint }}
 {{ $operation_data := .operation_data }}
 {{ $path := .path }}
-{{ $root_schema := .root_schema }}
 {{ $anchor := anchorize $endpoint }}
 
 <section class="rendered-data http-api {{ $method }}">
@@ -82,7 +80,7 @@
 </table>
 
 <hr/>
-{{ partial "openapi/render-request"   (dict "parameters" $operation_data.parameters "request_body" $operation_data.requestBody "path" $path "anchor_base" $anchor "root_schema" $root_schema ) }}
+{{ partial "openapi/render-request"   (dict "parameters" $operation_data.parameters "request_body" $operation_data.requestBody "path" $path "anchor_base" $anchor ) }}
 <hr/>
 {{ partial "openapi/render-responses" (dict "responses"  $operation_data.responses  "path" $path "anchor_base" $anchor ) }}
 

--- a/layouts/partials/openapi/render-parameters.html
+++ b/layouts/partials/openapi/render-parameters.html
@@ -6,7 +6,6 @@
   * `type`: the type of parameters to render: "header", "path", "query"
   * `caption`: caption to use for the table
   * `path`: the path where this definition was found, to enable us to resolve "$ref"
-  * `root_schema`: the root schema object where this definition was found, to enable us to resolve local "$ref" references
 
   This template renders a single table containing parameters of the given type.
 
@@ -15,7 +14,6 @@
 {{ $parameters := .parameters }}
 {{ $type := .type }}
 {{ $caption := .caption }}
-{{ $root_schema := .root_schema }}
 {{ $path := .path }}
 
 {{/* build a dict mapping from name->parameter, which render-object-table expects */}}
@@ -26,11 +24,7 @@
         Per https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#operation-object:
         the parameters can be reference objects; resolve them now.
     */}}
-    {{ $parameter = partial "openapi/resolve-ref-object" (dict
-        "schema" $parameter
-        "root_schema" $root_schema
-        "path" $path
-    ) }}
+    {{ $parameter = partial "openapi/resolve-ref-object" (dict "schema" $parameter "path" $path) }}
     {{ if (eq $parameter.in $type) }}
         {{/*
             merge the schema at the same level as the rest of the other fields because that is

--- a/layouts/partials/openapi/render-request.html
+++ b/layouts/partials/openapi/render-request.html
@@ -5,7 +5,6 @@
   * `parameters`: OpenAPI data specifying the parameters
   * `request_body`: OpenAPI data specifying the request body
   * `path`: the path where this definition was found, to enable us to resolve "$ref"
-  * `root_schema`: the root schema object where this definition was found, to enable us to resolve local "$ref" references
   * `anchor_base`: a prefix to add to the HTML anchors generated for each object
 
   This template renders:
@@ -18,7 +17,6 @@
 {{ $parameters := .parameters }}
 {{ $request_body := .request_body }}
 {{ $path := .path }}
-{{ $root_schema := .root_schema }}
 {{ $anchor_base := .anchor_base }}
 
 <h2>Request</h2>
@@ -33,22 +31,18 @@
             "type" "header"
             "caption" "header parameters"
             "path" $path
-            "root_schema" $root_schema
         ) }}
         {{ partial "openapi/render-parameters" (dict
             "parameters" $parameters
             "type" "path"
             "caption" "path parameters"
             "path" $path
-            "root_schema" $root_schema
         ) }}
         {{ partial "openapi/render-parameters" (dict
             "parameters" $parameters
             "type" "query"
             "caption" "query parameters"
-            "root_schema" $root_schema
             "path" $path
-            "root_schema" $root_schema
         ) }}
     {{ end }}
 

--- a/layouts/partials/openapi/resolve-ref-object.html
+++ b/layouts/partials/openapi/resolve-ref-object.html
@@ -13,16 +13,12 @@ The input parameter is a dict with the following keys:
 * `path`: The path of the schema file containing the (potential) ref; used for resolving
   relative references.
 
-* `root_schema`: The top-level schema which contains the potential ref; use for resolving `#/`
-  references.
-
 Ref: https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#reference-object.
 
 */}}
 
 {{ $schema := .schema }}
 {{ $path := .path }}
-{{ $root_schema := .root_schema }}
 
 {{ $ret := $schema }}
 


### PR DESCRIPTION
According to https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#operation-object, the entries in `parameters` lists can be reference objects. We don't currently support that in our templates, so let's fix that.







<!-- Replace -->
Preview: https://pr1749--matrix-spec-previews.netlify.app
<!-- Replace -->
