### PR TITLE
e2ee/qr: clarify that the device's Ed25519 signing key should be used

### DIFF
--- a/changelogs/client_server/newsfragments/1829.clarification
+++ b/changelogs/client_server/newsfragments/1829.clarification
@@ -1,1 +1,1 @@
-Clarified that the device's Ed25519 signing key should be used in QR code verification (as opposed to the device's Curve25519 identity key).
+Clarify that the device's Ed25519 signing key should be used in QR code verification (as opposed to the device's Curve25519 identity key).

--- a/changelogs/client_server/newsfragments/1829.clarification
+++ b/changelogs/client_server/newsfragments/1829.clarification
@@ -1,0 +1,1 @@
+Clarified that the device's Ed25519 signing key should be used in QR code verification (as opposed to the device's Curve25519 identity key).

--- a/content/client-server-api/modules/end_to_end_encryption.md
+++ b/content/client-server-api/modules/end_to_end_encryption.md
@@ -1197,11 +1197,12 @@ strings in the general form:
   - the ID as a UTF-8 string
 - the first key, as 32 bytes.  The key to use depends on the mode field:
   - if `0x00` or `0x01`, then the current user's own master cross-signing public key
-  - if `0x02`, then the current device's device key
+  - if `0x02`, then the current device's Ed25519 signing key
 - the second key, as 32 bytes.  The key to use depends on the mode field:
   - if `0x00`, then what the device thinks the other user's master
     cross-signing key is
-  - if `0x01`, then what the device thinks the other device's device key is
+  - if `0x01`, then what the device thinks the other device's Ed25519 signing
+    key is
   - if `0x02`, then what the device thinks the user's master cross-signing key
     is
 - a random shared secret, as a byte string.  It is suggested to use a secret


### PR DESCRIPTION
Source @uhoreg in #e2e:matrix.org:
https://matrix.to/#/matrix.org/$J6UbQwsakEsHMbv5yH7RUpM-OlklZ4U3Ti3VqWp9p8E?via=matrix.org&via=privacytools.io&via=envs.net

> It should be the ed25519 key. There was probably a bit of a
> terminology mixup in the MSC. But all verification methods verify the
> ed25519 key. In theory, devices should be able to change their
> curve25519 key, as long as the ed25519 key stays the same, though I
> don't think anyone has ever actually tried that, and I don't know what
> would happen if someone did. (I suspect that we would see lots of
> exciting errors)

Signed-off-by: Sumner Evans <sumner.evans@automattic.com>

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)








<!-- Replace -->
Preview: https://pr1829--matrix-spec-previews.netlify.app
<!-- Replace -->
