### PR TITLE
Add the `deprecated` field to OpenAPI definitions and JSON Schemas

### DIFF
--- a/changelogs/internal/newsfragments/1940.clarification
+++ b/changelogs/internal/newsfragments/1940.clarification
@@ -1,1 +1,1 @@
-Add the deprecated field to properties of OpenAPI definitions and JSON Schemas.
+Add the `deprecated` field to properties of OpenAPI definitions and JSON Schemas.

--- a/changelogs/internal/newsfragments/1940.clarification
+++ b/changelogs/internal/newsfragments/1940.clarification
@@ -1,0 +1,1 @@
+Add the deprecated field to properties of OpenAPI definitions and JSON Schemas.

--- a/data/api/client-server/joining.yaml
+++ b/data/api/client-server/joining.yaml
@@ -139,6 +139,7 @@ paths:
             type: string
         - in: query
           name: server_name
+          deprecated: true
           x-changedInMatrixVersion:
             "1.12": |-
               This parameter has been deprecated in favour of `via` and will be removed in

--- a/data/api/client-server/knocking.yaml
+++ b/data/api/client-server/knocking.yaml
@@ -50,6 +50,7 @@ paths:
             type: string
         - in: query
           name: server_name
+          deprecated: true
           x-changedInMatrixVersion:
             "1.12": |-
               This parameter has been deprecated in favour of `via` and will be removed in

--- a/data/api/client-server/login.yaml
+++ b/data/api/client-server/login.yaml
@@ -119,15 +119,18 @@ paths:
                   $ref: definitions/user_identifier.yaml
                 user:
                   type: string
+                  deprecated: true
                   description: The fully qualified user ID or just local part of the user ID, to
                     log in.  Deprecated in favour of `identifier`.
                 medium:
                   type: string
+                  deprecated: true
                   description: When logging in using a third-party identifier, the medium of the
                     identifier. Must be 'email'.  Deprecated in favour of
                     `identifier`.
                 address:
                   type: string
+                  deprecated: true
                   description: Third-party identifier for the user.  Deprecated in favour of
                     `identifier`.
                 password:
@@ -194,6 +197,7 @@ paths:
                     x-addedInMatrixVersion: "1.3"
                   home_server:
                     type: string
+                    deprecated: true
                     description: |-
                       The server_name of the homeserver on which the account has
                       been registered.

--- a/data/api/client-server/registration.yaml
+++ b/data/api/client-server/registration.yaml
@@ -169,6 +169,7 @@ paths:
                     x-addedInMatrixVersion: "1.3"
                   home_server:
                     type: string
+                    deprecated: true
                     description: |-
                       The server_name of the homeserver on which the account has
                       been registered.

--- a/data/event-schemas/schema/m.room.encrypted.yaml
+++ b/data/event-schemas/schema/m.room.encrypted.yaml
@@ -41,6 +41,7 @@ properties:
           Olm event. For more details, see [Messaging Algorithms](/client-server-api/#messaging-algorithms).
       sender_key:
         type: string
+        deprecated: true
         x-changedInMatrixVersion:
           "1.3": |-
             Previously this field was required, however given it offers no additional
@@ -56,6 +57,7 @@ properties:
           for more information.
       device_id:
         type: string
+        deprecated: true
         x-changedInMatrixVersion:
           "1.3": |-
             Previously this field was required for Megolm messages, however given it


### PR DESCRIPTION
I did a quick search of the "deprecated" word in the data folder and set the field where the description says that a property is deprecated.

This does not change the rendering of the spec because the descriptions already talk about the deprecation,
but it can be used by tools that rely on the OpenAPI definitions and JSON Schemas.


### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)








<!-- Replace -->
Preview: https://pr1940--matrix-spec-previews.netlify.app
<!-- Replace -->
