### PR TITLE
Add support for rendering string formats

### DIFF
--- a/changelogs/internal/newsfragments/1814.clarification
+++ b/changelogs/internal/newsfragments/1814.clarification
@@ -1,0 +1,1 @@
+Add support for rendering string formats.

--- a/data/custom-formats.yaml
+++ b/data/custom-formats.yaml
@@ -31,3 +31,8 @@ mx-event-id:
   title: Event ID
   url: /appendices#event-ids
   # regex: "^\\$"
+
+uri:
+  title: URI
+  url: http://tools.ietf.org/html/rfc3986
+  # no regex

--- a/layouts/partials/openapi/render-object-table.html
+++ b/layouts/partials/openapi/render-object-table.html
@@ -128,6 +128,8 @@ resolve-additional-types.)
 
     * `anchor`: optional HTML element id for the target type, which will be used to link to it.
 
+    * `format`: optional string for the format of the type, used for strings.
+
 */}}
 {{ define "partials/property-type" }}
     {{ $type := "" }}
@@ -143,6 +145,15 @@ resolve-additional-types.)
         {{ $items := .items }}
         {{ $inner_type := partial "property-type" $items }}
         {{ $type = delimit (slice "[" $inner_type "]") "" }}
+    {{ else if eq .type "string" }}
+        {{ $type = "string" }}
+
+        {{/* If the string uses a known format, use it. */}}
+        {{ with .format }}
+            {{ with partial "custom-format" . }}
+                {{ $type = . }}
+            {{ end }}
+        {{ end }}
     {{ else if or (reflect.IsSlice .type) .oneOf }}
         {{/*
             It's legal to specify an array of types.
@@ -167,7 +178,7 @@ resolve-additional-types.)
 
         {{ $type = delimit $types "|" }}
     {{ else }}
-        {{/* A simple type like string or boolean */}}
+        {{/* A simple type like integer or boolean */}}
         {{ $type = (htmlEscape .type) }}
     {{ end }}
 
@@ -241,8 +252,8 @@ resolve-additional-types.)
         {{ range $formatId, $formatType := $formatMap.Values }}
             {{ $formatKey := "string" }}
             {{ if ne $formatId "string" }}
-                {{ with index site.Data "custom-formats" $formatId }}
-                    {{ $formatKey = printf "<a href=\"%s\">%s</a>" (htmlEscape .url) (htmlEscape .title) }}
+                {{ with partial "custom-format" $formatId }}
+                    {{ $formatKey = . }}
                 {{ else }}
                     {{ errorf "Unsupported value for `x-pattern-format`: %s" $formatId }}
                 {{ end }}
@@ -289,4 +300,19 @@ resolve-additional-types.)
     {{ if .property.enum }}<p>One of: <code>[{{ delimit .property.enum ", " }}]</code>.</p>{{ end -}}
     {{ if (index .property "x-addedInMatrixVersion") }}{{ partial "added-in" (dict "v" (index .property "x-addedInMatrixVersion")) }}{{ end -}}
     {{ if (index .property "x-changedInMatrixVersion") }}{{ partial "changed-in" (dict "changes_dict" (index .property "x-changedInMatrixVersion")) }}{{ end -}}
+{{ end }}
+
+
+{{/*
+    Computes the type to display for a string format, given the identifier of
+    the format as a string.
+*/}} 
+{{ define "partials/custom-format" }}
+  {{ $customFormat := "" }}
+
+  {{ with index site.Data "custom-formats" . }}
+    {{ $customFormat = printf "<a href=\"%s\">%s</a>" (htmlEscape .url) (htmlEscape .title) }}
+  {{ end }}
+
+  {{ return $customFormat }}
 {{ end }}


### PR DESCRIPTION
Similar to #1796, but for property values instead of property names. Currently only non-custom formats are defined for strings in OpenAPI definitions so I decided to add support for the `uri` format to have something to see.

[For example](https://pr1814--matrix-spec-previews.netlify.app/client-server-api/#well-knownmatrixclient_homeserver-information):

![image](https://github.com/matrix-org/matrix-spec/assets/76261501/38df9330-df66-4b0a-ad66-a8bb60af9cc6)


<!-- Replace -->
Preview: https://pr1814--matrix-spec-previews.netlify.app
<!-- Replace -->
