### PR TITLE
Fix ToC of spec proposals

### DIFF
--- a/changelogs/internal/newsfragments/1885.clarification
+++ b/changelogs/internal/newsfragments/1885.clarification
@@ -1,0 +1,1 @@
+Generate the Table of Contents with Hugo rather than JavaScript.

--- a/layouts/shortcodes/proposal-tables.html
+++ b/layouts/shortcodes/proposal-tables.html
@@ -33,7 +33,7 @@
 {{ $states := .Site.Data.msc.proposals }}
 
 {{ range $states }}
-<h3 id="{{.label}}" class="proposal-table-title">{{ .title }}</h3>
+### {{ .title }} {.proposal-table-title}
     {{ if .proposals }}
 <table class="msc-table table">
   <thead>


### PR DESCRIPTION
It seems that headings detection doesn't work with HTML headings, I thought it did. Anyway, it works if we render them with markdown.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)


<!-- Replace -->
Preview: https://pr1885--matrix-spec-previews.netlify.app
<!-- Replace -->
