### PR TITLE
Fix anchors for schemas under `oneOf`

### DIFF
--- a/changelogs/internal/newsfragments/1799.clarification
+++ b/changelogs/internal/newsfragments/1799.clarification
@@ -1,0 +1,1 @@
+Fix anchors for schemas under `oneOf`.

--- a/layouts/partials/json-schema/resolve-additional-types.html
+++ b/layouts/partials/json-schema/resolve-additional-types.html
@@ -165,6 +165,7 @@
      * (https://json-schema.org/understanding-json-schema/reference/combining.html#oneof)
      */
     {{ if $this_object.oneOf }}
+        {{ $updated_items := slice }}
         {{ range $idx, $item := $this_object.oneOf }}
             {{ $res := partial "get-additional-objects" (dict
                 "this_object" $item
@@ -173,7 +174,11 @@
                 "name" (printf "%s.oneOf[%d]" $name $idx)
             ) }}
             {{ $all_objects = $res.objects }}
+            {{ $updated_items = $updated_items | append $res.schema }}
         {{ end }}
+
+        /* Update the top-level schema with the updated subschemas for the items */
+        {{ $this_object = merge $this_object (dict "oneOf" $updated_items) }}
     {{ end }}
 
     {{ return (dict


### PR DESCRIPTION
The subschemas were not updated in the parent schema, so the anchor would not be forwarded to the parent schema and the link to the subschema won't be rendered.

This results in 2 changes in the rendered spec:

For `m.room.encrypted`:

[Before](https://spec.matrix.org/v1.10/client-server-api/#mroomencrypted):

![image](https://github.com/matrix-org/matrix-spec/assets/76261501/9cc10571-0278-44f6-93bf-6e4049a297e0)

[After](https://pr1799--matrix-spec-previews.netlify.app/client-server-api/#mroomencrypted):

![image](https://github.com/matrix-org/matrix-spec/assets/76261501/6543868b-9e20-460d-879a-86e3c0290d64)


For `POST /_matrix/federation/v1/user/keys/claim`:

[Before](https://spec.matrix.org/v1.10/server-server-api/#post_matrixfederationv1userkeysclaim):

![image](https://github.com/matrix-org/matrix-spec/assets/76261501/1d367c19-3995-41be-a0bd-1920854ac666)

[After](https://pr1799--matrix-spec-previews.netlify.app/server-server-api/#post_matrixfederationv1userkeysclaim):

![image](https://github.com/matrix-org/matrix-spec/assets/76261501/67b1202f-9335-4903-b9c9-3343a3697bad)






<!-- Replace -->
Preview: https://pr1799--matrix-spec-previews.netlify.app
<!-- Replace -->
