### PR TITLE
Add `added-in` shortcode for unread markers section

### DIFF
--- a/changelogs/client_server/newsfragments/1941.feature
+++ b/changelogs/client_server/newsfragments/1941.feature
@@ -1,0 +1,1 @@
+Add support for marking rooms as unread as per [MSC2867](https://github.com/matrix-org/matrix-spec-proposals/pull/2867).

--- a/content/client-server-api/modules/read_markers.md
+++ b/content/client-server-api/modules/read_markers.md
@@ -57,6 +57,8 @@ applicable filters are also satisfied.
 
 #### Unread markers
 
+{{% added-in v="1.12" %}}
+
 Clients may use "unread markers" to allow users to label rooms for later
 attention irrespective of [read receipts](#receipts) or
 [fully read markers](#fully-read-markers).


### PR DESCRIPTION
It seems like it was forgotten in #1895.

### Pull Request Checklist

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)





<!-- Replace -->
Preview: https://pr1941--matrix-spec-previews.netlify.app
<!-- Replace -->
