### PR TITLE
Factor out common definition of `Tag` type

### DIFF
--- a/changelogs/internal/newsfragments/1793.misc
+++ b/changelogs/internal/newsfragments/1793.misc
@@ -1,0 +1,1 @@
+Factor out common definition of `Tag` type.

--- a/data/api/client-server/definitions/tag.yaml
+++ b/data/api/client-server/definitions/tag.yaml
@@ -1,0 +1,24 @@
+# Copyright 2020-2024 The Matrix.org Foundation C.I.C.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+title: Tag
+type: object
+properties:
+  order:
+    type: number
+    format: float
+    description: |-
+      A number in a range `[0,1]` describing a relative
+      position of the room under the given tag.
+    example: 0.25

--- a/data/api/client-server/tags.yaml
+++ b/data/api/client-server/tags.yaml
@@ -53,16 +53,7 @@ paths:
                   tags:
                     type: object
                     additionalProperties:
-                      title: Tag
-                      type: object
-                      properties:
-                        order:
-                          type: number
-                          format: float
-                          description: |-
-                            A number in a range `[0,1]` describing a relative
-                            position of the room under the given tag.
-                      additionalProperties: true
+                      $ref: definitions/tag.yaml
               examples:
                 response:
                   value: {
@@ -114,18 +105,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                order:
-                  type: number
-                  format: float
-                  description: |-
-                    A number in a range `[0,1]` describing a relative
-                    position of the room under the given tag.
-              additionalProperties: true
-              example: {
-                "order": 0.25
-              }
+              $ref: definitions/tag.yaml
         description: Extra data for the tag, e.g. ordering.
         required: true
       responses:

--- a/data/event-schemas/schema/m.tag.yaml
+++ b/data/event-schemas/schema/m.tag.yaml
@@ -17,16 +17,7 @@
           "type": "object",
           "description": "The tags on the room and their contents.",
           "additionalProperties": {
-            "title": "Tag",
-            "type": "object",
-            "properties": {
-              "order": {
-                "type": "number",
-                "format": "float",
-                "description":
-                  "A number in a range `[0,1]` describing a relative position of the room under the given tag."
-              }
-            }
+            "$ref": "../../api/client-server/definitions/tag.yaml"
           }
         }
       }


### PR DESCRIPTION
... and remove spurious `additionalProperties: true`. Aside from that being the default for all JSON objects, it's also misleading since we don't normally add additional properties to tags.