### PR TITLE
Remove distinction between `StateFilter` and `RoomEventFilter`

### DIFF
--- a/changelogs/client_server/newsfragments/2015.clarification
+++ b/changelogs/client_server/newsfragments/2015.clarification
@@ -1,0 +1,1 @@
+Remove distinction between `StateFilter` and `RoomEventFilter`.

--- a/content/client-server-api/_index.md
+++ b/content/client-server-api/_index.md
@@ -29,7 +29,7 @@ JSON object.  Clients should supply a `Content-Type` header of
 
 The exceptions are:
 
-- [`POST /_matrix/media/v3/upload`](#post_matrixmediav3upload) and 
+- [`POST /_matrix/media/v3/upload`](#post_matrixmediav3upload) and
   [`PUT /_matrix/media/v3/upload/{serverName}/{mediaId}`](#put_matrixmediav3uploadservernamemediaid),
   both of which take the uploaded media as the request body.
 - [`POST /_matrix/client/v3/logout`](#post_matrixclientv3logout) and
@@ -1471,7 +1471,7 @@ Content-Type: application/json
 ```
 
 Servers SHOULD NOT invalidate access tokens on locked accounts unless the
-client requests a logout (using the above endpoints). This ensures that 
+client requests a logout (using the above endpoints). This ensures that
 users can retain their sessions without having to log back in if the account
 becomes unlocked.
 
@@ -1756,8 +1756,9 @@ events to the client to ease implementation, although such redundancy
 should be minimised where possible to conserve bandwidth.
 
 In terms of filters, lazy-loading is enabled by enabling
-`lazy_load_members` on a `RoomEventFilter` (or a `StateFilter` in the
-case of `/sync` only). When enabled, lazy-loading aware endpoints (see
+`lazy_load_members` on a
+[`RoomEventFilter`](#post_matrixclientv3useruseridfilter_request_roomeventfilter).
+When enabled, lazy-loading aware endpoints (see
 below) will only include membership events for the `sender` of events
 being included in the response. For example, if a client makes a `/sync`
 request with lazy-loading enabled, the server will only return

--- a/data/api/client-server/definitions/sync_filter.yaml
+++ b/data/api/client-server/definitions/sync_filter.yaml
@@ -69,7 +69,6 @@ properties:
         type: boolean
       state:
         type: object
-        title: StateFilter
         allOf:
         - $ref: room_event_filter.yaml
         description: The state events to include for rooms.

--- a/data/api/client-server/sync.yaml
+++ b/data/api/client-server/sync.yaml
@@ -26,7 +26,8 @@ paths:
         incremental deltas to the state, and to receive new messages.
 
         *Note*: This endpoint supports lazy-loading. See [Filtering](/client-server-api/#filtering)
-        for more information. Lazy-loading members is only supported on a `StateFilter`
+        for more information. Lazy-loading members is only supported on the `state` part of a
+        [`RoomFilter`](#post_matrixclientv3useruseridfilter_request_roomfilter)
         for this endpoint. When lazy-loading is enabled, servers MUST include the
         syncing user's own membership event when they join a room, or when the
         full state of rooms is requested, to aid discovering the user's avatar &


### PR DESCRIPTION
They are exactly the same type, so let's combine their tables together.

History: the distinction was initally added in https://github.com/matrix-org/matrix-spec-proposals/pull/1758, when `lazy_load_members` wasn't supported on `RoomEventFilter`. `lazy_load_members` was later moved to `RoomEventFilter` in https://github.com/matrix-org/matrix-spec-proposals/pull/2035, but the distinct name for the object persisted.


<!-- Replace -->
Preview: https://pr2015--matrix-spec-previews.netlify.app
<!-- Replace -->
