### PR TITLE
Clarifications around encoding of data within verification QR codes

### DIFF
--- a/changelogs/client_server/newsfragments/1839.clarification
+++ b/changelogs/client_server/newsfragments/1839.clarification
@@ -1,0 +1,1 @@
+Specify the encoding to be used when generating QR codes for device verification.

--- a/content/client-server-api/modules/end_to_end_encryption.md
+++ b/content/client-server-api/modules/end_to_end_encryption.md
@@ -1200,7 +1200,7 @@ The binary segment MUST be of the following form:
   request event, encoded as:
   - two bytes in network byte order (big-endian) indicating the length in
     bytes of the ID as a UTF-8 string
-  - the ID encoded as a UTF-8 string (i.e. one UTF-8 byte per character)
+  - the ID encoded as a UTF-8 string
 - the first key, as 32 bytes.  The key to use depends on the mode field:
   - if `0x00` or `0x01`, then the current user's own master cross-signing public key
   - if `0x02`, then the current device's Ed25519 signing key

--- a/content/client-server-api/modules/end_to_end_encryption.md
+++ b/content/client-server-api/modules/end_to_end_encryption.md
@@ -1206,11 +1206,11 @@ The binary segment MUST be of the following form:
   - if `0x02`, then the current device's Ed25519 signing key
 - the second key, as 32 bytes.  The key to use depends on the mode field:
   - if `0x00`, then what the device thinks the other user's master
-    cross-signing key is
+    cross-signing public key is
   - if `0x01`, then what the device thinks the other device's Ed25519 signing
+    public key is
+  - if `0x02`, then what the device thinks the user's master cross-signing public
     key is
-  - if `0x02`, then what the device thinks the user's master cross-signing key
-    is
 - a random shared secret, as a sequence of bytes.  It is suggested to use a secret
   that is about 8 bytes long.  Note: as we do not share the length of the
   secret, and it is not a fixed size, clients will just use the remainder of

--- a/content/client-server-api/modules/end_to_end_encryption.md
+++ b/content/client-server-api/modules/end_to_end_encryption.md
@@ -1179,10 +1179,16 @@ The process between Alice and Bob verifying each other would be:
 
 ###### QR code format
 
-The QR codes to be displayed and scanned using this format will encode binary
-strings in the general form:
+The QR codes to be displayed and scanned must be
+[ISO/IEC 18004:2015](https://www.iso.org/standard/62021.html) compatible and
+contain a single segment that uses the byte mode encoding.
 
-- the ASCII string `MATRIX`
+The error correction level can be chosen by the device displaying the QR code.
+
+The binary segment must be of the following form:
+
+- the string `MATRIX` encoded as one ASCII byte per character (i.e. `0x4D`,
+  `0x41`, `0x54`, `0x52`, `0x49`, `0x58`)
 - one byte indicating the QR code version (must be `0x02`)
 - one byte indicating the QR code verification mode.  Should be one of the
   following values:
@@ -1210,7 +1216,7 @@ strings in the general form:
   secret, and it is not a fixed size, clients will just use the remainder of
   binary string as the shared secret.
 
-For example, if Alice displays a QR code encoding the following binary string:
+For example, if Alice displays a QR code encoding the following binary data:
 
 ```
       "MATRIX"    |ver|mode| len   | event ID

--- a/content/client-server-api/modules/end_to_end_encryption.md
+++ b/content/client-server-api/modules/end_to_end_encryption.md
@@ -1200,7 +1200,7 @@ The binary segment must be of the following form:
   request event, encoded as:
   - two bytes in network byte order (big-endian) indicating the length in
     bytes of the ID as a UTF-8 string
-  - the ID as a UTF-8 string
+  - the ID encoded as a UTF-8 string (i.e. one UTF-8 byte per character)
 - the first key, as 32 bytes.  The key to use depends on the mode field:
   - if `0x00` or `0x01`, then the current user's own master cross-signing public key
   - if `0x02`, then the current device's Ed25519 signing key
@@ -1211,10 +1211,10 @@ The binary segment must be of the following form:
     key is
   - if `0x02`, then what the device thinks the user's master cross-signing key
     is
-- a random shared secret, as a byte string.  It is suggested to use a secret
+- a random shared secret, as a sequence of bytes.  It is suggested to use a secret
   that is about 8 bytes long.  Note: as we do not share the length of the
   secret, and it is not a fixed size, clients will just use the remainder of
-  binary string as the shared secret.
+  binary segment as the shared secret.
 
 For example, if Alice displays a QR code encoding the following binary data:
 

--- a/content/client-server-api/modules/end_to_end_encryption.md
+++ b/content/client-server-api/modules/end_to_end_encryption.md
@@ -1179,13 +1179,13 @@ The process between Alice and Bob verifying each other would be:
 
 ###### QR code format
 
-The QR codes to be displayed and scanned must be
-[ISO/IEC 18004:2015](https://www.iso.org/standard/62021.html) compatible and
+The QR codes to be displayed and scanned MUST be
+compatible with [ISO/IEC 18004:2015](https://www.iso.org/standard/62021.html) and
 contain a single segment that uses the byte mode encoding.
 
 The error correction level can be chosen by the device displaying the QR code.
 
-The binary segment must be of the following form:
+The binary segment MUST be of the following form:
 
 - the string `MATRIX` encoded as one ASCII byte per character (i.e. `0x4D`,
   `0x41`, `0x54`, `0x52`, `0x49`, `0x58`)


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)

Currently the [spec](https://spec.matrix.org/v1.10/client-server-api/#qr-code-format) is specific about the contents of the binary data to be *present* within a QR, but it does not specify how that data should be *encoded* within a QR.

I've checked the original [MSC1544](https://github.com/matrix-org/matrix-spec-proposals/pull/1544/files#diff-fd371cd950df67f5a748e49d367ce76d81c216f62feaf870a714cf43413265b4R171) but don't see any obvious discussion around this. Also, no discussion in the spec [PR](https://github.com/matrix-org/matrix-spec-proposals/pull/3149).

As such, I assume this is an oversight.

I do have a hesitation about linking out to the ISO spec as it is not "open".

















<!-- Replace -->
Preview: https://pr1839--matrix-spec-previews.netlify.app
<!-- Replace -->
