### PR TITLE
Clarify that room avatars cannot be encrypted

### DIFF
--- a/changelogs/client_server/newsfragments/1871.clarification
+++ b/changelogs/client_server/newsfragments/1871.clarification
@@ -1,0 +1,1 @@
+Clarify that room avatars cannot be encrypted.

--- a/data/event-schemas/schema/core-event-schema/msgtype_infos/avatar_info.yaml
+++ b/data/event-schemas/schema/core-event-schema/msgtype_infos/avatar_info.yaml
@@ -1,0 +1,28 @@
+description: Metadata about an avatar image.
+properties:
+  h:
+    description: |-
+      The intended display height of the image in pixels. This may
+      differ from the intrinsic dimensions of the image file.
+    type: integer
+  w:
+    description: |-
+      The intended display width of the image in pixels. This may
+      differ from the intrinsic dimensions of the image file.
+    type: integer
+  mimetype:
+    description: The mimetype of the image, e.g. `image/jpeg`.
+    type: string
+  size:
+    description: Size of the image in bytes.
+    type: integer
+  thumbnail_url:
+    description: |-
+      The URL (typically [`mxc://` URI](/client-server-api/#matrix-content-mxc-uris)) to a thumbnail of the image.
+    type: string
+  thumbnail_info:
+    allOf:
+      - $ref: thumbnail_info.yaml
+    description: Metadata about the image referred to in `thumbnail_url`.
+title: AvatarInfo
+type: object

--- a/data/event-schemas/schema/m.room.avatar.yaml
+++ b/data/event-schemas/schema/m.room.avatar.yaml
@@ -7,7 +7,7 @@ properties:
     properties:
       info:
         allOf:
-          - $ref: core-event-schema/msgtype_infos/image_info.yaml
+          - $ref: core-event-schema/msgtype_infos/avatar_info.yaml
         description: Metadata about the image referred to in `url`.
       url:
         description: |-


### PR DESCRIPTION
Duplicating the info yaml isn't great but I think it'll be easier to wrangle than making the individual parameters reusable.

```
$ diff data/event-schemas/schema/core-event-schema/msgtype_infos/image_info.yaml data/event-schemas/schema/core-event-schema/msgtype_infos/avatar_info.yaml
1c1
< description: Metadata about an image.
---
> description: Metadata about an avatar image.
22d21
<       Only present if the thumbnail is unencrypted.
24,30d22
<   thumbnail_file:
<     description: |-
<       Information on the encrypted thumbnail file, as specified in
<       [End-to-end encryption](/client-server-api/#sending-encrypted-attachments).
<       Only present if the thumbnail is encrypted.
<     title: EncryptedFile
<     type: object
35c27
< title: ImageInfo
---
> title: AvatarInfo
```

Fixes: #562

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [ ] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)





<!-- Replace -->
Preview: https://pr1871--matrix-spec-previews.netlify.app
<!-- Replace -->
