### PR TITLE
Fix Hugo warnings

### DIFF
--- a/changelogs/internal/newsfragments/1775.clarification
+++ b/changelogs/internal/newsfragments/1775.clarification
@@ -1,0 +1,1 @@
+Fix Hugo warnings.

--- a/config.toml
+++ b/config.toml
@@ -129,7 +129,7 @@ sidebar_menu_compact = true
 [module]
   [module.hugoVersion]
     extended = true
-    min = "0.110.0"
+    min = "0.113.0"
   [[module.imports]]
     path = "github.com/matrix-org/docsy"
     disable = false

--- a/config.toml
+++ b/config.toml
@@ -10,15 +10,16 @@ enableRobotsTXT = true
 # We disable RSS, because (a) it's useless, (b) Hugo seems to generate broken
 # links to it when used with a --baseURL (for example, https://spec.matrix.org/v1.4/
 # contains `<link rel="alternate" type="application/rss&#43;xml" href="/v1.4/v1.4/index.xml">`).
-disableKinds = ["taxonomy", "taxonomyTerm", "RSS"]
+disableKinds = ["taxonomy", "RSS"]
 
 [languages]
 [languages.en]
 title = "Matrix Specification"
-description = "Home of the Matrix specification for decentralised communication"
 languageName ="English"
 # Weight used for sorting.
 weight = 1
+[languages.en.params]
+description = "Home of the Matrix specification for decentralised communication"
 
 # Entries in the main menu in the header.
 [menus]


### PR DESCRIPTION
There was, when building Hugo on recent versions, 1 warning on 0.113.0 in CI, and another one on 0.121.2 on my machine. This gets rid of them.

The first commit bumps the minimum supported Hugo version to the one used in CI so we can just handle the deprecated settings without keeping backwards compatibility.




<!-- Replace -->
Preview: https://pr1775--matrix-spec-previews.netlify.app
<!-- Replace -->
