### PR TITLE
Clarify wording in the /join endpoints summaries and descriptions

### DIFF
--- a/changelogs/client_server/newsfragments/2038.clarification
+++ b/changelogs/client_server/newsfragments/2038.clarification
@@ -1,0 +1,1 @@
+Clarify wording in the /join endpoints summaries and descriptions. Contributed by @HarHarLinks.

--- a/changelogs/client_server/newsfragments/2038.clarification
+++ b/changelogs/client_server/newsfragments/2038.clarification
@@ -1,1 +1,1 @@
-Clarify wording in the /join endpoints summaries and descriptions. Contributed by @HarHarLinks.
+Clarify wording in the `/join` endpoints' summaries and descriptions. Contributed by @HarHarLinks.

--- a/data/api/client-server/joining.yaml
+++ b/data/api/client-server/joining.yaml
@@ -18,12 +18,12 @@ info:
 paths:
   "/rooms/{roomId}/join":
     post:
-      summary: Start the requesting user participating in a particular room.
+      summary: Join the requesting user to a particular room.
       description: |-
         *Note that this API requires a room ID, not alias.*
         `/join/{roomIdOrAlias}` *exists if you have a room alias.*
 
-        This API starts a user participating in a particular room, if that user
+        This API starts a user's participation in a particular room, if that user
         is allowed to participate in that room. After this call, the client is
         allowed to see all current state events in the room, and all subsequent
         events associated with the room until the user leaves the room.
@@ -113,11 +113,11 @@ paths:
         - Room membership
   "/join/{roomIdOrAlias}":
     post:
-      summary: Start the requesting user participating in a particular room.
+      summary: Join the requesting user to a particular room.
       description: |-
         *Note that this API takes either a room ID or alias, unlike* `/rooms/{roomId}/join`.
 
-        This API starts a user participating in a particular room, if that user
+        This API starts a user'S participation in a particular room, if that user
         is allowed to participate in that room. After this call, the client is
         allowed to see all current state events in the room, and all subsequent
         events associated with the room until the user leaves the room.

--- a/data/api/client-server/joining.yaml
+++ b/data/api/client-server/joining.yaml
@@ -117,7 +117,7 @@ paths:
       description: |-
         *Note that this API takes either a room ID or alias, unlike* `/rooms/{roomId}/join`.
 
-        This API starts a user'S participation in a particular room, if that user
+        This API starts a user's participation in a particular room, if that user
         is allowed to participate in that room. After this call, the client is
         allowed to see all current state events in the room, and all subsequent
         events associated with the room until the user leaves the room.


### PR DESCRIPTION
Contributed wearing my community hat.

The trigger for this is me finding the wording incomprehensible in the list of operations at https://playground.matrix.org. The reasoning for this wording is that other endpoint summaries also use the term "join" directly,  such as
> Gets the list of currently joined users and their profile data.

> Knock on a room, requesting permission to join.

Given that the wording is fairly old (2016), I think this modernizes it appropriately.

Signed-off-by: HarHarLinks <2803622+HarHarLinks@users.noreply.github.com>

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)



<!-- Replace -->
Preview: https://pr2038--matrix-spec-previews.netlify.app
<!-- Replace -->
