### PR TITLE
Mention notifying AS for sender_localpart events

### DIFF
--- a/changelogs/application_service/newsfragments/1810.clarification
+++ b/changelogs/application_service/newsfragments/1810.clarification
@@ -1,0 +1,1 @@
+Clarify that appservices should be notified of events relating to the sender_localpart user.

--- a/data/api/application-service/definitions/registration.yaml
+++ b/data/api/application-service/definitions/registration.yaml
@@ -42,7 +42,7 @@ properties:
           - $ref: namespace_list.yaml
           - description: |-
               A list of namespaces defining the user IDs that the application
-              service is interested in, in addition to it's `sender_localpart`.
+              service is interested in, in addition to its `sender_localpart`.
               Events will be sent to the AS if a local user matching one of the
               namespaces is the target of the event, or is a joined member of
               the room where the event occurred.

--- a/data/api/application-service/definitions/registration.yaml
+++ b/data/api/application-service/definitions/registration.yaml
@@ -29,7 +29,9 @@ properties:
     description: A secret token that the homeserver will use authenticate requests to the application service.
   sender_localpart:
     type: string
-    description: The localpart of the user associated with the application service.
+    description: |-
+      The localpart of the user associated with the application service. Events will be sent to the AS if this user is the target of the event, or
+      is a joined member of the room where the event occurred.
   namespaces:
     type: object
     title: Namespaces
@@ -40,9 +42,10 @@ properties:
           - $ref: namespace_list.yaml
           - description: |-
               A list of namespaces defining the user IDs that the application
-              service is interested in. Events will be sent to the AS if a
-              local user matching one of the namespaces is the target of the event,
-              or is a joined member of the room where the event occurred.
+              service is interested in, in addition to it's `sender_localpart`.
+              Events will be sent to the AS if a local user matching one of the
+              namespaces is the target of the event, or is a joined member of
+              the room where the event occurred.
       rooms:
         allOf:
           - $ref: namespace_list.yaml


### PR DESCRIPTION
Conduit and Synapse already do this, and appservices such as Draupnir depend on this behavior.










<!-- Replace -->
Preview: https://pr1810--matrix-spec-previews.netlify.app
<!-- Replace -->
