### PR TITLE
Remove unused `release_date` from Hugo config

### DIFF
--- a/changelogs/internal/newsfragments/2042.clarification
+++ b/changelogs/internal/newsfragments/2042.clarification
@@ -1,0 +1,1 @@
+Remove unused `release_date` from Hugo config.

--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -65,7 +65,7 @@ status = "unstable"
 # A URL pointing to the latest, stable release of the spec. To be shown in the unstable version warning banner.
 current_version_url = "https://spec.matrix.org/latest"
 # The following is used when status = "stable", and is displayed in various UI elements on a released version
-# of the spec. CI will set these values here automatically when a release git tag (i.e `v1.5`) is created.
+# of the spec.
 # major = "1"
 # minor = "13"
 

--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -68,7 +68,6 @@ current_version_url = "https://spec.matrix.org/latest"
 # of the spec. CI will set these values here automatically when a release git tag (i.e `v1.5`) is created.
 # major = "1"
 # minor = "13"
-# release_date = "December 19, 2024"
 
 # User interface configuration
 [params.ui]

--- a/meta/releasing.md
+++ b/meta/releasing.md
@@ -72,9 +72,6 @@ release.
    # and `minor = "2"`
    major = "1"
    minor = "2"
-
-   # Today's date. Please use the format implied here for consistency.
-   release_date = "October 01, 2021"
    ```
 3. Commit the changes.
 4. Generate the changelog.
@@ -102,7 +99,6 @@ release.
     current_version_url = "https://spec.matrix.org/latest"
     # major = "1"
     # minor = "2"
-    # release_date = "October 01, 2021"
     ```
 11. Push pending commits and ensure the unstable spec updates accordingly from the
     GitHub Actions pipeline.


### PR DESCRIPTION
It seems unnecessary because it is not used anywhere. Also the date format used in the changelog would change in #2033 so it's unclear if the formats should still match if we keep this.

The second commit removes an erroneous sentence since we are in the area. The version is actually updated manually during the release (as can be seen in `/meta/releasing.md`), not by CI.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)





<!-- Replace -->
Preview: https://pr2042--matrix-spec-previews.netlify.app
<!-- Replace -->
