### PR TITLE
Remove CSS workaround for scroll-anchoring

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -26,12 +26,6 @@ Custom SCSS for the Matrix spec
  */
 @import "syntax.scss";
 
-/* Workaround for https://github.com/google/docsy/issues/1116:
- * fix scroll-anchoring */
-.td-outer {
-    height: auto;
-}
-
 /* Overrides for the navbar */
 .td-navbar {
   box-shadow: 0px 0px 8px rgba(179, 179, 179, 0.25);

--- a/changelogs/internal/newsfragments/1976.clarification
+++ b/changelogs/internal/newsfragments/1976.clarification
@@ -1,0 +1,1 @@
+Remove CSS workaround for scroll-anchoring.


### PR DESCRIPTION
Docsy does not set the `height` anymore, but the `min-height`, which doesn't seem to affect scroll-anchoring. See https://github.com/google/docsy/commit/f22a70ec566ecdcfb267e1792115e96f7ed16ade


### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)





<!-- Replace -->
Preview: https://pr1976--matrix-spec-previews.netlify.app
<!-- Replace -->
