### PR TITLE
Upgrade version of Hugo used to build the spec in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -268,7 +268,8 @@ jobs:
       - name: "➕ Setup Hugo"
         uses: peaceiris/actions-hugo@16361eb4acea8698b220b76c0d4e84e1fd22c61d
         with:
-          hugo-version: '0.113.0'
+          # Cannot build the spec with Hugo 0.125.0 because of https://github.com/google/docsy/issues/1930
+          hugo-version: '0.124.1'
           extended: true
       - name: "📥 Source checkout"
         uses: actions/checkout@v4

--- a/changelogs/internal/newsfragments/1794.clarification
+++ b/changelogs/internal/newsfragments/1794.clarification
@@ -1,0 +1,1 @@
+Update the version of Hugo used to render the spec to v0.124.1.

--- a/layouts/partials/openapi/render-object-table.html
+++ b/layouts/partials/openapi/render-object-table.html
@@ -46,7 +46,7 @@
 
  <tr>
   <td><code>{{ $property_name }}</code></td>
-  <td><code>{{ partial "partials/property-type" $property }}</code></td>
+  <td><code>{{ partial "partials/property-type" $property | safeHTML }}</code></td>
   <td>{{ partial "partials/property-description" (dict "property" $property "required" $required) }}</td>
  </tr>
 
@@ -67,7 +67,7 @@
  {{ $property := . }}
 
  <tr>
-  <td><code>{{ partial "partials/property-type" $property }}</code></td>
+  <td><code>{{ partial "partials/property-type" $property | safeHTML }}</code></td>
   <td>{{ partial "partials/property-description" (dict "property" $property) }}</td>
  </tr>
 </table>
@@ -128,14 +128,14 @@
             {{ end }}
         {{ else }}
             {{ range .type }}
-                {{ $types = $types | append . }}
+                {{ $types = $types | append (htmlEscape .) }}
             {{ end }}
         {{ end }}
 
         {{ $type = delimit $types "|" }}
     {{ else }}
         {{/* A simple type like string or boolean */}}
-        {{ $type = .type }}
+        {{ $type = (htmlEscape .type) }}
     {{ end }}
 
     {{ return $type }}
@@ -165,9 +165,9 @@
             If the property has a `title`, use that rather than `type`.
             This means we can write things like `EventFilter` rather than `object`.
         */}}
-        {{ $type = .title }}
+        {{ $type = .title | htmlEscape }}
         {{ if .anchor }}
-            {{ $type = printf "<a href=\"#%s\">%s</a>" (htmlEscape .anchor) (htmlEscape $type) | safeHTML }}
+            {{ $type = printf "<a href=\"#%s\">%s</a>" (htmlEscape .anchor) $type }}
         {{ end }}
     {{ else if reflect.IsMap .additionalProperties }}
         {{/*


### PR DESCRIPTION
Bumped to Hugo 0.124.1, because there is an incompatibility with docsy in the latest version (0.125.0): https://github.com/google/docsy/issues/1930.

The second commit is a fix for the rendered spec in the `render-object-table` partial.

The behavior of `delimit` changed, Hugo doesn't recognize "safe" HTML passed to it anymore, so it escapes nested HTML links even if they were marked as "safe", like this:

![image](https://github.com/matrix-org/matrix-spec/assets/76261501/28fcd62c-3c93-43a1-b634-68081c1661df)

To fix that we escape the schema data manually and consider the output of the `property-type` partial as "safe".

I usually do a diff to check if there are visible changes in the rendered spec. Sadly, it seems that the way that URLs are built has changed (most of them are absolute now when they where relative before), so the diff is filled with that. I didn't notice any other change in the rendered spec though.




<!-- Replace -->
Preview: https://pr1794--matrix-spec-previews.netlify.app
<!-- Replace -->
