### PR TITLE
Remove `span` element from `added-in` and `changed-in` shortcodes

### DIFF
--- a/changelogs/internal/newsfragments/1972.clarification
+++ b/changelogs/internal/newsfragments/1972.clarification
@@ -1,0 +1,1 @@
+Remove `span` element from `added-in` and `changed-in` shortcodes.

--- a/layouts/shortcodes/added-in.html
+++ b/layouts/shortcodes/added-in.html
@@ -2,8 +2,8 @@
 
 {{- with page.Params.version -}}
   {{- if eq $ver . -}}
-    <span><strong>[New in this version]</strong></span>
+    <strong>[New in this version]</strong>
   {{- end -}}
 {{- else -}}
-  <span><strong>[Added in <code>v{{ $ver }}</code>]</strong></span>
+  <strong>[Added in <code>v{{ $ver }}</code>]</strong>
 {{- end -}}

--- a/layouts/shortcodes/changed-in.html
+++ b/layouts/shortcodes/changed-in.html
@@ -2,8 +2,8 @@
 
 {{- with page.Params.version -}}
   {{- if eq $ver . -}}
-    <span><strong>[Changed in this version]</strong></span>
+    <strong>[Changed in this version]</strong>
   {{- end -}}
 {{- else -}}
-  <span><strong>[Changed in <code>v{{ $ver }}</code>]</strong></span>
+  <strong>[Changed in <code>v{{ $ver }}</code>]</strong>
 {{- end -}}


### PR DESCRIPTION
It is unnecessary and has no effect.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)





<!-- Replace -->
Preview: https://pr1972--matrix-spec-previews.netlify.app
<!-- Replace -->
