### PR TITLE
Enforce consistent vertical spacing between paragraphs in endpoint definitions

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -410,6 +410,11 @@ footer {
       border-top: 1px $table-border-color solid;
     }
 
+    td > p:last-child {
+      // Avoid unnecessary space at the bottom of the cells.
+      margin-bottom: 0;
+    }
+
     &.object-table, &.response-table, &.content-type-table {
         border: 1px $table-border-color solid;
 

--- a/changelogs/internal/newsfragments/1969.clarification
+++ b/changelogs/internal/newsfragments/1969.clarification
@@ -1,0 +1,1 @@
+Enforce consistent vertical spacing between paragraphs in endpoint definitions.

--- a/layouts/partials/added-in.html
+++ b/layouts/partials/added-in.html
@@ -1,13 +1,13 @@
-{{ $ver := .v }}
-{{ $this := .this }}
+{{ $ver := .v -}}
+{{ $this := .this -}}
 
 {{/*
     This differs from the shortcode added-in by wanting to be a block instead of inline
     and by slightly altering the rendered text as a result.
 */}}
 
-{{ if $this }}
-  **New in this version.**
-{{ else }}
-  **Added in `v{{ $ver }}`**
-{{ end }}
+{{ if $this -}}
+  <p><strong>New in this version.</strong></p>
+{{ else -}}
+  <p><strong>Added in <code>v{{ $ver }}</code></strong></p>
+{{ end -}}

--- a/layouts/partials/changed-in.html
+++ b/layouts/partials/changed-in.html
@@ -6,9 +6,10 @@
     version -> details pairs.
 */ -}}
 {{ range $ver, $details := .changes_dict -}}
-    <br><br>
+  <p>
     <strong>
       Changed in <code>v{{ $ver }}</code>:
     </strong>
     {{ $details | markdownify }}
-{{ end }}
+  </p>
+{{ end -}}

--- a/layouts/partials/openapi/render-content-type.html
+++ b/layouts/partials/openapi/render-content-type.html
@@ -21,7 +21,12 @@
  <tr>
   <td><code>{{ $mime }}</code></td>
   <td>
-   {{ $body.schema.description | markdownify -}}
+   {{/*
+     Force the rendering as a block so the description is always inside a
+     paragraph. This allows to always keep the same spacing between paragraphs
+     when adding added-in and changed-in paragraphs.
+   */}}
+   {{ $body.schema.description | page.RenderString (dict "display" "block") -}}
    {{ if (index $body.schema "x-addedInMatrixVersion") }}{{ partial "added-in" (dict "v" (index $body.schema "x-addedInMatrixVersion")) }}{{ end -}}
    {{ if (index $body.schema "x-changedInMatrixVersion") }}{{ partial "changed-in" (dict "changes_dict" (index $body.schema "x-changedInMatrixVersion")) }}{{ end -}}
   </td>

--- a/layouts/partials/openapi/render-object-table.html
+++ b/layouts/partials/openapi/render-object-table.html
@@ -310,7 +310,7 @@ resolve-additional-types.)
     {{ $description := .property.description -}}
     {{ if .required -}}
         {{/*
-          Concatenate "Required:" to make it part of the first paragraph of the
+          Prepend "Required:" to make it part of the first paragraph of the
           description.
         */}}
         {{- $description = printf "<strong>Required: </strong>%s" $description -}}

--- a/layouts/partials/openapi/render-object-table.html
+++ b/layouts/partials/openapi/render-object-table.html
@@ -306,9 +306,21 @@ resolve-additional-types.)
       * `x-changedInMatrixVersion`: optional string indicating in which Matrix
         spec version this property was last changed.
 */}}
