### PR TITLE
Specify the order in which one-time keys are returned (MSC4225)

### DIFF
--- a/changelogs/client_server/newsfragments/2029.clarification
+++ b/changelogs/client_server/newsfragments/2029.clarification
@@ -1,0 +1,1 @@
+Specify order of one-time keys, as per [MSC4225](https://github.com/matrix-org/matrix-spec-proposals/pull/4225).

--- a/changelogs/client_server/newsfragments/2029.clarification
+++ b/changelogs/client_server/newsfragments/2029.clarification
@@ -1,1 +1,1 @@
-Specify order of one-time keys, as per [MSC4225](https://github.com/matrix-org/matrix-spec-proposals/pull/4225).
+Specify order that one-time keys are issued by `/keys/claim`, as per [MSC4225](https://github.com/matrix-org/matrix-spec-proposals/pull/4225).

--- a/data/api/client-server/keys.yaml
+++ b/data/api/client-server/keys.yaml
@@ -300,6 +300,10 @@ paths:
         [/keys/upload](/client-server-api/#post_matrixclientv3keysupload). (All
         keys uploaded within a given call to `/keys/upload` are considered
         equivalent in this regard; no ordering is specified within them.)
+
+        Servers must ensure that each one-time key is returned at most once,
+        so when a key has been returned, no other request will ever return
+        the same key.
       operationId: claimKeys
       security:
         - accessTokenQuery: []

--- a/data/api/client-server/keys.yaml
+++ b/data/api/client-server/keys.yaml
@@ -288,7 +288,17 @@ paths:
   /keys/claim:
     post:
       summary: Claim one-time encryption keys.
-      description: Claims one-time keys for use in pre-key messages.
+      description: |-
+        Claims one-time keys for use in pre-key messages.
+
+        The request contains the user ID, device ID and algorithm name of the
+        keys that are required. The response contains a key matching this -
+        either a one-time key, or if none are available, a fallback key.
+
+        One-time keys are given out in the order that they were uploaded via
+        [/keys/upload](/client-server-api/#post_matrixclientv3keysupload). (All
+        keys uploaded within a given call to `/keys/upload` are considered
+        equivalent in this regard; no ordering is specified within them.)
       operationId: claimKeys
       security:
         - accessTokenQuery: []

--- a/data/api/client-server/keys.yaml
+++ b/data/api/client-server/keys.yaml
@@ -292,8 +292,9 @@ paths:
         Claims one-time keys for use in pre-key messages.
 
         The request contains the user ID, device ID and algorithm name of the
-        keys that are required. The response contains a key matching this -
-        either a one-time key, or if none are available, a fallback key.
+        keys that are required. If a key matching these requirements can be
+        found, the response contains it. The returned key is a one-time key
+        if one is available, and otherwise a fallback key.
 
         One-time keys are given out in the order that they were uploaded via
         [/keys/upload](/client-server-api/#post_matrixclientv3keysupload). (All

--- a/data/api/server-server/user_keys.yaml
+++ b/data/api/server-server/user_keys.yaml
@@ -32,6 +32,10 @@ paths:
         [/keys/upload](/client-server-api/#post_matrixclientv3keysupload). (All
         keys uploaded within a given call to `/keys/upload` are considered
         equivalent in this regard; no ordering is specified within them.)
+
+        Servers must ensure that each one-time key is returned at most once,
+        so when a key has been returned, no other request will ever return
+        the same key.
       operationId: claimUserEncryptionKeys
       security:
         - signedRequest: []

--- a/data/api/server-server/user_keys.yaml
+++ b/data/api/server-server/user_keys.yaml
@@ -20,7 +20,17 @@ paths:
   /user/keys/claim:
     post:
       summary: Claims one-time encryption keys for a user.
-      description: Claims one-time keys for use in pre-key messages.
+      description: |-
+        Claims one-time keys for use in pre-key messages.
+
+        The request contains the user ID, device ID and algorithm name of the
+        keys that are required. The response contains a key matching this -
+        either a one-time key, or if none are available, a fallback key.
+
+        One-time keys are given out in the order that they were uploaded via
+        [/keys/upload](/client-server-api/#post_matrixclientv3keysupload). (All
+        keys uploaded within a given call to `/keys/upload` are considered
+        equivalent in this regard; no ordering is specified within them.)
       operationId: claimUserEncryptionKeys
       security:
         - signedRequest: []

--- a/data/api/server-server/user_keys.yaml
+++ b/data/api/server-server/user_keys.yaml
@@ -24,8 +24,9 @@ paths:
         Claims one-time keys for use in pre-key messages.
 
         The request contains the user ID, device ID and algorithm name of the
-        keys that are required. The response contains a key matching this -
-        either a one-time key, or if none are available, a fallback key.
+        keys that are required. If a key matching these requirements can be
+        found, the response contains it. The returned key is a one-time key
+        if one is available, and otherwise a fallback key.
 
         One-time keys are given out in the order that they were uploaded via
         [/keys/upload](/client-server-api/#post_matrixclientv3keysupload). (All


### PR DESCRIPTION
As per [MSC4225](https://github.com/matrix-org/matrix-spec-proposals/pull/4225)

### Pull Request Checklist

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)









Specifically: https://pr2029--matrix-spec-previews.netlify.app/client-server-api/#post_matrixclientv3keysclaim and https://pr2029--matrix-spec-previews.netlify.app/server-server-api/#post_matrixfederationv1userkeysclaim





<!-- Replace -->
Preview: https://pr2029--matrix-spec-previews.netlify.app
<!-- Replace -->
