### PR TITLE
Reduce whitespace on mobile viewports

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -118,7 +118,7 @@ Custom SCSS for the Matrix spec
   }
 }
 
-@media (min-width: 768px) {
+@include media-breakpoint-up(md) {
   @supports (position: sticky) {
     .td-sidebar-nav {
       /* This overrides calc(100vh - 10rem);, which gives us a blank space at the bottom of the sidebar */
@@ -177,7 +177,7 @@ footer {
 
 /* Remove some padding before the main content, when the sidebar is disabled */
 .td-main main {
-  @media (max-width: 768px) {
+  @include media-breakpoint-down(md) {
     padding-top: 0;
   }
 }
@@ -481,7 +481,7 @@ of .td-content. This applies the same style to any blockquotes that descend from
 Make padding symmetrical (this selector is used in the default styles to apply padding-left: 3rem)
 */
 .pl-md-5, .px-md-5 {
-  @media (min-width: 768px) {
+  @include media-breakpoint-up(md) {
     padding-right: 3rem;
   }
 }

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -40,10 +40,14 @@ Custom SCSS for the Matrix spec
   .navbar-brand {
     font-size: 1.1rem;
 
+    @media (max-width: 768px) {
+      text-align: center;
+      white-space: normal;
+    }
+
     .navbar-version {
       color: $secondary;
     }
-
   }
 
   .nav-link {
@@ -170,6 +174,12 @@ footer {
     display: inline; visibility: visible; counter-increment: h6; content: counter(h2) "." counter(h3) "." counter(h4) "." counter(h5) "." counter(h6) ". "
   }
 
+}
+
+.td-main main {
+  @media (max-width: 768px) {
+    padding-top: 0;
+  }
 }
 
 /* Adjust the scroll margin for everything in the main content, so that
@@ -471,12 +481,20 @@ of .td-content. This applies the same style to any blockquotes that descend from
 Make padding symmetrical (this selector is used in the default styles to apply padding-left: 3rem)
 */
 .pl-md-5, .px-md-5 {
-  padding-right: 3rem;
+  @media (min-width: 768px) {
+    padding-right: 3rem;
+  }
 }
 
 /* Adjust default styles for info banner */
 .pageinfo-primary {
-  max-width: 80%;
+  @media (min-width: 768px) {
+    max-width: 80%;
+  }
+  @media (max-width: 768px) {
+    margin-top: 0;
+    margin-right: 0;
+  }
   margin-left: 0;
   border: 0;
   border-left: solid 5px $secondary;

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -491,10 +491,8 @@ Make padding symmetrical (this selector is used in the default styles to apply p
   @media (min-width: 768px) {
     max-width: 80%;
   }
-  @media (max-width: 768px) {
-    margin-top: 0;
-    margin-right: 0;
-  }
+  margin-top: 0;
+  margin-right: 0;
   margin-left: 0;
   border: 0;
   border-left: solid 5px $secondary;

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -488,7 +488,7 @@ Make padding symmetrical (this selector is used in the default styles to apply p
 
 /* Adjust default styles for info banner */
 .pageinfo-primary {
-  @media (min-width: 768px) {
+  @include media-breakpoint-up(lg) {
     max-width: 80%;
   }
   margin-top: 0;

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -40,10 +40,9 @@ Custom SCSS for the Matrix spec
   .navbar-brand {
     font-size: 1.1rem;
 
-    @media (max-width: 768px) {
-      text-align: center;
-      white-space: normal;
-    }
+    /* Allow the text to wrap if it is wider than the viewport */
+    text-align: center;
+    white-space: normal;
 
     .navbar-version {
       color: $secondary;

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -175,6 +175,7 @@ footer {
 
 }
 
+/* Remove some padding before the main content, when the sidebar is disabled */
 .td-main main {
   @media (max-width: 768px) {
     padding-top: 0;

--- a/changelogs/internal/newsfragments/1770.clarification
+++ b/changelogs/internal/newsfragments/1770.clarification
@@ -1,0 +1,1 @@
+Reduce whitespace on mobile viewports


### PR DESCRIPTION
I'm probably the only person occasionally reading the spec on my phone but whenever I do it's usually quite cumbersome. One of the issues is a sub-optimal use of white space. This PR removes some of the needless emptiness on mobile viewports.

<table>
<tr>
 <td><strong>Before
 <td><strong>After
<tr>
 <td><img src="https://github.com/matrix-org/matrix-spec/assets/1137962/139ee372-7c6e-4ec1-b4ed-3faa2dd9b6fa">
 <td><img src="https://github.com/matrix-org/matrix-spec/assets/1137962/ec1a9261-1cd9-429d-872b-2b50769d0c5a">
<tr>
 <td><img src="https://github.com/matrix-org/matrix-spec/assets/1137962/b13d5b8c-8c2a-4128-9b7b-108e68acb73c">
 <td><img src="https://github.com/matrix-org/matrix-spec/assets/1137962/cbd5aa13-c923-45d0-b357-4bee26aa53d5">
</table>



















<!-- Replace -->
Preview: https://pr1770--matrix-spec-previews.netlify.app
<!-- Replace -->
