### PR TITLE
Fix callback function for fallback login

### DIFF
--- a/changelogs/client_server/newsfragments/1899.clarification
+++ b/changelogs/client_server/newsfragments/1899.clarification
@@ -1,0 +1,1 @@
+Clarify that the fallback login page calls `window.matrixLogin.onLogin` instead of `window.onLogin`.

--- a/content/client-server-api/_index.md
+++ b/content/client-server-api/_index.md
@@ -1401,7 +1401,7 @@ fallback login API:
 
 This returns an HTML and JavaScript page which can perform the entire
 login process. The page will attempt to call the JavaScript function
-`window.onLogin` when login has been successfully completed.
+`window.matrixLogin.onLogin` when login has been successfully completed.
 
 {{% added-in v="1.1" %}} Non-credential parameters valid for the `/login`
 endpoint can be provided as query string parameters here. These are to be


### PR DESCRIPTION
As described in #640 this has been the reality in Synapse for almost 9 years and was recently implemented in Dendrite, too. Element's legacy mobile apps depend on this implementation. I couldn't find any clients or servers that use the form that is currently documented in the spec. Therefore, this appears save to correct in the spec.

Fixes: #640

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [ ] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)





<!-- Replace -->
Preview: https://pr1899--matrix-spec-previews.netlify.app
<!-- Replace -->
