### PR TITLE
Bump minimum Hugo version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ place after an MSC has been accepted, not as part of a proposal itself.
 
 1. Install the extended version (often the OS default) of Hugo:
    <https://gohugo.io/getting-started/installing>. Note that at least Hugo
-   v0.110.0 is required.
+   v0.113.0 is required.
 
    Alternatively, use the Docker image at
    https://hub.docker.com/r/klakegg/hugo/. (The "extended edition" is required

--- a/changelogs/internal/newsfragments/1788.clarification
+++ b/changelogs/internal/newsfragments/1788.clarification
@@ -1,0 +1,1 @@
+Fix Hugo warnings.


### PR DESCRIPTION
To match the one in `config.toml` changed in #1775.




<!-- Replace -->
Preview: https://pr1788--matrix-spec-previews.netlify.app
<!-- Replace -->