-{{ define "partials/property-description" }}
-    {{ if .required }}<strong>Required: </strong>{{end -}}
-    {{ .property.description | markdownify -}}
+{{ define "partials/property-description" -}}
+    {{ $description := .property.description -}}
+    {{ if .required -}}
+        {{/*
+          Concatenate "Required:" to make it part of the first paragraph of the
+          description.
+        */}}
+        {{- $description = printf "<strong>Required: </strong>%s" $description -}}
+    {{ end -}}
+    {{/*
+      Force the rendering as a block so the description is always inside a
+      paragraph. This allows to always keep the same spacing between paragraphs
+      when adding added-in and changed-in paragraphs.
+    */}}
+    {{ $description | page.RenderString (dict "display" "block") -}}
     {{ if .property.enum }}<p>One of: <code>[{{ delimit .property.enum ", " }}]</code>.</p>{{ end -}}
     {{ if (index .property "x-addedInMatrixVersion") }}{{ partial "added-in" (dict "v" (index .property "x-addedInMatrixVersion")) }}{{ end -}}
     {{ if (index .property "x-changedInMatrixVersion") }}{{ partial "changed-in" (dict "changes_dict" (index .property "x-changedInMatrixVersion")) }}{{ end -}}


### PR DESCRIPTION
Use `p` elements to separate paragraphs instead of `br` and enforce single paragraphs to be wrapped in `p` for consistency. Finally, remove the bottom margin of the last paragraph in a table cell.

Examples of previously affected areas:

- `GET /_matrix/client/versions`:

  Unnecessary space above "Changed in"

  [Before:](https://spec.matrix.org/v1.12/client-server-api/#get_matrixclientversions)

  ![Capture d’écran du 2024-10-12 18-12-49](https://github.com/user-attachments/assets/0a101e38-5a53-4fbf-a072-19194334a63d)

  [After:](https://pr1969--matrix-spec-previews.netlify.app/client-server-api/#get_matrixclientversions)

  ![image](https://github.com/user-attachments/assets/fc54baa9-8f91-4eb2-9300-1e5052073bc5)

- `GET /_matrix/client/v3/rooms/{roomId}/messages`'s query parameters:

  Inconsistent space above "Changed in": when the description is made of a single paragraph, the "Changed in" looks like a second paragraph with a regular spacing, but in this case, when the description is made of several paragraphs, the spacing is twice as big.
  
  [Before:](https://spec.matrix.org/v1.12/client-server-api/#get_matrixclientv3roomsroomidmessages)

  ![Capture d’écran du 2024-10-12 18-19-01](https://github.com/user-attachments/assets/5301118a-adf9-4760-afb1-4ee818e8cbc4)

  [After:](https://pr1969--matrix-spec-previews.netlify.app/client-server-api/#get_matrixclientv3roomsroomidmessages)

  ![image](https://github.com/user-attachments/assets/6954e253-2084-4c34-b91c-172ceb2646e1)

- `GET /_matrix/client/v3/rooms/{roomId}/messages`'s 200 response:

  "Required:" is not inline: when the description is made of a single paragraph, "Required:" looks like it is part of the paragraph, but in this case, when the description is made of several paragraphs, it is in its own paragraph.
  
  [Before:](https://spec.matrix.org/v1.12/client-server-api/#get_matrixclientv3roomsroomidmessages)

  ![Capture d’écran du 2024-10-12 18-24-47](https://github.com/user-attachments/assets/8a8ea6b7-5ceb-4f26-b61d-8087603c193d)

  [After:](https://pr1969--matrix-spec-previews.netlify.app/client-server-api/#get_matrixclientv3roomsroomidmessages)

  ![image](https://github.com/user-attachments/assets/cbc31001-98e0-4c08-a961-0ba9a253be2f)

- `GET /_matrix/client/v3/rooms/{roomId}/messages`'s 200 response:

  Inconsistent spacing at the bottom of the table cells. When the description is made of a single paragraph, the padding looks the same at the bottom as at the top, but in this case, when the description is made of several paragraphs, the padding at the bottom is twice as big. This also affects cells with "Added in" or "Changed in" paragraphs.
  
  [Before:](https://spec.matrix.org/v1.12/client-server-api/#get_matrixclientv3roomsroomidmessages)

  ![Capture d’écran du 2024-10-12 18-30-30](https://github.com/user-attachments/assets/81868d7e-837b-4259-aad6-07b3758100f1)

  [After:](https://pr1969--matrix-spec-previews.netlify.app/client-server-api/#get_matrixclientv3roomsroomidmessages)

  ![image](https://github.com/user-attachments/assets/7b46e9a5-45d1-4840-97f5-bf47ec50749d)

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)


<!-- Replace -->
Preview: https://pr1969--matrix-spec-previews.netlify.app
<!-- Replace -->
