### PR TITLE
Use dedicated fonts for better support of mathematical symbols

### DIFF
--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -42,16 +42,15 @@ $td-enable-google-fonts: false;
 /*
  * The $font-family-sans-serif definition here overrides the default value set by docsy
  * (https://github.com/matrix-org/docsy/blob/66a4e61d2d34edc7196b9df83a7d09cd4af14b47/assets/scss/_variables.scss#L68)
- * and:
- *
- * - Adds "Inter" to the front (making it the default)
- * - Inserts "Arial Unicode MS" before "Arial" (because the former contains more mathematical glyphs)
- *
- * The Inter font itself is loaded via stylesheet links layouts/partials/hooks/head-end.html.
  */
-$font-family-sans-serif: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-  "Helvetica Neue", Arial Unicode MS, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
-  "Segoe UI Symbol";
+$font-family-sans-serif:
+  // Add "Inter" to the front, making it the default. The font itself is loaded via stylesheet
+  // links in layouts/partials/hooks/head-end.html.
+  "Inter",
+  -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue",
+  // Insert fonts suited for mathematical symbols on different platforms before "Arial"
+  "STIX Two Math", "Cambria Math", "Noto Sans Math", "Dejavu Sans",
+  Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 
 // Disable smooth scrolling as it makes TOC highlighting jump during the transition.
 $enable-smooth-scroll: false;

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -40,15 +40,18 @@ $table-bg: $secondary-lightest-background;
 $td-enable-google-fonts: false;
 
 /*
- * Replace the default font with Inter.
+ * The $font-family-sans-serif definition here overrides the default value set by docsy
+ * (https://github.com/matrix-org/docsy/blob/66a4e61d2d34edc7196b9df83a7d09cd4af14b47/assets/scss/_variables.scss#L68)
+ * and:
  *
- * The $font-family-sans-serif definition here overrides the default value set by docsy:
- * https://github.com/matrix-org/docsy/blob/66a4e61d2d34edc7196b9df83a7d09cd4af14b47/assets/scss/_variables.scss#L68
- * and adds "Inter" to the front.
+ * - Adds "Inter" to the front (making it the default)
+ * - Inserts "Arial Unicode MS" before "Arial" (because the former contains more mathematical glyphs)
  *
- * The font itself is loaded via stylesheet link layouts/partials/hooks/head-end.html.
+ * The Inter font itself is loaded via stylesheet links layouts/partials/hooks/head-end.html.
  */
-$font-family-sans-serif: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+$font-family-sans-serif: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+  "Helvetica Neue", Arial Unicode MS, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
+  "Segoe UI Symbol";
 
 // Disable smooth scrolling as it makes TOC highlighting jump during the transition.
 $enable-smooth-scroll: false;

--- a/changelogs/internal/newsfragments/1919.clarification
+++ b/changelogs/internal/newsfragments/1919.clarification
@@ -1,0 +1,1 @@
+Prefer Arial Unicode MS over Arial for better support of mathematical symbols.

--- a/changelogs/internal/newsfragments/1919.clarification
+++ b/changelogs/internal/newsfragments/1919.clarification
@@ -1,1 +1,1 @@
-Prefer Arial Unicode MS over Arial for better support of mathematical symbols.
+Use dedicated fonts for better support of mathematical symbols.

--- a/content/rooms/fragments/v2-state-res.md
+++ b/content/rooms/fragments/v2-state-res.md
@@ -50,7 +50,7 @@ chain for each state *S*<sub>*i*</sub>, that is the union of the auth
 chains for each event in *S*<sub>*i*</sub>, and then taking every event
 that doesn't appear in every auth chain. If *C*<sub>*i*</sub> is the
 full auth chain of *S*<sub>*i*</sub>, then the auth difference is
- ∪ *C*<sub>*i*</sub> −  ∩ *C*<sub>*i*</sub>.
+∪ *C*<sub>*i*</sub> − ∩ *C*<sub>*i*</sub>.
 
 **Full conflicted set.**
 The *full conflicted set* is the union of the conflicted state set and


### PR DESCRIPTION
Fixes: #1125

This injects various fonts _before_ Arial (which has limited support for mathematical symbols):

* STIX Two Math – included in [macOS Catalina](https://www.idownloadblog.com/2020/05/28/macos-catalina-fonts-list/) and [Sonoma](https://support.apple.com/en-us/108939)
* Cambria Math – included in [Windows 10](https://learn.microsoft.com/en-us/typography/fonts/windows_10_font_list) and [11](https://learn.microsoft.com/en-us/typography/fonts/windows_11_font_list)
* Noto Sans Math – included on some Linux variants (e.g. Fedora) but might be ignored by browsers to avoid fingerprinting
* Dejavu Sans – included on some Linux variants (e.g. [Ubuntu](https://github.com/adrg/os-font-list/blob/master/md/linux/Ubuntu-21.04_Hirsute-Hippo.md) but not Fedora)

This is how it looks on macOS Sonoma:

![Screenshot 2024-08-19 at 13 31 27](https://github.com/user-attachments/assets/d7801e13-a99e-4511-847d-3b6328484d30)

### Alternatives

The only other alternative I considered was using the n-ary union and intersection symbols ⋃ and ⋂. Those wouldn't require any font changes but are way bigger which might look even worse:

![Screenshot 2024-08-07 at 15 23 39](https://github.com/user-attachments/assets/6a2201b6-3e00-4394-aacf-ad4e0337205a)

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [ ] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)





<!-- Replace -->
Preview: https://pr1919--matrix-spec-previews.netlify.app
<!-- Replace -->
