### PR TITLE
Fix added-in Matrix spec version for report room endpoint

### DIFF
--- a/changelogs/client_server/newsfragments/2028.new
+++ b/changelogs/client_server/newsfragments/2028.new
@@ -1,0 +1,1 @@
+Add `POST /_matrix/client/v3/rooms/{roomId}/report` as per [MSC4151](https://github.com/matrix-org/matrix-spec-proposals/pull/4151).

--- a/content/client-server-api/modules/report_content.md
+++ b/content/client-server-api/modules/report_content.md
@@ -25,7 +25,7 @@ be legitimate.
 verify that the reporting user is currently joined to the room the event
 is in before accepting a report.
 
-{{% added-in v="1.12" %}} Contrarily, servers MUST NOT restrict room reports
+{{% added-in v="1.13" %}} Contrarily, servers MUST NOT restrict room reports
 based on whether or not the reporting user is joined to the room. This is
 because users can be exposed to harmful content without being joined to a
 room. For instance, through room directories or invites.

--- a/data/api/client-server/report_content.yaml
+++ b/data/api/client-server/report_content.yaml
@@ -18,7 +18,7 @@ info:
 paths:
   "/rooms/{roomId}/report":
     post:
-      x-addedInMatrixVersion: "1.12"
+      x-addedInMatrixVersion: "1.13"
       summary: Report a room as inappropriate.
       description: |-
         Reports a room as inappropriate to the server, which may then notify


### PR DESCRIPTION
#1938 was merged this cycle with "added in" set to v1.12 instead of v1.13. This fixes it.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)





<!-- Replace -->
Preview: https://pr2028--matrix-spec-previews.netlify.app
<!-- Replace -->
