### PR TITLE
Additional keys in GET /capabilities don't have to be objects

### DIFF
--- a/changelogs/client_server/newsfragments/1945.clarification
+++ b/changelogs/client_server/newsfragments/1945.clarification
@@ -1,0 +1,1 @@
+Additional keys in `GET /capabilities` don't have to be objects.

--- a/data/api/client-server/capabilities.yaml
+++ b/data/api/client-server/capabilities.yaml
@@ -43,7 +43,9 @@ paths:
                       The custom capabilities the server supports, using the
                       Java package naming convention.
                     additionalProperties:
-                      type: object
+                      description: |-
+                        Application-dependent keys using the
+                        [Common Namespaced Identifier Grammar](/appendices/#common-namespaced-identifier-grammar).
                     properties:
                       m.change_password:
                         $ref: '#/components/schemas/booleanCapability'


### PR DESCRIPTION
Fixes: #1943

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)





<!-- Replace -->
Preview: https://pr1945--matrix-spec-previews.netlify.app
<!-- Replace -->
