### PR TITLE
Allmightlegend/1707

### DIFF
--- a/changelogs/server_server/newsfragments/1707.clarification
+++ b/changelogs/server_server/newsfragments/1707.clarification
@@ -1,0 +1,47 @@
+1. Typing notifications (which contain a single room_id)
+2. Read receipts (which can contain multiple room_ids)
+3. Presence updates (which do not contain room_ids)
+
+Typing Notification EDU Example:
+
+{
+  "edu_type": "m.typing",
+  "content": {
+    "room_id": "!roomid:example.com",
+    "user_id": "@user:example.com"
+  }
+}
+
+Read Receipt EDU Example:
+
+{
+  "edu_type": "m.receipt",
+  "content": {
+    "!roomid1:example.com": {
+      "$eventid:example.com": {
+        "@user:example.com": {
+          "ts": 1436451550453
+        }
+      }
+    },
+    "!roomid2:example.com": {
+      "$eventid:example.com": {
+        "@user:example.com": {
+          "ts": 1436451550453
+        }
+      }
+    }
+  }
+}
+
+Presence Update EDU Example (without room_id):
+
+{
+  "edu_type": "m.presence",
+  "content": {
+    "user_id": "@user:example.com",
+    "presence": "online",
+    "last_active_ago": 2478593,
+    "currently_active": true
+  }
+}

--- a/content/server-server-api.md
+++ b/content/server-server-api.md
@@ -698,9 +698,10 @@ information it needs.
 
 ## EDUs
 
-EDUs, by comparison to PDUs, do not have an ID, a room ID, or a list of
-"previous" IDs. They are intended to be non-persistent data such as user
-presence, typing notifications, etc.
+Some EDUs may lack a room_id, while others, such as typing notifications, 
+include a single room_id, and some, like read receipt EDUs, can have 
+multiple room_ids.. They are intended to be non-persistent data such as
+user presence, typing notifications, etc.
 
 {{% definition path="api/server-server/definitions/edu_with_example" %}}
 


### PR DESCRIPTION
1. Typing notifications (which contain a single room_id)
2. Read receipts (which can contain multiple room_ids)
3. Presence updates (which do not contain room_ids)

Typing Notification EDU Example:

```
{
  "edu_type": "m.typing",
  "content": {
    "room_id": "!roomid:example.com",
    "user_id": "@user:example.com"
  }
}
```

Read Receipt EDU Example:
```

{
  "edu_type": "m.receipt",
  "content": {
    "!roomid1:example.com": {
      "$eventid:example.com": {
        "@user:example.com": {
          "ts": 1436451550453
        }
      }
    },
    "!roomid2:example.com": {
      "$eventid:example.com": {
        "@user:example.com": {
          "ts": 1436451550453
        }
      }
    }
  }
}
```

Presence Update EDU Example (without room_id):
```
{
  "edu_type": "m.presence",
  "content": {
    "user_id": "@user:example.com",
    "presence": "online",
    "last_active_ago": 2478593,
    "currently_active": true
  }
}
```

Signed-off-by : `Srinjoy Sen Chowdhury srinjoysen123@gmail.com`

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)
