### PR TITLE
Fix error in ToC script at the bottom of the page

### DIFF
--- a/assets/js/toc.js
+++ b/assets/js/toc.js
@@ -107,6 +107,11 @@ function getCurrentHeading(headings, headerOffset) {
     index += 1;
   }
 
+  // At the bottom of the page we might not have a heading.
+  if (!currentHeading) {
+    currentHeading = prevHeading;
+  }
+
   return currentHeading;
 }
 

--- a/changelogs/internal/newsfragments/2002.clarification
+++ b/changelogs/internal/newsfragments/2002.clarification
@@ -1,0 +1,1 @@
+Improve the JS script to highlight the current ToC entry.


### PR DESCRIPTION
It didn't account for the case where there is no visible heading at the bottom of the page.

The error should be easy to reproduce in the current unstable spec, by navigating to the very bottom of the CS spec. A bunch or errors should appear in the console log.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)





<!-- Replace -->
Preview: https://pr2002--matrix-spec-previews.netlify.app
<!-- Replace -->
