### PR TITLE
Clarify that servers must forward custom keys in `PusherData`

### DIFF
--- a/changelogs/client_server/newsfragments/1973.clarification
+++ b/changelogs/client_server/newsfragments/1973.clarification
@@ -1,1 +1,1 @@
-Servers must forward custom keys in `PusherData` when sending notifications to the push gateway.
+Clarify that servers must forward custom keys in `PusherData` when sending notifications to the push gateway.

--- a/changelogs/client_server/newsfragments/1973.clarification
+++ b/changelogs/client_server/newsfragments/1973.clarification
@@ -1,0 +1,1 @@
+Servers must forward custom keys in `PusherData` when sending notifications to the push gateway.

--- a/data/api/client-server/pusher.yaml
+++ b/data/api/client-server/pusher.yaml
@@ -210,17 +210,21 @@ paths:
                   type: object
                   description: |-
                     Required if `kind` is not `null`. A dictionary of information
-                    for the pusher implementation itself. If `kind` is `http`,
-                    this should contain `url` which is the URL to use to send
-                    notifications to.
+                    for the pusher implementation itself.
+
+                    If `kind` is `http`, this MUST contain `url` which is the URL
+                    to use for sending notifications. Clients MAY use this object
+                    to pass custom data to their push gateway. Servers MUST forward
+                    the entire content including any custom keys but excluding `url`
+                    when calling [`/_matrix/push/v1/notify`](/push-gateway-api/#post_matrixpushv1notify).
                   title: PusherData
                   properties:
                     url:
                       type: string
                       format: uri
                       description: |-
-                        Required if `kind` is `http`. The URL to use to send
-                        notifications to. MUST be an HTTPS URL with a path of
+                        Required if `kind` is `http`. The URL to use for sending
+                        notifications. MUST be an HTTPS URL with a path of
                         `/_matrix/push/v1/notify`.
                       example: https://push-gateway.location.here/_matrix/push/v1/notify
                     format:

--- a/data/api/client-server/pusher.yaml
+++ b/data/api/client-server/pusher.yaml
@@ -215,7 +215,7 @@ paths:
                     If `kind` is `http`, this MUST contain `url` which is the URL
                     to use for sending notifications. Clients MAY use this object
                     to pass custom data to their push gateway. Servers MUST forward
-                    the entire content including any custom keys but excluding `url`
+                    the entire content including `format` and any custom keys but excluding `url`
                     when calling [`/_matrix/push/v1/notify`](/push-gateway-api/#post_matrixpushv1notify).
                   title: PusherData
                   properties:


### PR DESCRIPTION
Relates to: #921

CC @jplatte.

While at it I tried to improve the "URL to use to send notifications to" wording and upgraded "should contain `url`" to "MUST contain `url`" since the field is required for http pushers.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)











<!-- Replace -->
Preview: https://pr1973--matrix-spec-previews.netlify.app
<!-- Replace -->
