### PR TITLE
Remove trailing slash on void HTML elements

### DIFF
--- a/changelogs/internal/newsfragments/2009.clarification
+++ b/changelogs/internal/newsfragments/2009.clarification
@@ -1,0 +1,1 @@
+Remove trailing slash on void HTML elements.

--- a/layouts/partials/events/render-event.html
+++ b/layouts/partials/events/render-event.html
@@ -27,7 +27,7 @@
 
 </summary>
 
-  <hr/>
+  <hr>
 
 {{ if (index $event_data "x-addedInMatrixVersion") }}
   {{ partial "added-in" (dict "v" (index $event_data "x-addedInMatrixVersion")) }}

--- a/layouts/partials/favicons.html
+++ b/layouts/partials/favicons.html
@@ -7,5 +7,5 @@
 {{- $ico := resources.Get "icons/favicon.ico" -}}
 {{- $svg := resources.Get "icons/favicon.svg" -}}
 
-<link rel="shortcut icon" href="{{ $ico.RelPermalink }}" >
-<link rel="icon" type="image/svg+xml" href="{{ $svg.RelPermalink }}" />
+<link rel="shortcut icon" href="{{ $ico.RelPermalink }}">
+<link rel="icon" type="image/svg+xml" href="{{ $svg.RelPermalink }}">

--- a/layouts/partials/openapi/render-operation.html
+++ b/layouts/partials/openapi/render-operation.html
@@ -40,7 +40,7 @@
   </h1>
 </summary>
 
-  <hr/>
+  <hr>
 
 {{ if $operation_data.deprecated }}
     {{ partial "alert" (dict "type" "warning" "omit_title" "true" "content" "This API is deprecated and will be removed from a future release.") }}
@@ -84,9 +84,9 @@
  </tr>
 </table>
 
-<hr/>
+<hr>
 {{ partial "openapi/render-request"   (dict "parameters" $operation_data.parameters "request_body" $operation_data.requestBody "anchor_base" $anchor ) }}
-<hr/>
+<hr>
 {{ partial "openapi/render-responses" (dict "responses" $operation_data.responses "anchor_base" $anchor ) }}
 
 </details>

--- a/layouts/shortcodes/changelog/changelogs.html
+++ b/layouts/shortcodes/changelog/changelogs.html
@@ -4,5 +4,5 @@
 */}}
 
 {{ with index .Page.RegularPages.ByDate.Reverse 0 }}
-   <meta http-equiv="refresh" content="0; url={{ .RelPermalink }}" />
+   <meta http-equiv="refresh" content="0; url={{ .RelPermalink }}">
 {{ end }}

--- a/layouts/shortcodes/definition.html
+++ b/layouts/shortcodes/definition.html
@@ -39,7 +39,7 @@
 
 </summary>
 
-<hr/>
+<hr>
 
 {{ if (index $definition "x-addedInMatrixVersion") }}
   {{ partial "added-in" (dict "v" (index $definition "x-addedInMatrixVersion")) }}

--- a/layouts/shortcodes/diagram.html
+++ b/layouts/shortcodes/diagram.html
@@ -45,8 +45,8 @@
     {{- $fallback := $highRes.Resize (printf "%sx png" $width) -}}
 
 <picture>
-    <source srcset="{{ $lowRes.RelPermalink }}, {{ $highRes.RelPermalink }} 2x" type="image/webp" />
-    <img src="{{ $fallback.RelPermalink }}" alt="{{ $alt }}" width="{{ $width }}" height="{{ $height }}" loading="lazy" />
+    <source srcset="{{ $lowRes.RelPermalink }}, {{ $highRes.RelPermalink }} 2x" type="image/webp">
+    <img src="{{ $fallback.RelPermalink }}" alt="{{ $alt }}" width="{{ $width }}" height="{{ $height }}" loading="lazy">
 </picture>
 {{- else -}}
     {{- errorf "diagram %s not found" $path -}}

--- a/layouts/shortcodes/event-fields.html
+++ b/layouts/shortcodes/event-fields.html
@@ -28,7 +28,7 @@
 </h1>
 </summary>
 
-<hr/>
+<hr>
 
 {{ $event.description | markdownify }}
 


### PR DESCRIPTION
According to the [W3C's HTML validator](https://validator.w3.org), [trailing slashes in void-element have no effect](https://github.com/validator/validator/wiki/Markup-%C2%BB-Void-elements#trailing-slashes-in-void-element-start-tags-do-not-mark-the-start-tags-as-self-closing), and [might interact badly in some cases](https://github.com/validator/validator/wiki/Markup-%C2%BB-Void-elements#trailing-slashes-directly-preceded-by-unquoted-attribute-values).

Although this is not strictly necessary, it's nice to have clean bill when using a validator.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)





<!-- Replace -->
Preview: https://pr2009--matrix-spec-previews.netlify.app
<!-- Replace -->
