### PR TITLE
Fix `changed-in` partial when used with multiple paragraphs

### DIFF
--- a/changelogs/internal/newsfragments/2006.clarification
+++ b/changelogs/internal/newsfragments/2006.clarification
@@ -1,0 +1,1 @@
+Fix `changed-in` partial when used with multiple paragraphs.

--- a/layouts/partials/changed-in.html
+++ b/layouts/partials/changed-in.html
@@ -1,15 +1,11 @@
-{{/*
+{{- /*
     Renders the "Changed in [version]:" blocks for x-changedInMatrixVersion
     annotations for openapi parameters
 
     Takes a single 'changes_dict' parameter, which should be a map of
     version -> details pairs.
 */ -}}
-{{ range $ver, $details := .changes_dict -}}
-  <p>
-    <strong>
-      Changed in <code>v{{ $ver }}</code>:
-    </strong>
-    {{ $details | markdownify }}
-  </p>
+{{- range $ver, $details := .changes_dict -}}
+    {{- $details = printf "**Changed in `v%s`:** %s" $ver (default "" $details) -}}
+    {{- $details | page.RenderString (dict "display" "block") -}}
 {{ end -}}


### PR DESCRIPTION
When used with a text that includes multiple paragraphs, the partial created invalid HTML by nesting `<p>` elements. It also changed the rendering by making "Changed in vX.XX:" a separate paragraph, when it is inline with a single paragraph.

To change that we do as with "Required" and prepend "Changed in vX.XX:" to the text before it is rendered, making it inline with the first paragraph.

Example: in the `POST /_matrix/client/v3/join/{roomIdOrAlias}`'s request definition:

[Before](https://spec.matrix.org/unstable/client-server-api/#post_matrixclientv3joinroomidoralias):

![image](https://github.com/user-attachments/assets/72d25da1-0709-4b2e-ae72-280d212eed80)

[After](https://pr2006--matrix-spec-previews.netlify.app/client-server-api/#post_matrixclientv3joinroomidoralias):

![image](https://github.com/user-attachments/assets/93b65321-e308-45d8-b396-2edf520d6c72)


### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)


<!-- Replace -->
Preview: https://pr2006--matrix-spec-previews.netlify.app
<!-- Replace -->
