### PR TITLE
Clarify that an access token is optional on `/account/password` and `/account/deactivate`

### DIFF
--- a/changelogs/client_server/newsfragments/1843.clarification
+++ b/changelogs/client_server/newsfragments/1843.clarification
@@ -1,0 +1,1 @@
+Clarify that authentication is optional on the `POST /account/password` and `POST /account/deactivate` endpoints.

--- a/changelogs/client_server/newsfragments/1843.clarification
+++ b/changelogs/client_server/newsfragments/1843.clarification
@@ -1,1 +1,1 @@
-Clarify that authentication is optional on the `POST /account/password` and `POST /account/deactivate` endpoints.
+Clarify that an access token is optional on the `POST /account/password` and `POST /account/deactivate` endpoints.

--- a/data/api/client-server/registration.yaml
+++ b/data/api/client-server/registration.yaml
@@ -387,6 +387,7 @@ paths:
         access token provided in the request. Whether other access tokens for
         the user are revoked depends on the request parameters.
       security:
+        - {}
         - accessTokenQuery: []
         - accessTokenBearer: []
       operationId: changePassword
@@ -592,6 +593,7 @@ paths:
         parameter because the homeserver is expected to sign the request to the
         identity server instead.
       security:
+        - {}
         - accessTokenQuery: []
         - accessTokenBearer: []
       operationId: deactivateAccount


### PR DESCRIPTION
The descriptions of the endpoints clearly state that the access token is not required, but it also says:

> Requires Authentication: Yes

This changes it to show:

> Requires Authentication: Optional

Fixes #1807.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)








<!-- Replace -->
Preview: https://pr1843--matrix-spec-previews.netlify.app
<!-- Replace -->
