### PR TITLE
Clean up pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,3 @@
----
-name: Spec clarification/not a proposal
-about: A change that's not a spec proposal, such as a clarification to the spec itself.
-title: ''
-labels: ''
-assignees: ''
-
----
 
 ### Pull Request Checklist
 

--- a/changelogs/internal/newsfragments/1831.clarification
+++ b/changelogs/internal/newsfragments/1831.clarification
@@ -1,0 +1,1 @@
+Clean up pull request template.


### PR DESCRIPTION
As far as I can tell, these header lines only encourage people to create badly-formatted PRs.

Also we only have one template so let's give it the default name.

<!-- Replace -->
Preview: https://pr1831--matrix-spec-previews.netlify.app
<!-- Replace -->
