### PR TITLE
Add missing error.soft_logout

### DIFF
--- a/changelogs/client_server/newsfragments/1836.clarification
+++ b/changelogs/client_server/newsfragments/1836.clarification
@@ -1,0 +1,1 @@
+Add missing `soft_logout` property to `error.yaml`, as used by `refresh.yaml`. Contributed by @PaarthShah.

--- a/data/api/client-server/definitions/errors/error.yaml
+++ b/data/api/client-server/definitions/errors/error.yaml
@@ -23,4 +23,7 @@ properties:
     type: string
     description: A human-readable error message.
     example: An unknown error occurred
+  soft_logout:
+    type: boolean
+    description: If true within a 401 response, the client can offer to re-log in the user.
 required: ["errcode"]


### PR DESCRIPTION
`soft_logout` is used by 401 responses by the refresh endpoint, but is not defined properly on the error.
https://github.com/matrix-org/matrix-spec/blob/a17550648cc4d96bf79ed21103fe30503e1a0fae/data/api/client-server/refresh.yaml#L100

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)








<!-- Replace -->
Preview: https://pr1836--matrix-spec-previews.netlify.app
<!-- Replace -->
