### PR TITLE
Set python version for the Towncrier CI job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -167,6 +167,8 @@ jobs:
         uses: actions/checkout@v4
       - name: "➕ Setup Python"
         uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
       - name: "➕ Install towncrier"
         run: "pip install 'towncrier'"
       - name: "Generate changelog"

--- a/changelogs/internal/newsfragments/1805.clarification
+++ b/changelogs/internal/newsfragments/1805.clarification
@@ -1,0 +1,1 @@
+Set python version for the Towncrier CI job.


### PR DESCRIPTION
Otherwise the version might change depending on the runner. We just use the same version as other jobs.

This removes a GitHub warning.




<!-- Replace -->
Preview: https://pr1805--matrix-spec-previews.netlify.app
<!-- Replace -->
