### PR TITLE
Don't mention that `GET /_matrix/client/v3/profile/{userId}` can return additional properties because this is true for almost every endpoint

### DIFF
--- a/changelogs/client_server/newsfragments/1910.clarification
+++ b/changelogs/client_server/newsfragments/1910.clarification
@@ -1,0 +1,1 @@
+Update response schema of `GET /_matrix/client/v3/profile/{userId}` to clarify that properties other than `displayname` or `avatar_url` can be returned.

--- a/changelogs/client_server/newsfragments/1910.clarification
+++ b/changelogs/client_server/newsfragments/1910.clarification
@@ -1,1 +1,1 @@
-Update response schema of `GET /_matrix/client/v3/profile/{userId}` to clarify that properties other than `displayname` or `avatar_url` can be returned.
+Don't mention that `GET /_matrix/client/v3/profile/{userId}` can return additional properties because this is true for almost every endpoint.

--- a/data/api/client-server/profile.yaml
+++ b/data/api/client-server/profile.yaml
@@ -222,7 +222,7 @@ paths:
                     type: string
                     description: The user's display name if they have set one, otherwise not
                       present.
-                additionalProperties: true
+                additionalProperties: {}
               examples:
                 response:
                   value: {

--- a/data/api/client-server/profile.yaml
+++ b/data/api/client-server/profile.yaml
@@ -222,6 +222,7 @@ paths:
                     type: string
                     description: The user's display name if they have set one, otherwise not
                       present.
+                additionalProperties: true
               examples:
                 response:
                   value: {

--- a/data/api/client-server/profile.yaml
+++ b/data/api/client-server/profile.yaml
@@ -195,8 +195,7 @@ paths:
       description: |-
         Get the combined profile information for this user. This API may be used
         to fetch the user's own profile information or other users; either
-        locally or on remote homeservers. This API may return keys which are not
-        limited to `displayname` or `avatar_url`.
+        locally or on remote homeservers.
       operationId: getUserProfile
       parameters:
         - in: path
@@ -222,7 +221,6 @@ paths:
                     type: string
                     description: The user's display name if they have set one, otherwise not
                       present.
-                additionalProperties: {}
               examples:
                 response:
                   value: {


### PR DESCRIPTION
The endpoint is [documented](https://spec.matrix.org/v1.11/client-server-api/#get_matrixclientv3profileuserid) as:

> This API may return keys which are not limited to `displayname` or `avatar_url`.

This is superfluous though because its true for pretty much every endpoint and calling it out only here can be irritating.

~The response schema doesn't include `additionalProperties` though and, thus, no `<Other properties>` row is rendered.~

~This pull requests requires #1909 for the change to be visible in the rendered spec.~

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [ ] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)











<!-- Replace -->
Preview: https://pr1910--matrix-spec-previews.netlify.app
<!-- Replace -->
