### PR TITLE
Remove `withVersioning` parameter of `rver-fragment` shortcode.

### DIFF
--- a/changelogs/internal/newsfragments/1971.clarification
+++ b/changelogs/internal/newsfragments/1971.clarification
@@ -1,0 +1,1 @@
+Remove `withVersioning` parameter of `rver-fragment` shortcode.

--- a/content/rooms/v11.md
+++ b/content/rooms/v11.md
@@ -21,7 +21,7 @@ event keeps the `redacts` property under `content`. The
 
 The full redaction algorithm follows.
 
-{{% rver-fragment name="v11-redactions" withVersioning="true" %}}
+{{% rver-fragment name="v11-redactions" %}}
 
 ### Event format
 

--- a/layouts/shortcodes/rver-fragment.html
+++ b/layouts/shortcodes/rver-fragment.html
@@ -7,23 +7,12 @@
 
     The `name` parameter is the file name without extension.
 
-    The `withVersioning` parameter is optional and defaults to false. When true, any
-    mentions of "New in this version" from the `added-in` shortcode are removed prior
-    to rendering. This is useful if needing to use a fragment where part of it describes
-    new functionality in a given room version but isn't new for subsequent versions.
-
 */}}
 
-{{ $name := .Params.name }}
-{{ $withVersioning := .Params.withVersioning }}
+{{ $name := .Params.name -}}
 
-{{ with .Site.GetPage "rooms/fragments" }}
-    {{ with .Resources.GetMatch (printf "%s%s" $name ".md") }}
-        {{ $content := .RenderShortcodes }}
-        {{ if not $withVersioning }}
-            {{ $content = (replace $content "[New in this version]" "") }}
-            {{ $content = (replace $content "[Changed in this version]" "") }}
-        {{ end }}
-{{ $content | safeHTML }}
-    {{ end }}
-{{ end }}
+{{ with .Site.GetPage "rooms/fragments" -}}
+    {{ with .Resources.GetMatch (printf "%s.md" $name) -}}
+        {{ .RenderShortcodes | safeHTML }}
+    {{ end -}}
+{{ end -}}


### PR DESCRIPTION
Since #1884, we detect automatically in the `added-in` and `changed-in` shortcodes whether we need to add text according to the page's room version so this parameter has become unnecessary.
Moreover, forgetting to set this param can remove the text generated by the shortcodes so it is safer to just get rid of it.

Case in point, two `[New in this version]` were missing:
- Room v3 - Handling redactions ([before](https://spec.matrix.org/v1.12/rooms/v3/#handling-redactions) / [after](https://pr1971--matrix-spec-previews.netlify.app/rooms/v3/#handling-redactions))
- Room v4 - Event IDs ([before](https://spec.matrix.org/unstable/rooms/v4/#event-ids) / [after](https://pr1971--matrix-spec-previews.netlify.app/rooms/v4/#event-ids))

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)


<!-- Replace -->
Preview: https://pr1971--matrix-spec-previews.netlify.app
<!-- Replace -->
