### PR TITLE
Clarify that dont_notify and coalesce MUST be gracefully ignored

### DIFF
--- a/changelogs/client_server/newsfragments/1890.clarification
+++ b/changelogs/client_server/newsfragments/1890.clarification
@@ -1,0 +1,1 @@
+Clarify that the deprecated dont_notify and coalesce push rule actions MUST be ignored, not rejected by homeservers.

--- a/changelogs/client_server/newsfragments/1890.clarification
+++ b/changelogs/client_server/newsfragments/1890.clarification
@@ -1,1 +1,1 @@
-Clarify that the deprecated dont_notify and coalesce push rule actions MUST be ignored, not rejected by homeservers.
+Clarify that the deprecated dont_notify and coalesce push rule actions MUST be ignored, not rejected.

--- a/changelogs/client_server/newsfragments/1890.clarification
+++ b/changelogs/client_server/newsfragments/1890.clarification
@@ -1,1 +1,1 @@
-Clarify that the deprecated dont_notify and coalesce push rule actions MUST be ignored, not rejected.
+Clarify that the deprecated `dont_notify` and `coalesce` push rule actions MUST be ignored, not rejected.

--- a/content/client-server-api/modules/push.md
+++ b/content/client-server-api/modules/push.md
@@ -187,10 +187,10 @@ other keys as their parameters, e.g.
 ###### Historical Actions
 
 Older versions of the Matrix specification included the `dont_notify` and
-`coalesce` actions. Homeservers MUST ignore these actions by stripping them
-from any actions array they encounter. This means that setting the actions
-on a rule to e.g. `["dont_notify"]` MUST be equivalent to setting an empty
-actions array.
+`coalesce` actions. Clients and homeservers MUST ignore these actions, for
+instance, by stripping them from actions arrays they encounter. This means,
+for example, that a rule with `["dont_notify"]` actions MUST be equivalent
+to a rule with an empty actions array.
 
 ##### Conditions
 

--- a/content/client-server-api/modules/push.md
+++ b/content/client-server-api/modules/push.md
@@ -184,11 +184,13 @@ they are represented as a dictionary with a key equal to their name and
 other keys as their parameters, e.g.
 `{ "set_tweak": "sound", "value": "default" }`.
 
-{{% boxes/note %}}
+###### Historical Actions
+
 Older versions of the Matrix specification included the `dont_notify` and
-`coalesce` actions. These should both be considered no-ops (ignored, not
-rejected) if received from a client.
-{{% /boxes/note %}}
+`coalesce` actions. Homeservers MUST ignore these actions by stripping them
+from any actions array they encounter. This means that setting the actions
+on a rule to e.g. `["dont_notify"]` MUST be equivalent to setting an empty
+actions array.
 
 ##### Conditions
 


### PR DESCRIPTION
Relates to: https://github.com/matrix-org/matrix-spec/pull/1501/files#r1176822971.

I replaced the info box with a subsection akin to the one for historical user IDs to prevent using RFC2119 keywords inside an explanatory box.

I also attempted to be a little more verbose about what ignoring means by describing the filtering behavior [implemented in Synapse](https://github.com/element-hq/synapse/blob/f79dbd0f61194929585d7010a3ec1b9ee208f033/rust/src/push/evaluator.rs#L221).

CC @clokep 

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [ ] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)











<!-- Replace -->
Preview: https://pr1890--matrix-spec-previews.netlify.app
<!-- Replace -->
