### PR TITLE
Remove `type` and `language` attributes of `script` element

### DIFF
--- a/changelogs/internal/newsfragments/2021.clarification
+++ b/changelogs/internal/newsfragments/2021.clarification
@@ -1,0 +1,1 @@
+Remove `type` and `language` attributes of `script` element.

--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -7,4 +7,4 @@
 
 */}}
 {{ $toc := resources.Get "js/toc.js" -}}
-<script defer language="javascript" type="text/javascript"  src="{{ $toc.RelPermalink }}"></script>
+<script defer src="{{ $toc.RelPermalink }}"></script>


### PR DESCRIPTION
The [`type`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type) attribute is not needed when the content is JavaScript. From MDN:

> Authors are encouraged to omit the attribute if the script refers to JavaScript code rather than specify a MIME type.

And the [`language`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#language) attribute is non-standard and deprecated.


### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)





<!-- Replace -->
Preview: https://pr2021--matrix-spec-previews.netlify.app
<!-- Replace -->
