### PR TITLE
Fix regression introduced when inlining "Required" with description

### DIFF
--- a/layouts/partials/openapi/render-object-table.html
+++ b/layouts/partials/openapi/render-object-table.html
@@ -313,7 +313,7 @@ resolve-additional-types.)
           Prepend "Required:" to make it part of the first paragraph of the
           description.
         */}}
-        {{- $description = printf "<strong>Required: </strong>%s" $description -}}
+        {{- $description = printf "<strong>Required: </strong>%s" (default "" $description) -}}
     {{ end -}}
     {{/*
       Force the rendering as a block so the description is always inside a


### PR DESCRIPTION
This was a regression in the rendered spec introduced in #1969.

If the description is not set in the object definition, Hugo generates a weird string after "Required": `%!s(<nil>)`.

To avoid that, we default the description to an empty string when it is not set.

Example, in the `m.text` definition:

[Before](https://spec.matrix.org/unstable/client-server-api/#mtext):

![image](https://github.com/user-attachments/assets/40ab5196-b1f4-4518-a7d6-70e6818a8727)



### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)
