### PR TITLE
Improve the JS script to highlight the current ToC entry

### DIFF
--- a/changelogs/internal/newsfragments/1991.clarification
+++ b/changelogs/internal/newsfragments/1991.clarification
@@ -1,0 +1,1 @@
+Improve the JS script to highlight the current ToC entry.

--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -2,10 +2,8 @@
 
   This template is included at the end of each page's `<body>`.
 
-  We're using it here to:
-
-  1) highlight and scroll the ToC in the sidebar to match the place we are at
-  in the document.
+  We're using it here to highlight and scroll the ToC in the sidebar to match
+  the place we are at in the document.
 
 */}}
 

--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -4,14 +4,9 @@
 
   We're using it here to:
 
-  1) include the JS that generates the table of contents. It would be better
-  to generate the table of contents as part of the Hugo build process, but
-  that doesn't work nicely with the way we want to author client-server modules
-  as separate files.
-
-  2) highlight and scroll the ToC in the sidebar to match the place we are at
+  1) highlight and scroll the ToC in the sidebar to match the place we are at
   in the document.
 
 */}}
 
-<script defer language="javascript" type="text/javascript"  src="{{ "js/toc.js" | urlize | relURL }}"></script>
+<script defer language="javascript" type="text/javascript"  src="{{ "js/toc.js" | relURL }}"></script>


### PR DESCRIPTION
The code relied on an `IntersectionOberver`, so the ToC was only updated when a heading was in the viewport.
It meant that if we jumped to a part of the text that has no heading, the ToC would still point to the old entry. This issue can be reproduced by clicking on a link to an endpoint definition, clicking somewhere in the scrollbar, or using the search function from the browser.

The new code looks for the correct heading when the view is scrolled so the correct entry is always selected.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)





<!-- Replace -->
Preview: https://pr1991--matrix-spec-previews.netlify.app
<!-- Replace -->
