### PR TITLE
Fix required fields in `/_matrix/key/v2/server` response schema

### DIFF
--- a/changelogs/server_server/newsfragments/1930.clarification
+++ b/changelogs/server_server/newsfragments/1930.clarification
@@ -1,0 +1,1 @@
+Fix required fields in `/_matrix/key/v2/server` response schema.

--- a/data/api/server-server/definitions/keys.yaml
+++ b/data/api/server-server/definitions/keys.yaml
@@ -98,4 +98,4 @@ properties:
       publishes a key which is valid for a significant amount of time without a way
       for the homeserver owner to revoke it.
     example: 1052262000000
-required: ["server_name", "verify_keys"]
+required: ["server_name", "verify_keys", "signatures", "valid_until_ts"]


### PR DESCRIPTION
Fixes #613

`old_verify_keys` is intentionally omitted, there's no reason to require it and I accidentally fixed it being required in Synapse before realizing there was a spec issue: https://github.com/element-hq/synapse/pull/17568. Dendrite already doesn't require it, Ruma points to the spec issue https://github.com/ruma/ruma/blob/ruma-federation-api-0.9.0/crates/ruma-federation-api/src/discovery.rs#L51

<!-- Replace -->
Preview: https://pr1930--matrix-spec-previews.netlify.app
<!-- Replace -->
