### PR TITLE
Clarify that lazy_load_members in timeline isn't respected in /sync

### DIFF
--- a/data/api/client-server/definitions/room_event_filter.yaml
+++ b/data/api/client-server/definitions/room_event_filter.yaml
@@ -28,7 +28,8 @@ allOf:
       description: |-
         If `true`, enables lazy-loading of membership events. See
         [Lazy-loading room members](/client-server-api/#lazy-loading-room-members)
-        for more information. Defaults to `false`.
+        for more information. Defaults to `false`. Only applies to the `/messages`
+        endpoint, for `/sync` this should be specified in `StateFilter` instead.
     include_redundant_members:
       type: boolean
       description: |-
@@ -36,7 +37,8 @@ allOf:
         been sent to the client. Does not
         apply unless `lazy_load_members` is `true`. See
         [Lazy-loading room members](/client-server-api/#lazy-loading-room-members)
-        for more information. Defaults to `false`.
+        for more information. Defaults to `false`. Only applies to the `/messages`
+        endpoint, for `/sync` this should be specified in `StateFilter` instead.
     not_rooms:
       description: A list of room IDs to exclude. If this list is absent then no rooms
         are excluded. A matching room will be excluded even if it is listed in the `'rooms'`


### PR DESCRIPTION
This one caught me out today, clarify that sync only uses `lazy_load_members` from `state`.

https://github.com/element-hq/synapse/blob/develop/synapse/api/filtering.py#L240-L241

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [ ] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)

Signed-off-by: Brad Murray <brad@beeper.com>

<!-- Replace -->
Preview: https://pr2010--matrix-spec-previews.netlify.app
<!-- Replace -->
