### PR TITLE
Fix author links in the proposals lists

### DIFF
--- a/changelogs/internal/newsfragments/1997.clarification
+++ b/changelogs/internal/newsfragments/1997.clarification
@@ -1,0 +1,1 @@
+Fix relative URLs when serving the specification with a custom `baseURL`.

--- a/layouts/shortcodes/proposal-tables.html
+++ b/layouts/shortcodes/proposal-tables.html
@@ -60,7 +60,6 @@
             {{ end }}
             {{ $docs_links := delimit $docs_links_list ", " }}
 
-            {{ $authors_list := apply .authors "htmlEscape" "." }}
             {{ $authors_list := apply .authors "printf" "<a href=\"https://github.com/%s\">@%s</a>" "." "." }}
             {{ $authors := delimit $authors_list ", " }}
 

--- a/layouts/shortcodes/proposal-tables.html
+++ b/layouts/shortcodes/proposal-tables.html
@@ -60,6 +60,7 @@
             {{ end }}
             {{ $docs_links := delimit $docs_links_list ", " }}
 
+            {{ $authors_list := apply .authors "htmlEscape" "." }}
             {{ $authors_list := apply .authors "printf" "<a href=\"https://github.com/%s\">@%s</a>" "." "." }}
             {{ $authors := delimit $authors_list ", " }}
 
@@ -68,8 +69,8 @@
       <td>{{ .title }}</td>
       <td>{{ .created_at }}</td>
       <td>{{ .updated_at }}</td>
-      <td>{{ with $docs_links }}{{ $docs_links }}{{ end }}</td>
-      <td>{{ $authors }}</td>
+      <td>{{ with $docs_links }}{{ $docs_links | safeHTML }}{{ end }}</td>
+      <td>{{ $authors | safeHTML }}</td>
       <td>{{ with .shepherd }}<a href="https://github.com/{{ . }}">@{{ . }}</a>{{ end }}</td>
   </tr>
         {{ end }}


### PR DESCRIPTION
Links were broken since the upgrade of the hugo version in #1984.

The broken state can be viewed at [the preview from that PR](https://pr1984--matrix-spec-previews.netlify.app/proposals/#work-in-progress). ~~It cannot be viewed at https://spec.matrix.org/proposals yet because it hasn't been updated since the upgrade (although it is broken on a different way because of the upgrade too).~~ Now visible at https://spec.matrix.org/proposals/#work-in-progress


### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)








<!-- Replace -->
Preview: https://pr1997--matrix-spec-previews.netlify.app
<!-- Replace -->
