### PR TITLE
Disable smooth scrolling

### DIFF
--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -49,3 +49,6 @@ $td-enable-google-fonts: false;
  * The font itself is loaded via stylesheet link layouts/partials/hooks/head-end.html.
  */
 $font-family-sans-serif: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+
+// Disable smooth scrolling as it makes TOC highlighting jump during the transition.
+$enable-smooth-scroll: false;

--- a/changelogs/internal/newsfragments/1762.clarification
+++ b/changelogs/internal/newsfragments/1762.clarification
@@ -1,0 +1,1 @@
+Update Docsy to v0.8.0.


### PR DESCRIPTION
It was not enabled before the docsy update (#1699) and it messes with the TOC highlighting during the transition.

Fixes #1761.




<!-- Replace -->
Preview: https://pr1762--matrix-spec-previews.netlify.app
<!-- Replace -->
