### PR TITLE
Clarify that redaction events are subject to auth rules

### DIFF
--- a/changelogs/room_versions/newsfragments/1824.clarification
+++ b/changelogs/room_versions/newsfragments/1824.clarification
@@ -1,0 +1,1 @@
+Clarify that redaction events are still subject to all applicable auth rules.

--- a/content/rooms/fragments/v8-auth-rules.md
+++ b/content/rooms/fragments/v8-auth-rules.md
@@ -24,7 +24,7 @@ level_ is **not** considered by the auth rules.
 
 The ability to send a redaction event does not mean that the redaction itself should
 be performed. Receiving servers must perform additional checks, as described in
-the [Handling Redactions](#handling-redactions) section below.
+the [Handling Redactions](#handling-redactions) section.
 {{% /boxes/note %}}
 
 The rules are as follows:

--- a/content/rooms/fragments/v8-auth-rules.md
+++ b/content/rooms/fragments/v8-auth-rules.md
@@ -1,11 +1,9 @@
 
 Events must be signed by the server denoted by the `sender` property.
 
-`m.room.redaction` events are not explicitly part of the auth rules.
-They are still subject to the minimum power level rules, but should always
-fall into "10. Otherwise, allow". Instead of being authorized at the time
-of receipt, they are authorized at a later stage: see the
-[Redactions](#redactions) section below for more information.
+While they are still subject to them, there are no auth rules specifically for
+`m.room.redaction` events. The actual redaction of content is authorized at a
+later stage: see the [Redactions](#redactions) section below for more information.
 
 The types of state events that affect authorization are:
 

--- a/content/rooms/fragments/v8-auth-rules.md
+++ b/content/rooms/fragments/v8-auth-rules.md
@@ -19,8 +19,8 @@ the default power level for users in the room.
 `m.room.redaction` events are subject to auth rules in the same way as any other event.
 In practice, that means they will normally be allowed by the auth rules, unless the
 `m.room.power_levels` event sets a power level requirement for `m.room.redaction`
-events via the `events` or `events_default` properties. In particular, the /redact
-level/ is **not** considered by the auth rules.
+events via the `events` or `events_default` properties. In particular, the _redact
+level_ is **not** considered by the auth rules.
 
 The ability to send a redaction event does not mean that the redaction itself should
 be performed. Receiving servers must perform additional checks, as described in

--- a/content/rooms/fragments/v8-auth-rules.md
+++ b/content/rooms/fragments/v8-auth-rules.md
@@ -1,10 +1,6 @@
 
 Events must be signed by the server denoted by the `sender` property.
 
-While they are still subject to them, there are no auth rules specifically for
-`m.room.redaction` events. The actual redaction of content is authorized at a
-later stage: see the [Redactions](#redactions) section below for more information.
-
 The types of state events that affect authorization are:
 
 -   [`m.room.create`](/client-server-api#mroomcreate)
@@ -17,6 +13,18 @@ The types of state events that affect authorization are:
 Power levels are inferred from defaults when not explicitly supplied.
 For example, mentions of the `sender`'s power level can also refer to
 the default power level for users in the room.
+{{% /boxes/note %}}
+
+{{% boxes/note %}}
+`m.room.redaction` events are subject to auth rules in the same way as any other event.
+In practice, that means they will normally be allowed by the auth rules, unless the
+`m.room.power_levels` event sets a power level requirement for `m.room.redaction`
+events via the `events` or `events_default` properties. In particular, the /redact
+level/ is **not** considered by the auth rules.
+
+The ability to send a redaction event does not mean that the redaction itself should
+be performed. Receiving servers must perform additional checks, as described in
+the [Handling Redactions](#handling-redactions) section below.
 {{% /boxes/note %}}
 
 The rules are as follows:

--- a/content/rooms/v10.md
+++ b/content/rooms/v10.md
@@ -99,7 +99,7 @@ level_ is **not** considered by the auth rules.
 
 The ability to send a redaction event does not mean that the redaction itself should
 be performed. Receiving servers must perform additional checks, as described in
-the [Handling redactions](#handling-redactions) section below.
+the [Handling redactions](#handling-redactions) section.
 {{% /boxes/note %}}
 
 The rules are as follows:

--- a/content/rooms/v10.md
+++ b/content/rooms/v10.md
@@ -76,10 +76,6 @@ correctly structured are rejected under the authorization rules below.
 
 Events must be signed by the server denoted by the `sender` property.
 
-While they are still subject to them, there are no auth rules specifically for
-`m.room.redaction` events. The actual redaction of content is authorized at a
-later stage: see the [Redactions](#redactions) section below for more information.
-
 The types of state events that affect authorization are:
 
 -   [`m.room.create`](/client-server-api#mroomcreate)
@@ -92,6 +88,18 @@ The types of state events that affect authorization are:
 Power levels are inferred from defaults when not explicitly supplied.
 For example, mentions of the `sender`'s power level can also refer to
 the default power level for users in the room.
+{{% /boxes/note %}}
+
+{{% boxes/note %}}
+`m.room.redaction` events are subject to auth rules in the same way as any other event.
+In practice, that means they will normally be allowed by the auth rules, unless the
+`m.room.power_levels` event sets a power level requirement for `m.room.redaction`
+events via the `events` or `events_default` properties. In particular, the /redact
+level/ is **not** considered by the auth rules.
+
+The ability to send a redaction event does not mean that the redaction itself should
+be performed. Receiving servers must perform additional checks, as described in
+the [Redactions](#redactions) section below.
 {{% /boxes/note %}}
 
 The rules are as follows:

--- a/content/rooms/v10.md
+++ b/content/rooms/v10.md
@@ -94,8 +94,8 @@ the default power level for users in the room.
 `m.room.redaction` events are subject to auth rules in the same way as any other event.
 In practice, that means they will normally be allowed by the auth rules, unless the
 `m.room.power_levels` event sets a power level requirement for `m.room.redaction`
-events via the `events` or `events_default` properties. In particular, the /redact
-level/ is **not** considered by the auth rules.
+events via the `events` or `events_default` properties. In particular, the _redact
+level_ is **not** considered by the auth rules.
 
 The ability to send a redaction event does not mean that the redaction itself should
 be performed. Receiving servers must perform additional checks, as described in

--- a/content/rooms/v10.md
+++ b/content/rooms/v10.md
@@ -76,11 +76,9 @@ correctly structured are rejected under the authorization rules below.
 
 Events must be signed by the server denoted by the `sender` property.
 
-`m.room.redaction` events are not explicitly part of the auth rules.
-They are still subject to the minimum power level rules, but should always
-fall into "10. Otherwise, allow". Instead of being authorized at the time
-of receipt, they are authorized at a later stage: see the
-[Redactions](#redactions) section below for more information.
+While they are still subject to them, there are no auth rules specifically for
+`m.room.redaction` events. The actual redaction of content is authorized at a
+later stage: see the [Redactions](#redactions) section below for more information.
 
 The types of state events that affect authorization are:
 

--- a/content/rooms/v10.md
+++ b/content/rooms/v10.md
@@ -99,7 +99,7 @@ level_ is **not** considered by the auth rules.
 
 The ability to send a redaction event does not mean that the redaction itself should
 be performed. Receiving servers must perform additional checks, as described in
-the [Redactions](#redactions) section below.
+the [Handling redactions](#handling-redactions) section below.
 {{% /boxes/note %}}
 
 The rules are as follows:

--- a/content/rooms/v11.md
+++ b/content/rooms/v11.md
@@ -101,8 +101,8 @@ the default power level for users in the room.
 `m.room.redaction` events are subject to auth rules in the same way as any other event.
 In practice, that means they will normally be allowed by the auth rules, unless the
 `m.room.power_levels` event sets a power level requirement for `m.room.redaction`
-events via the `events` or `events_default` properties. In particular, the /redact
-level/ is **not** considered by the auth rules.
+events via the `events` or `events_default` properties. In particular, the _redact
+level_ is **not** considered by the auth rules.
 
 The ability to send a redaction event does not mean that the redaction itself should
 be performed. Receiving servers must perform additional checks, as described in

--- a/content/rooms/v11.md
+++ b/content/rooms/v11.md
@@ -106,7 +106,7 @@ level_ is **not** considered by the auth rules.
 
 The ability to send a redaction event does not mean that the redaction itself should
 be performed. Receiving servers must perform additional checks, as described in
-the [Redactions](#redactions) section below.
+the [Handling redactions](#handling-redactions) section below.
 {{% /boxes/note %}}
 
 The rules are as follows:

--- a/content/rooms/v11.md
+++ b/content/rooms/v11.md
@@ -106,7 +106,7 @@ level_ is **not** considered by the auth rules.
 
 The ability to send a redaction event does not mean that the redaction itself should
 be performed. Receiving servers must perform additional checks, as described in
-the [Handling redactions](#handling-redactions) section below.
+the [Handling redactions](#handling-redactions) section.
 {{% /boxes/note %}}
 
 The rules are as follows:

--- a/content/rooms/v11.md
+++ b/content/rooms/v11.md
@@ -83,11 +83,9 @@ such events over the Client-Server API.
 
 Events must be signed by the server denoted by the `sender` property.
 
-`m.room.redaction` events are not explicitly part of the auth rules.
-They are still subject to the minimum power level rules, but should always
-fall into "10. Otherwise, allow". Instead of being authorized at the time
-of receipt, they are authorized at a later stage: see the
-[Redactions](#redactions) section below for more information.
+While they are still subject to them, there are no auth rules specifically for
+`m.room.redaction` events. The actual redaction of content is authorized at a
+later stage: see the [Redactions](#redactions) section below for more information.
 
 The types of state events that affect authorization are:
 

--- a/content/rooms/v11.md
+++ b/content/rooms/v11.md
@@ -83,10 +83,6 @@ such events over the Client-Server API.
 
 Events must be signed by the server denoted by the `sender` property.
 
-While they are still subject to them, there are no auth rules specifically for
-`m.room.redaction` events. The actual redaction of content is authorized at a
-later stage: see the [Redactions](#redactions) section below for more information.
-
 The types of state events that affect authorization are:
 
 -   [`m.room.create`](/client-server-api#mroomcreate)
@@ -99,6 +95,18 @@ The types of state events that affect authorization are:
 Power levels are inferred from defaults when not explicitly supplied.
 For example, mentions of the `sender`'s power level can also refer to
 the default power level for users in the room.
+{{% /boxes/note %}}
+
+{{% boxes/note %}}
+`m.room.redaction` events are subject to auth rules in the same way as any other event.
+In practice, that means they will normally be allowed by the auth rules, unless the
+`m.room.power_levels` event sets a power level requirement for `m.room.redaction`
+events via the `events` or `events_default` properties. In particular, the /redact
+level/ is **not** considered by the auth rules.
+
+The ability to send a redaction event does not mean that the redaction itself should
+be performed. Receiving servers must perform additional checks, as described in
+the [Redactions](#redactions) section below.
 {{% /boxes/note %}}
 
 The rules are as follows:

--- a/content/rooms/v3.md
+++ b/content/rooms/v3.md
@@ -94,7 +94,7 @@ The complete structure of a event in a v3 room is shown below.
 the same way as any other event. In practice, that means they will normally be allowed
 by the auth rules, unless the `m.room.power_levels` event sets a power level requirement
 for `m.room.redaction`events via the `events` or `events_default` properties. In
-particular, the /redact level/ is **not** considered by the auth rules.
+particular, the _redact level_ is **not** considered by the auth rules.
 
 The ability to send a redaction event does not mean that the redaction itself should
 be performed. Receiving servers must perform additional checks, as described in

--- a/content/rooms/v3.md
+++ b/content/rooms/v3.md
@@ -98,7 +98,7 @@ particular, the _redact level_ is **not** considered by the auth rules.
 
 The ability to send a redaction event does not mean that the redaction itself should
 be performed. Receiving servers must perform additional checks, as described in
-the [Handling Redactions](#handling-redactions) section below.
+the [Handling Redactions](#handling-redactions) section.
 {{% /boxes/note %}}
 
 <!-- set withVersioning=true so we get all the "new in this version" stuff -->

--- a/content/rooms/v3.md
+++ b/content/rooms/v3.md
@@ -89,12 +89,10 @@ The complete structure of a event in a v3 room is shown below.
 
 ### Authorization rules
 
-{{< added-in this=true >}} `m.room.redaction` events are no longer
-explicitly part of the auth rules. They are still subject to the
-minimum power level rules, but should always fall into "11. Otherwise,
-allow". Instead of being authorized at the time of receipt, they are
-authorized at a later stage: see the [Handling Redactions](#handling-redactions)
-section below for more information.
+{{< added-in this=true >}} While they are still subject to them,
+there are no auth rules specifically for `m.room.redaction` events anymore.
+The actual redaction of content is authorized at alater stage: see the
+[Redactions](#redactions) section below for more information.
 
 <!-- set withVersioning=true so we get all the "new in this version" stuff -->
 {{< rver-fragment name="v3-auth-rules" withVersioning=true >}}

--- a/content/rooms/v3.md
+++ b/content/rooms/v3.md
@@ -89,10 +89,17 @@ The complete structure of a event in a v3 room is shown below.
 
 ### Authorization rules
 
-{{< added-in this=true >}} While they are still subject to them,
-there are no auth rules specifically for `m.room.redaction` events anymore.
-The actual redaction of content is authorized at alater stage: see the
-[Redactions](#redactions) section below for more information.
+{{% boxes/note %}}
+{{< added-in this=true >}} `m.room.redaction` events are subject to auth rules in
+the same way as any other event. In practice, that means they will normally be allowed
+by the auth rules, unless the `m.room.power_levels` event sets a power level requirement
+for `m.room.redaction`events via the `events` or `events_default` properties. In
+particular, the /redact level/ is **not** considered by the auth rules.
+
+The ability to send a redaction event does not mean that the redaction itself should
+be performed. Receiving servers must perform additional checks, as described in
+the [Handling Redactions](#handling-redactions) section below.
+{{% /boxes/note %}}
 
 <!-- set withVersioning=true so we get all the "new in this version" stuff -->
 {{< rver-fragment name="v3-auth-rules" withVersioning=true >}}

--- a/content/rooms/v6.md
+++ b/content/rooms/v6.md
@@ -40,11 +40,9 @@ in [room version 5](/rooms/v5).
 
 ### Authorization rules
 
-`m.room.redaction` events are not explicitly part of the auth rules.
-They are still subject to the minimum power level rules, but should always
-fall into "10. Otherwise, allow". Instead of being authorized at the time
-of receipt, they are authorized at a later stage: see the
-[Handling Redactions](#handling-redactions) section below for more information.
+While they are still subject to them, there are no auth rules specifically for
+`m.room.redaction` events. The actual redaction of content is authorized at a
+later stage: see the [Redactions](#redactions) section below for more information.
 
 {{< added-in this=true >}} Rule 4, which related specifically to events
 of type `m.room.aliases`, is removed. `m.room.aliases` events must still pass

--- a/content/rooms/v6.md
+++ b/content/rooms/v6.md
@@ -69,8 +69,8 @@ the default power level for users in the room.
 `m.room.redaction` events are subject to auth rules in the same way as any other event.
 In practice, that means they will normally be allowed by the auth rules, unless the
 `m.room.power_levels` event sets a power level requirement for `m.room.redaction`
-events via the `events` or `events_default` properties. In particular, the /redact
-level/ is **not** considered by the auth rules.
+events via the `events` or `events_default` properties. In particular, the _redact
+level_ is **not** considered by the auth rules.
 
 The ability to send a redaction event does not mean that the redaction itself should
 be performed. Receiving servers must perform additional checks, as described in

--- a/content/rooms/v6.md
+++ b/content/rooms/v6.md
@@ -40,10 +40,6 @@ in [room version 5](/rooms/v5).
 
 ### Authorization rules
 
-While they are still subject to them, there are no auth rules specifically for
-`m.room.redaction` events. The actual redaction of content is authorized at a
-later stage: see the [Redactions](#redactions) section below for more information.
-
 {{< added-in this=true >}} Rule 4, which related specifically to events
 of type `m.room.aliases`, is removed. `m.room.aliases` events must still pass
 authorization checks relating to state events.
@@ -67,6 +63,18 @@ The types of state events that affect authorization are:
 Power levels are inferred from defaults when not explicitly supplied.
 For example, mentions of the `sender`'s power level can also refer to
 the default power level for users in the room.
+{{% /boxes/note %}}
+
+{{% boxes/note %}}
+`m.room.redaction` events are subject to auth rules in the same way as any other event.
+In practice, that means they will normally be allowed by the auth rules, unless the
+`m.room.power_levels` event sets a power level requirement for `m.room.redaction`
+events via the `events` or `events_default` properties. In particular, the /redact
+level/ is **not** considered by the auth rules.
+
+The ability to send a redaction event does not mean that the redaction itself should
+be performed. Receiving servers must perform additional checks, as described in
+the [Handling Redactions](#handling-redactions) section below.
 {{% /boxes/note %}}
 
 The rules are as follows:

--- a/content/rooms/v6.md
+++ b/content/rooms/v6.md
@@ -74,7 +74,7 @@ level_ is **not** considered by the auth rules.
 
 The ability to send a redaction event does not mean that the redaction itself should
 be performed. Receiving servers must perform additional checks, as described in
-the [Handling Redactions](#handling-redactions) section below.
+the [Handling Redactions](#handling-redactions) section.
 {{% /boxes/note %}}
 
 The rules are as follows:

--- a/content/rooms/v7.md
+++ b/content/rooms/v7.md
@@ -60,7 +60,7 @@ level_ is **not** considered by the auth rules.
 
 The ability to send a redaction event does not mean that the redaction itself should
 be performed. Receiving servers must perform additional checks, as described in
-the [Handling redactions](#handling-redactions) section below.
+the [Handling redactions](#handling-redactions) section.
 {{% /boxes/note %}}
 
 The rules are as follows:

--- a/content/rooms/v7.md
+++ b/content/rooms/v7.md
@@ -37,10 +37,6 @@ new point for `membership=knock` is added.
 
 Events must be signed by the server denoted by the `sender` property.
 
-While they are still subject to them, there are no auth rules specifically for
-`m.room.redaction` events. The actual redaction of content is authorized at a
-later stage: see the [Redactions](#redactions) section below for more information.
-
 The types of state events that affect authorization are:
 
 -   [`m.room.create`](/client-server-api#mroomcreate)
@@ -53,6 +49,18 @@ The types of state events that affect authorization are:
 Power levels are inferred from defaults when not explicitly supplied.
 For example, mentions of the `sender`'s power level can also refer to
 the default power level for users in the room.
+{{% /boxes/note %}}
+
+{{% boxes/note %}}
+`m.room.redaction` events are subject to auth rules in the same way as any other event.
+In practice, that means they will normally be allowed by the auth rules, unless the
+`m.room.power_levels` event sets a power level requirement for `m.room.redaction`
+events via the `events` or `events_default` properties. In particular, the /redact
+level/ is **not** considered by the auth rules.
+
+The ability to send a redaction event does not mean that the redaction itself should
+be performed. Receiving servers must perform additional checks, as described in
+the [Redactions](#redactions) section below.
 {{% /boxes/note %}}
 
 The rules are as follows:

--- a/content/rooms/v7.md
+++ b/content/rooms/v7.md
@@ -55,8 +55,8 @@ the default power level for users in the room.
 `m.room.redaction` events are subject to auth rules in the same way as any other event.
 In practice, that means they will normally be allowed by the auth rules, unless the
 `m.room.power_levels` event sets a power level requirement for `m.room.redaction`
-events via the `events` or `events_default` properties. In particular, the /redact
-level/ is **not** considered by the auth rules.
+events via the `events` or `events_default` properties. In particular, the _redact
+level_ is **not** considered by the auth rules.
 
 The ability to send a redaction event does not mean that the redaction itself should
 be performed. Receiving servers must perform additional checks, as described in

--- a/content/rooms/v7.md
+++ b/content/rooms/v7.md
@@ -37,11 +37,9 @@ new point for `membership=knock` is added.
 
 Events must be signed by the server denoted by the `sender` property.
 
-`m.room.redaction` events are not explicitly part of the auth rules.
-They are still subject to the minimum power level rules, but should always
-fall into "10. Otherwise, allow". Instead of being authorized at the time
-of receipt, they are authorized at a later stage: see the
-[Redactions](#redactions) section below for more information.
+While they are still subject to them, there are no auth rules specifically for
+`m.room.redaction` events. The actual redaction of content is authorized at a
+later stage: see the [Redactions](#redactions) section below for more information.
 
 The types of state events that affect authorization are:
 

--- a/content/rooms/v7.md
+++ b/content/rooms/v7.md
@@ -60,7 +60,7 @@ level_ is **not** considered by the auth rules.
 
 The ability to send a redaction event does not mean that the redaction itself should
 be performed. Receiving servers must perform additional checks, as described in
-the [Redactions](#redactions) section below.
+the [Handling redactions](#handling-redactions) section below.
 {{% /boxes/note %}}
 
 The rules are as follows:


### PR DESCRIPTION
[Context](https://matrix.to/#/%23matrix-spec%3Amatrix.org/%24Y5gvmJK2fv-HwBRURrf6cHMtFvmqrTvfZ9Lur4fqDhE?via=ahouansou.cz&via=l1qu1d.net&via=0x1a8510f2.space&via=the-apothecary.club): there was a misunderstanding about how redactions interact with auth rules.





Signed-off-by: Matthias Ahouansou <matthias@ahouansou.cz>











<!-- Replace -->
Preview: https://pr1824--matrix-spec-previews.netlify.app
<!-- Replace -->
