### PR TITLE
Fix property type resolution in render-object-table

### DIFF
--- a/changelogs/internal/newsfragments/1789.clarification
+++ b/changelogs/internal/newsfragments/1789.clarification
@@ -1,0 +1,1 @@
+Fix property type resolution in `render-object-table` partial.

--- a/layouts/partials/openapi/render-object-table.html
+++ b/layouts/partials/openapi/render-object-table.html
@@ -78,20 +78,20 @@
 {{ end }}
 
 {{/*
-    Computes the type to display for a property, given:
+    Computes the type to display for a property's schema, given:
 
-    * `type`: string or array of strings for the type(s) of the property
+    * `type`: optional string or array of strings for the type(s) of the property
 
     * `title`: optional string for the title of the property
 
     * `oneOf`: optional array of dictionaries describing the different formats
       that the property can have
 
-    * `additionalProperties`: optional dictionary for properties with undefined
-      names
+    * `additionalProperties`: if the type is an object, optional dictionary for
+      properties with undefined names
 
-    * `patternProperties`: optional dictionary for properties with names
-      adhering to a regex pattern
+    * `patternProperties`: if the type is an object, optional dictionary for
+      properties with names adhering to a regex pattern
 
     * `items`: if the type is an array, array of dictionaries describing the
       format of the array's items
@@ -100,37 +100,59 @@
 
 */}}
 {{ define "partials/property-type" }}
-    {{ $type := .type }}
+    {{ $type := "" }}
 
-    {{ if or (eq .type "object") (and .oneOf (reflect.IsSlice .oneOf)) }}
-        {{ $type = partial "type-or-title" . }}
-    {{ end }}
-
-    {{/*
-        If the property is an array, indicate this with square brackets,
-        like `[type]`.
-    */}}
-    {{ if eq .type "array"}}
+    {{ if eq .type "object" }}
+        {{/* Resolve the type or title of the object */}}
+        {{ $type = partial "object-type-or-title" . }}
+    {{ else if eq .type "array"}}
+        {{/*
+            If the property is an array, indicate this with square brackets,
+            like `[type]`.
+        */}}
         {{ $items := .items }}
         {{ if .items }}
             {{ $items = partial "json-schema/resolve-allof" .items }}
         {{ end }}
-        {{ $inner_type := partial "type-or-title" $items }}
+        {{ $inner_type := partial "property-type" $items }}
         {{ $type = delimit (slice "[" $inner_type "]") "" }}
+    {{ else if or (reflect.IsSlice .type) .oneOf }}
+        {{/*
+            It's legal to specify an array of types.
+            
+            There are two ways to do that:
+              - Use an array of strings.
+              - Use oneOf, with items having a schema.
+
+            Join them together in that case, like `type|other_type`.
+        */}}
+        {{ $types := slice }}
+
+        {{ if .oneOf }}
+            {{ range .oneOf }}
+                {{ $types = $types | append (partial "property-type" .) }}
+            {{ end }}
+        {{ else }}
+            {{ range .type }}
+                {{ $types = $types | append . }}
+            {{ end }}
+        {{ end }}
+
+        {{ $type = delimit $types "|" }}
+    {{ else }}
+        {{/* A simple type like string or boolean */}}
+        {{ $type = .type }}
     {{ end }}
 
     {{ return $type }}
 {{ end }}
 
 {{/*
-    Computes the type to display for a property's schema, given:
+    Computes the type to display for an object property's schema, given:
 
-    * `type`: string or array of strings for the type(s) of the property
+    * `type`: string equal to "object"
 
-    * `title`: optional string for the title of the property
-
-    * `oneOf`: optional array of dictionaries describing the different formats
-      that the property can have
+    * `title`: optional string for the title of the object property
 
     * `additionalProperties`: optional dictionary for properties with undefined
       names
@@ -142,8 +164,8 @@
 
     The title has a higher priority than anything else.
 */}}
-{{ define "partials/type-or-title" }}
-    {{ $type := "" }}
+{{ define "partials/object-type-or-title" }}
+    {{ $type := "object" }}
     {{ if .title }}
         {{/*
             If the property has a `title`, use that rather than `type`.
@@ -176,32 +198,8 @@
         {{ end }}
 
         {{ $type = delimit (slice "{string: " (delimit $types "|") "}" ) "" }}
-    {{ else if reflect.IsSlice .type }}
-        {{/* It's legal to specify an array of types. Join them together in that case */}}
-
-        {{ $types := slice }}
-
-        {{ range .type }}
-            {{ $types = $types | append . }}
-        {{ end }}
-
-        {{ $type = delimit $types "|" }}
-    {{ else if and .oneOf (reflect.IsSlice .oneOf) }}
-        {{/*
-            This is like an array of types except some of the types probably have a schema.
-            Join them together too.
-        */}}
-
-        {{ $types := slice }}
-
-        {{ range .oneOf }}
-            {{ $types = $types | append (partial "type-or-title" .) }}
-        {{ end }}
-
-        {{ $type = delimit $types "|" }}
-    {{ else }}
-        {{ $type = .type }}
     {{ end }}
+
     {{ return $type }}
 {{ end }}
 


### PR DESCRIPTION
The split was not clear between property-type and type-or-title, so it was not obvious which partial should be called for recursion. That resulted in an error where type-or-title was only called for objects and array items, even if it also resolves arrays of types.

This makes the split clearer. property-type must be called for any schema, and object-type-or-title is only called for object schemas.

This fixes some rendering in the CS API, for example the `displayname` of `m.room.member`:

Before:

![image](https://github.com/matrix-org/matrix-spec/assets/76261501/29fc0114-a5c4-4ede-a0f7-1f11e577f6c4)

After:

![image](https://github.com/matrix-org/matrix-spec/assets/76261501/043cdf17-2fd2-4cf3-a5af-220c1f2e99e3)


Also the `value` of a `PushCondition`:

Before:

![image](https://github.com/matrix-org/matrix-spec/assets/76261501/c9123842-1f7d-42ac-b0f9-014b55cf091a)

After:

![image](https://github.com/matrix-org/matrix-spec/assets/76261501/0cc4c8eb-37d2-47f1-a0a0-9dc63e18a6f9)


<!-- Replace -->
Preview: https://pr1789--matrix-spec-previews.netlify.app
<!-- Replace -->
