### PR TITLE
Add anchors in `definition` shortcode

### DIFF
--- a/changelogs/internal/newsfragments/1802.clarification
+++ b/changelogs/internal/newsfragments/1802.clarification
@@ -1,0 +1,1 @@
+Add anchors in `definition` shortcode.

--- a/layouts/shortcodes/definition.html
+++ b/layouts/shortcodes/definition.html
@@ -26,7 +26,9 @@
 {{ $definition = partial "json-schema/resolve-refs" (dict "schema" $definition "path" $path) }}
 {{ $definition = partial "json-schema/resolve-allof" $definition }}
 
-<section class="rendered-data definition" id="definition-{{ anchorize $definition.title }}">
+{{ $anchor_base := printf "definition-%s" (anchorize $definition.title) }}
+
+<section class="rendered-data definition" id="{{ $anchor_base }}">
 
 <details {{ if not $compact }}open{{ end }}>
 <summary>
@@ -46,7 +48,11 @@
 {{ $definition.description | markdownify }}
 
 
-{{ $additional_types := partial "json-schema/resolve-additional-types" (dict "schema" $definition "name" (printf "\"%s\"" $path)) }}
+{{ $additional_types := partial "json-schema/resolve-additional-types" (dict
+    "schema" $definition
+    "anchor_base" $anchor_base
+    "name" (printf "\"%s\"" $path))
+}}
 
 {{ range $additional_types }}
     {{ partial "openapi/render-object-table" . }}


### PR DESCRIPTION
Allows to link to subschemas when using this shortcode.

For example, for `m.receipt`:

[Before](https://spec.matrix.org/v1.10/server-server-api/#definition-mreceipt):

![image](https://github.com/matrix-org/matrix-spec/assets/76261501/8219e92b-7539-4046-854d-e4782b66d67d)

After:

![image](https://github.com/matrix-org/matrix-spec/assets/76261501/ce4074cf-6814-4489-a6d8-063d293e93f2)


<!-- Replace -->
Preview: https://pr1802--matrix-spec-previews.netlify.app
<!-- Replace -->
