### PR TITLE
Clarify that relations recursion should be capped at a certain depth

### DIFF
--- a/changelogs/client_server/newsfragments/1854.clarification
+++ b/changelogs/client_server/newsfragments/1854.clarification
@@ -1,0 +1,1 @@
+ Clarify that relations recursion should be capped at a certain depth.

--- a/data/api/client-server/relations.yaml
+++ b/data/api/client-server/relations.yaml
@@ -315,11 +315,10 @@ components:
         If set to `false`, only events which have direct a relation with the given
         event will be included.
 
-        If set to `true`, all events which relate to the given event, or relate to
-        events that relate to the given event, will be included.
-
-        It is recommended that homeservers traverse at least 3 levels of relationships.
-        Implementations may perform more but should be careful to not infinitely recurse.
+        If set to `true`, events which have an indirect relation with the given event
+        will be included additionally up to a certain depth level. Homeservers SHOULD traverse
+        at least 3 levels of relationships. Implementations MAY perform more but MUST be careful
+        to not infinitely recurse.
 
         The default value is `false`.
       schema:


### PR DESCRIPTION
Due to the capped nature of the recursion the phrase "all events" is not necessarily correct in all cases. For the same reason, I also thought it's better to contract the two paragraphs because the depth is only relevant for the `recurse=true` case.

While at it, I also tried to convert the keywords to #1782 (though I'm not sure if this would better be applied holistically in this file).

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [ ] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)





<!-- Replace -->
Preview: https://pr1854--matrix-spec-previews.netlify.app
<!-- Replace -->
