### PR TITLE
Replace references to obsolete RFC 1341 with RFC 2046

### DIFF
--- a/changelogs/server_server/newsfragments/1869.feature
+++ b/changelogs/server_server/newsfragments/1869.feature
@@ -1,0 +1,1 @@
+Media downloads and thumbnails are now authenticated, as per [MSC3916](https://github.com/matrix-org/matrix-spec-proposals/pull/3916).

--- a/data/api/server-server/content_repository.yaml
+++ b/data/api/server-server/content_repository.yaml
@@ -37,7 +37,7 @@ paths:
               schema:
                 # This is a workaround for us not being able to say the response is required.
                 description: |-
-                  **Required.** MUST contain a `boundary` (per [RFC 1341](https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html))
+                  **Required.** MUST contain a `boundary` (per [RFC 2046](https://datatracker.ietf.org/doc/html/rfc2046#section-5.1))
                   delineating exactly two parts:
 
                   The first part has a `Content-Type` header of `application/json`
@@ -154,7 +154,7 @@ paths:
               schema:
                 # This is a workaround for us not being able to say the response is required.
                 description: |-
-                  **Required.** MUST contain a `boundary` (per [RFC 1341](https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html))
+                  **Required.** MUST contain a `boundary` (per [RFC 2046](https://datatracker.ietf.org/doc/html/rfc2046#section-5.1))
                   delineating exactly two parts:
 
                   The first part has a `Content-Type` header of `application/json`


### PR DESCRIPTION
Sorry to discover that only after #1858 was merged, but it turns out that if we look at [the whole RFC 1341 on the IETF's website](https://datatracker.ietf.org/doc/html/rfc1341), or even [the TOC of the RFC on the W3C's website](https://www.w3.org/Protocols/rfc1341/0_TableOfContents.html), we can see that it was obsoleted by [RFC 1521](https://datatracker.ietf.org/doc/html/rfc1521), which was in turn obsoleted by RFCs 2045-2049, and the part that interests us is now in [RFC 2046](https://datatracker.ietf.org/doc/html/rfc2046).

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)





<!-- Replace -->
Preview: https://pr1869--matrix-spec-previews.netlify.app
<!-- Replace -->
