### PR TITLE
Fix `event-group` shortcode for changes in `resolve-refs` partial

### DIFF
--- a/changelogs/internal/newsfragments/1754.clarification
+++ b/changelogs/internal/newsfragments/1754.clarification
@@ -1,0 +1,1 @@
+Add support for `$ref` URIs containing fragments in OpenAPI definitions and JSON schemas.

--- a/layouts/shortcodes/event-group.html
+++ b/layouts/shortcodes/event-group.html
@@ -12,7 +12,7 @@
 
 */}}
 
-{{ $path := "event-schemas/schema" }}
+{{ $base_path := "event-schemas/schema" }}
 
 {{ $events := index .Site.Data "event-schemas" "schema" }}
 {{ $group_name := .Params.group_name }}
@@ -22,6 +22,7 @@
     {{ $prefix := substr $event_name 0 (len $group_name) }}
     {{ if eq $prefix $group_name }}
 
+        {{ $path := delimit (slice $base_path $event_name) "/" }}
         {{ $event_data = partial "json-schema/resolve-refs" (dict "schema" $event_data "path" $path) }}
         {{ $event_data := partial "json-schema/resolve-allof" $event_data }}
 


### PR DESCRIPTION
This was broken because "path" needs to point to the file now, and results in `sdp_stream_metadata` having an unresolved ref in `m.call.invite`, `m.call.answer` and `m.call.negotiate`.

cc @richvdh 




<!-- Replace -->
Preview: https://pr1754--matrix-spec-previews.netlify.app
<!-- Replace -->
