### PR TITLE
Replace references to RFC7235 and RFC7230 with references to RFC9110

### DIFF
--- a/changelogs/server_server/newsfragments/1844.clarification
+++ b/changelogs/server_server/newsfragments/1844.clarification
@@ -1,1 +1,1 @@
-Replace references to RFC7235 and RFC7230 that are obsoleted by RFC9110.
+Replace references to RFC 7235 and RFC 7230 that are obsoleted by RFC 9110.

--- a/changelogs/server_server/newsfragments/1844.clarification
+++ b/changelogs/server_server/newsfragments/1844.clarification
@@ -1,0 +1,1 @@
+Replace references to RFC7235 and RFC7230 that are obsoleted by RFC9110.

--- a/content/server-server-api.md
+++ b/content/server-server-api.md
@@ -390,9 +390,9 @@ Unknown parameters are ignored.
 
 {{% boxes/note %}}
 {{< changed-in v="1.11" >}}
-This section used to reference [RFC7235](https://datatracker.ietf.org/doc/html/rfc7235#section-2.1)
-and [RFC7230](https://datatracker.ietf.org/doc/html/rfc9110#section-5.6.2), that
-were obsoleted by RFC9110 without changes to the sections of interest here.
+This section used to reference [RFC 7235](https://datatracker.ietf.org/doc/html/rfc7235#section-2.1)
+and [RFC 7230](https://datatracker.ietf.org/doc/html/rfc9110#section-5.6.2), that
+were obsoleted by RFC 9110 without changes to the sections of interest here.
 {{% /boxes/note %}}
 
 ### Response Authentication

--- a/content/server-server-api.md
+++ b/content/server-server-api.md
@@ -349,14 +349,14 @@ def authorization_headers(origin_name, origin_signing_key,
 ```
 
 The format of the Authorization header is given in
-[RFC 7235](https://datatracker.ietf.org/doc/html/rfc7235#section-2.1). In
+[Section 11.4 of RFC 9110](https://datatracker.ietf.org/doc/html/rfc9110#section-11.4). In
 summary, the header begins with authorization scheme `X-Matrix`, followed by one
 or more spaces, followed by a comma-separated list of parameters written as
 name=value pairs. Zero or more spaces and tabs around each comma are allowed.
 The names are case insensitive and order does not matter. The
 values must be enclosed in quotes if they contain characters that are not
 allowed in `token`s, as defined in
-[RFC 7230](https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.6); if a
+[Section 5.6.2 of RFC 9110](https://datatracker.ietf.org/doc/html/rfc9110#section-5.6.2); if a
 value is a valid `token`, it may or may not be enclosed in quotes. Quoted
 values may include backslash-escaped characters. When parsing the header, the
 recipient must unescape the characters. That is, a backslash-character pair is
@@ -387,6 +387,13 @@ The authorization parameters to include are:
 - `signature`: the signature of the JSON as calculated in step 1.
 
 Unknown parameters are ignored.
+
+{{% boxes/note %}}
+{{< changed-in v="1.11" >}}
+This section used to reference [RFC7235](https://datatracker.ietf.org/doc/html/rfc7235#section-2.1)
+and [RFC7230](https://datatracker.ietf.org/doc/html/rfc9110#section-5.6.2), that
+were obsoleted by RFC9110 without changes to the sections of interest here.
+{{% /boxes/note %}}
 
 ### Response Authentication
 


### PR DESCRIPTION
[RFC9110](https://datatracker.ietf.org/doc/html/rfc9110) obsoletes the sections we are interested in of RFC7235 and RFC7230.

According to the "Changes from Previous RFCs" appendix of RFC9110, there are [no changes from RFC7235](https://datatracker.ietf.org/doc/html/rfc9110#name-changes-from-rfc-7235) and [no changes in section 5.6.2 from RFC7230](https://datatracker.ietf.org/doc/html/rfc9110#name-changes-from-rfc-7230), making this effectively a drop-in replacement.

Fixes #1569.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)








<!-- Replace -->
Preview: https://pr1844--matrix-spec-previews.netlify.app
<!-- Replace -->
