### PR TITLE
Exclude checklists from alternate output formats

### DIFF
--- a/changelogs/internal/newsfragments/1954.clarification
+++ b/changelogs/internal/newsfragments/1954.clarification
@@ -1,0 +1,1 @@
+Exclude markdown checklists from alternate output formats.

--- a/config.toml
+++ b/config.toml
@@ -146,3 +146,4 @@ sidebar_menu_compact = true
     mediaType = "text/markdown"
     isPlainText = true
     baseName = "checklist"
+    notAlternative = true


### PR DESCRIPTION
This removes the "alternate" links reported to be broken in https://github.com/matrix-org/matrix-spec/pull/1937#issuecomment-2382949109. This isn't a great solution but the double prefix issue is already handled similarly in https://github.com/matrix-org/matrix-spec/blob/main/config.toml#L12.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)





<!-- Replace -->
Preview: https://pr1954--matrix-spec-previews.netlify.app
<!-- Replace -->
