### PR TITLE
Move size limits for user, room and event IDs into the appendix and clarify that the length is to be measured in bytes

### DIFF
--- a/changelogs/appendices/newsfragments/1850.clarification
+++ b/changelogs/appendices/newsfragments/1850.clarification
@@ -1,0 +1,1 @@
+Move size limits for user, room and event IDs into the appendix and clarify that the length is to be measured in bytes.

--- a/changelogs/client_server/newsfragments/1850.clarification
+++ b/changelogs/client_server/newsfragments/1850.clarification
@@ -1,0 +1,1 @@
+Move size limits for user, room and event IDs into the appendix and clarify that the length is to be measured in bytes.

--- a/content/appendices.md
+++ b/content/appendices.md
@@ -556,7 +556,7 @@ The `domain` of a user ID is the [server name](#server-name) of the
 homeserver which allocated the account.
 
 The length of a user ID, including the `@` sigil and the domain, MUST
-NOT exceed 255 characters.
+NOT exceed 255 bytes.
 
 The complete grammar for a legal user ID is:
 
@@ -663,6 +663,9 @@ Room IDs are case-sensitive. They are not meant to be
 human-readable. They are intended to be treated as fully opaque strings
 by clients.
 
+The length of a room ID, including the `!` sigil and the domain, MUST
+NOT exceed 255 bytes.
+
 #### Room Aliases
 
 A room may have zero or more aliases. A room alias has the format:
@@ -673,8 +676,8 @@ The `domain` of a room alias is the [server name](#server-name) of the
 homeserver which created the alias. Other servers may contact this
 homeserver to look up the alias.
 
-Room aliases MUST NOT exceed 255 bytes (including the `#` sigil and the
-domain).
+The length of a room alias, including the `#` sigil and the domain, MUST
+NOT exceed 255 bytes.
 
 #### Event IDs
 
@@ -688,6 +691,8 @@ whereas more recent versions omit the domain and use a base64-encoded hash inste
 
 Event IDs are case-sensitive. They are not meant to be human-readable. They are
 intended to be treated as fully opaque strings by clients.
+
+The length of an event ID MUST NOT exceed 255 bytes.
 
 
 ### URIs

--- a/content/appendices.md
+++ b/content/appendices.md
@@ -689,11 +689,11 @@ However, the precise format depends upon the [room version
 specification](/rooms): early room versions included a `domain` component,
 whereas more recent versions omit the domain and use a base64-encoded hash instead.
 
+In addition to the requirements of the room version, the length of an event ID,
+including the `$` sigil and the domain where present, MUST NOT exceed 255 bytes.
+
 Event IDs are case-sensitive. They are not meant to be human-readable. They are
 intended to be treated as fully opaque strings by clients.
-
-The length of an event ID MUST NOT exceed 255 bytes.
-
 
 ### URIs
 

--- a/content/client-server-api/_index.md
+++ b/content/client-server-api/_index.md
@@ -1842,16 +1842,15 @@ updates not being sent.
 
 The complete event MUST NOT be larger than 65536 bytes, when formatted
 with the [federation event format](#room-event-format), including any
-signatures, and encoded as [Canonical
-JSON](/appendices#canonical-json).
+signatures, and encoded as [Canonical JSON](/appendices#canonical-json).
 
 There are additional restrictions on sizes per key:
 
--   `sender` MUST NOT exceed 255 bytes (including domain).
--   `room_id` MUST NOT exceed 255 bytes.
+-   `sender` MUST NOT exceed the size limit for [user IDs](/appendices/#user-identifiers).
+-   `room_id` MUST NOT exceed the size limit for [room IDs](/appendices/#room-ids).
 -   `state_key` MUST NOT exceed 255 bytes.
 -   `type` MUST NOT exceed 255 bytes.
--   `event_id` MUST NOT exceed 255 bytes.
+-   `event_id` MUST NOT exceed the size limit for [event IDs](/appendices/#event-ids).
 
 Some event types have additional size restrictions which are specified
 in the description of the event. Additional keys have no limit other


### PR DESCRIPTION
Fixes: #1826
Relates to: #1001

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [ ] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)








<!-- Replace -->
Preview: https://pr1850--matrix-spec-previews.netlify.app
<!-- Replace -->
