### PR TITLE
Fix markup syntax in v2 state res

### DIFF
--- a/changelogs/room_versions/newsfragments/1896.clarification.rst
+++ b/changelogs/room_versions/newsfragments/1896.clarification.rst
@@ -1,0 +1,1 @@
+Fix a formatting issue in v2 state res.

--- a/content/rooms/fragments/v2-state-res.md
+++ b/content/rooms/fragments/v2-state-res.md
@@ -138,7 +138,7 @@ The *resolution* of a set of states is obtained as follows:
 1.  Select the set *X* of all *power events* that appear in the *full
     conflicted set*. For each such power event *P*, enlarge *X* by adding
     the events in the auth chain of *P* which also belong to the full
-    conflicted set. Sort $X$ into a list using the *reverse topological
+    conflicted set. Sort *X* into a list using the *reverse topological
     power ordering*.
 2.  Apply the *iterative auth checks algorithm*, starting from the
     *unconflicted state map*, to the list of events from the previous


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)


<!-- Replace -->
Preview: https://pr1896--matrix-spec-previews.netlify.app
<!-- Replace -->
