### PR TITLE
Use `json` instead of `json5` for syntax highlighting

### DIFF
--- a/changelogs/client_server/newsfragments/2017.clarification
+++ b/changelogs/client_server/newsfragments/2017.clarification
@@ -1,0 +1,1 @@
+Use `json` instead of `json5` for syntax highlighting.

--- a/content/client-server-api/modules/event_replacements.md
+++ b/content/client-server-api/modules/event_replacements.md
@@ -309,7 +309,7 @@ for re-notifying if the sending client feels a large enough revision was made).
 
 For example, if there is an event mentioning Alice:
 
-```json5
+```json
 {
     "event_id": "$original_event",
     "type": "m.room.message",
@@ -324,7 +324,7 @@ For example, if there is an event mentioning Alice:
 
 And an edit to also mention Bob:
 
-```json5
+```json
 {
   "content": {
     "body": "* Hello Alice & Bob!",

--- a/content/client-server-api/modules/rich_replies.md
+++ b/content/client-server-api/modules/rich_replies.md
@@ -31,7 +31,7 @@ the `rel_type` and `event_id` properties of `m.relates_to` become *optional*.
 
 An example reply would be:
 
-```json5
+```json
 {
   "content": {
     "m.relates_to": {
@@ -187,7 +187,7 @@ of the replied to event and any users mentioned in that event. See
 
 An example including mentioning the original sender and other users:
 
-```json5
+```json
 {
   "content": {
     "m.relates_to": {


### PR DESCRIPTION
Chroma, the library used for syntax highlighting in Hugo, [does not support JSON5](https://github.com/alecthomas/chroma/issues/629) so those code blocks were not highlighted. However it supports comments in JSON so they are highlighted correctly in the rendered spec.


### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)





<!-- Replace -->
Preview: https://pr2017--matrix-spec-previews.netlify.app
<!-- Replace -->
