### PR TITLE
Clarify that the event field of the send_join is only required when performing a restricted join

### DIFF
--- a/changelogs/server_server/newsfragments/1834.clarification
+++ b/changelogs/server_server/newsfragments/1834.clarification
@@ -1,0 +1,1 @@
+Clarify that the `event` field of the `/v2/send_join` response is only required when `join_authorised_via_users_server` was present in the `content` field of the request.

--- a/data/api/server-server/joins-v2.yaml
+++ b/data/api/server-server/joins-v2.yaml
@@ -207,9 +207,9 @@ paths:
                     title: SignedMembershipEvent
                     x-addedInMatrixVersion: "1.2"
                     description: |-
-                      Required if the room version [supports restricted join rules](/rooms/#feature-matrix). The signed
-                      copy of the membership event sent to other servers by the resident server, including the resident
-                      server's signature.
+                      Required if the `content` of the event in the request contained the `join_authorised_via_users_server`
+                        field. The signed copy of the membership event sent to other servers by the resident server,
+                        including the resident server's signature.
                   servers_in_room:
                     type: array
                     x-addedInMatrixVersion: "1.6"


### PR DESCRIPTION
Fixes #1708 

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)


<!-- Replace -->
Preview: https://pr1834--matrix-spec-previews.netlify.app
<!-- Replace -->
