### PR TITLE
Remove enum for `POST /login` `type` definition

### DIFF
--- a/data/api/client-server/login.yaml
+++ b/data/api/client-server/login.yaml
@@ -109,10 +109,13 @@ paths:
               properties:
                 type:
                   type: string
-                  enum:
-                    - m.login.password
-                    - m.login.token
-                  description: The login type being used.
+                  description: |-
+                    The login type being used.
+
+                    This must be a type returned in one of the flows of the
+                    response of the [`GET /login`](/client-server-api/#get_matrixclientv3login)
+                    endpoint, like `m.login.password`, `m.login.token` or
+                    `m.login.sso`.
                 identifier:
                   $ref: definitions/user_identifier.yaml
                 user:


### PR DESCRIPTION
Since the enum is not exhaustive, improve the description of the property instead.