### PR TITLE
Clean up unecessary `allOf`s

### DIFF
--- a/changelogs/internal/newsfragments/1797.clarification
+++ b/changelogs/internal/newsfragments/1797.clarification
@@ -1,0 +1,1 @@
+Clean up unnecessary `allOf`s in OpenAPI definitions.

--- a/data/api/client-server/definitions/push_ruleset.yaml
+++ b/data/api/client-server/definitions/push_ruleset.yaml
@@ -14,37 +14,22 @@
 properties:
   content:
     items:
-      allOf:
-      - $ref: push_rule.yaml
-      title: PushRule
-      type: object
+      $ref: push_rule.yaml
     type: array
   override:
     items:
-      allOf:
-      - $ref: push_rule.yaml
-      title: PushRule
-      type: object
+      $ref: push_rule.yaml
     type: array
   room:
     items:
-      allOf:
-      - $ref: push_rule.yaml
-      title: PushRule
-      type: object
+      $ref: push_rule.yaml
     type: array
   sender:
     items:
-      allOf:
-      - $ref: push_rule.yaml
-      title: PushRule
-      type: object
+      $ref: push_rule.yaml
     type: array
   underride:
     items:
-      allOf:
-      - $ref: push_rule.yaml
-      title: PushRule
-      type: object
+      $ref: push_rule.yaml
     type: array
 type: object

--- a/data/api/client-server/definitions/room_key_backup.yaml
+++ b/data/api/client-server/definitions/room_key_backup.yaml
@@ -20,8 +20,7 @@ properties:
     type: object
     description: "A map of session IDs to key data."
     additionalProperties:
