### PR TITLE
Change the accessible role of info boxes to `note`

### DIFF
--- a/changelogs/internal/newsfragments/2022.clarification
+++ b/changelogs/internal/newsfragments/2022.clarification
@@ -1,0 +1,1 @@
+Change the accessible role of info boxes to `note`.

--- a/layouts/partials/alert.html
+++ b/layouts/partials/alert.html
@@ -15,6 +15,6 @@
 {{ $content := .content}}
 {{ $omit_title := .omit_title }}
 
-<div class="alert {{ $type }} {{ if $omit_title }}omit-title{{end}}" role="alert">
+<div class="alert {{ $type }} {{ if $omit_title }}omit-title{{end}}" role="note">
 {{ $content }}
 </div>


### PR DESCRIPTION
The [`alert`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role) role is intrusive and should only be used when the user's immediate attention is required.

Given that these boxes expand on the paragraph where they are included, the [`note`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/note_role) role seems more appropriate.


### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)





<!-- Replace -->
Preview: https://pr2022--matrix-spec-previews.netlify.app
<!-- Replace -->
