### PR TITLE
Document the removal changelog category

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -99,6 +99,8 @@ the ``newsfragments`` directory. The ``type`` can be one of the following:
 
 * ``deprecation`` - Used when deprecating something.
 
+* ``removal`` - Used when removing something that was unused or previously deprecated.
+
 All news fragments must have a brief summary explaining the change in the
 contents of the file. The summary must end in a full stop to be in line with
 the style guide and formatting must be done using Markdown.

--- a/changelogs/internal/newsfragments/1907.clarification
+++ b/changelogs/internal/newsfragments/1907.clarification
@@ -1,0 +1,1 @@
+Document the `removal` changelog category.


### PR DESCRIPTION
Following up on https://github.com/matrix-org/matrix-spec/pull/1870#discussion_r1671569975 this adds the `removal` changelog category. Historically this has been used for things that were removed both [with](https://github.com/matrix-org/matrix-spec/commit/67d5d9eb4948c1b475ea75538c133de4a61547e9#diff-6ecaf7381f5ba89f5681e2b185b53e01357028485c7a516f79888ad5c9ba975aR1) and [without](https://github.com/matrix-org/matrix-spec/commit/3c45c0aeb42ff312fc3ba250927f4c6883558c2b#diff-a0f4add9e01494e3b8216727fb8c25ffc94105d94935362b28c07b68fece2f50R1) deprecation. I think there is possibly some overlap with the `breaking` category because removing something is normally not backwards compatible. One could argue though that a removal change is not breaking if the functionality was known to be unused or explicitly deprecated before.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [ ] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)





<!-- Replace -->
Preview: https://pr1907--matrix-spec-previews.netlify.app
<!-- Replace -->