-      allOf:
-        - $ref: "key_backup_data.yaml"
+      $ref: "key_backup_data.yaml"
     example: {
       "sessionid1": {
         "first_message_index": 1,

--- a/data/api/client-server/device_management.yaml
+++ b/data/api/client-server/device_management.yaml
@@ -36,9 +36,7 @@ paths:
                     type: array
                     description: A list of all registered devices for this user.
                     items:
-                      type: object
-                      allOf:
-                        - $ref: definitions/client_device.yaml
+                      $ref: definitions/client_device.yaml
               examples:
                 response:
                   value: {
@@ -75,9 +73,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                allOf:
-                  - $ref: definitions/client_device.yaml
+                $ref: definitions/client_device.yaml
               examples:
                 response:
                   value: {

--- a/data/api/client-server/filter.yaml
+++ b/data/api/client-server/filter.yaml
@@ -143,9 +143,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                allOf:
-                  - $ref: definitions/sync_filter.yaml
+                $ref: definitions/sync_filter.yaml
               examples:
                 response:
                   value: {

--- a/data/api/client-server/key_backup.yaml
+++ b/data/api/client-server/key_backup.yaml
@@ -841,8 +841,7 @@ paths:
                   type: object
                   description: A map of room IDs to room key backup data.
                   additionalProperties:
-                    allOf:
-                      - $ref: definitions/room_key_backup.yaml
+                    $ref: definitions/room_key_backup.yaml
                   example:
                     "!room:example.org":
                       sessions:
@@ -946,8 +945,7 @@ paths:
                     type: object
                     description: A map of room IDs to room key backup data.
                     additionalProperties:
-                      allOf:
-                        - $ref: definitions/room_key_backup.yaml
+                      $ref: definitions/room_key_backup.yaml
                     example:
                       "!room:example.org":
                         sessions:

--- a/data/api/client-server/keys.yaml
+++ b/data/api/client-server/keys.yaml
@@ -226,8 +226,7 @@ paths:
                       uploaded via `/keys/signatures/upload` that the requesting user
                       is allowed to see.
                     additionalProperties:
-                      allOf:
-                        - $ref: definitions/cross_signing_key.yaml
+                      $ref: definitions/cross_signing_key.yaml
                     example:
                       "@alice:example.com":
                         user_id: "@alice:example.com"
@@ -244,8 +243,7 @@ paths:
                       information returned will be the same as uploaded via
                       `/keys/device_signing/upload`.
                     additionalProperties:
-                      allOf:
-                        - $ref: definitions/cross_signing_key.yaml
+                      $ref: definitions/cross_signing_key.yaml
                     example:
                       "@alice:example.com":
                         user_id: "@alice:example.com"
@@ -265,8 +263,7 @@ paths:
                       information returned will be the same as uploaded via
                       `/keys/device_signing/upload`.
                     additionalProperties:
-                      allOf:
-                        - $ref: definitions/cross_signing_key.yaml
+                      $ref: definitions/cross_signing_key.yaml
                     example:
                       "@alice:example.com":
                         user_id: "@alice:example.com"

--- a/data/api/client-server/pushrules.yaml
+++ b/data/api/client-server/pushrules.yaml
@@ -470,9 +470,7 @@ paths:
                     rule to be applied to an event. A rule with no conditions
                     always matches. Only applicable to `underride` and `override` rules.
                   items:
-                    type: object
-                    allOf:
-                      - $ref: definitions/push_condition.yaml
+                    $ref: definitions/push_condition.yaml
                 pattern:
                   type: string
                   description: Only applicable to `content` rules. The glob-style pattern to match

--- a/data/api/server-server/knocks.yaml
+++ b/data/api/server-server/knocks.yaml
@@ -171,8 +171,7 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: ../client-server/definitions/errors/error.yaml
+                $ref: ../client-server/definitions/errors/error.yaml
               examples:
                 response:
                   value: {
@@ -186,8 +185,7 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: ../client-server/definitions/errors/error.yaml
+                $ref: ../client-server/definitions/errors/error.yaml
               examples:
                 response:
                   value: {
@@ -318,8 +316,7 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: ../client-server/definitions/errors/error.yaml
+                $ref: ../client-server/definitions/errors/error.yaml
               examples:
                 response:
                   value: {
@@ -333,8 +330,7 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: ../client-server/definitions/errors/error.yaml
+                $ref: ../client-server/definitions/errors/error.yaml
               examples:
                 response:
                   value: {

--- a/data/api/server-server/user_keys.yaml
+++ b/data/api/server-server/user_keys.yaml
@@ -178,8 +178,7 @@ paths:
                       uploaded via `/keys/signatures/upload` that the user is
                       allowed to see.
                     additionalProperties:
-                      allOf:
-                        - $ref: ../client-server/definitions/cross_signing_key.yaml
+                      $ref: ../client-server/definitions/cross_signing_key.yaml
                     example:
                       "@alice:example.com":
                         user_id: "@alice:example.com"
@@ -196,8 +195,7 @@ paths:
                       information returned will be the same as uploaded via
                       `/keys/device_signing/upload`.
                     additionalProperties:
-                      allOf:
-                        - $ref: ../client-server/definitions/cross_signing_key.yaml
+                      $ref: ../client-server/definitions/cross_signing_key.yaml
                     example:
                       "@alice:example.com":
                         user_id: "@alice:example.com"

--- a/data/event-schemas/schema/m.call.reject.yaml
+++ b/data/event-schemas/schema/m.call.reject.yaml
@@ -18,9 +18,7 @@ allOf:
 - "$ref": core-event-schema/room_event.yaml
 properties:
   content:
-    type: object
-    allOf:
-    - "$ref": core-event-schema/call_event.yaml
+    "$ref": core-event-schema/call_event.yaml
   type:
     type: string
     enum:

--- a/data/event-schemas/schema/m.key.verification.accept.yaml
+++ b/data/event-schemas/schema/m.key.verification.accept.yaml
@@ -44,8 +44,7 @@ properties:
           ephemeral public key (encoded as unpadded base64) and the canonical JSON
           representation of the `m.key.verification.start` message.
       m.relates_to:
-        allOf:
-          - $ref: m.key.verification.m.relates_to.yaml
+        $ref: m.key.verification.m.relates_to.yaml
     required:
       - method
       - key_agreement_protocol

--- a/data/event-schemas/schema/m.key.verification.cancel.yaml
+++ b/data/event-schemas/schema/m.key.verification.cancel.yaml
@@ -58,8 +58,7 @@ properties:
           respond again with `m.unexpected_message` to avoid the other device potentially
           sending another error response.
       m.relates_to:
-        allOf:
-          - $ref: m.key.verification.m.relates_to.yaml
+        $ref: m.key.verification.m.relates_to.yaml
     required:
       - code
       - reason

--- a/data/event-schemas/schema/m.key.verification.done.yaml
+++ b/data/event-schemas/schema/m.key.verification.done.yaml
@@ -13,8 +13,7 @@ properties:
           Required when sent as a to-device message. The opaque identifier for
           the verification process/request.
       m.relates_to:
-        allOf:
-          - $ref: m.key.verification.m.relates_to.yaml
+        $ref: m.key.verification.m.relates_to.yaml
     type: object
   type:
     enum:

--- a/data/event-schemas/schema/m.key.verification.key.yaml
+++ b/data/event-schemas/schema/m.key.verification.key.yaml
@@ -18,8 +18,7 @@ properties:
         description: |-
           The device's ephemeral public key, encoded as unpadded base64.
       m.relates_to:
-        allOf:
-          - $ref: m.key.verification.m.relates_to.yaml
+        $ref: m.key.verification.m.relates_to.yaml
     required:
       - key
     type: object

--- a/data/event-schemas/schema/m.key.verification.mac.yaml
+++ b/data/event-schemas/schema/m.key.verification.mac.yaml
@@ -29,8 +29,7 @@ properties:
           The MAC of the comma-separated, sorted, list of key IDs given in the `mac`
           property, encoded as unpadded base64.
       m.relates_to:
-        allOf:
-          - $ref: m.key.verification.m.relates_to.yaml
+        $ref: m.key.verification.m.relates_to.yaml
     required:
       - mac
       - keys

--- a/data/event-schemas/schema/m.key.verification.ready.yaml
+++ b/data/event-schemas/schema/m.key.verification.ready.yaml
@@ -27,8 +27,7 @@ properties:
         items:
           type: string
       m.relates_to:
-        allOf:
-          - $ref: m.key.verification.m.relates_to.yaml
+        $ref: m.key.verification.m.relates_to.yaml
     required:
       - from_device
       - methods

--- a/data/event-schemas/schema/m.key.verification.start$m.reciprocate.v1.yaml
+++ b/data/event-schemas/schema/m.key.verification.start$m.reciprocate.v1.yaml
@@ -30,8 +30,7 @@ properties:
         description: |-
           The shared secret from the QR code, encoded using unpadded base64.
       m.relates_to:
-        allOf:
-          - $ref: m.key.verification.m.relates_to.yaml
+        $ref: m.key.verification.m.relates_to.yaml
     required:
       - from_device
       - method

--- a/data/event-schemas/schema/m.key.verification.start$m.sas.v1.yaml
+++ b/data/event-schemas/schema/m.key.verification.start$m.sas.v1.yaml
@@ -58,8 +58,7 @@ properties:
           type: string
           enum: ["decimal", "emoji"]
       m.relates_to:
-        allOf:
-          - $ref: m.key.verification.m.relates_to.yaml
+        $ref: m.key.verification.m.relates_to.yaml
     required:
       - from_device
       - method

--- a/data/event-schemas/schema/m.key.verification.start.yaml
+++ b/data/event-schemas/schema/m.key.verification.start.yaml
@@ -32,8 +32,7 @@ properties:
           when the `method` chosen only verifies one user's key. This field will
           never be present if the `method` verifies keys both ways.
       m.relates_to:
-        allOf:
-          - $ref: m.key.verification.m.relates_to.yaml
+        $ref: m.key.verification.m.relates_to.yaml
     required:
       - from_device
       - method


### PR DESCRIPTION
Most of them were unnecessary to begin with. A few of them were necessary given the definition, but it turns out that the fields were duplicates to the ones in the `$ref`.




<!-- Replace -->
Preview: https://pr1797--matrix-spec-previews.netlify.app
<!-- Replace -->
