### PR TITLE
Clarify that v1.0 of Matrix was a symbolic release

### DIFF
--- a/changelogs/internal/newsfragments/2045.clarification
+++ b/changelogs/internal/newsfragments/2045.clarification
@@ -1,1 +1,1 @@
-Clarify that v1.0 of Matrix was a symbolic release prior to the current global versionins system.
+Clarify that v1.0 of Matrix was a symbolic release prior to the current global versioning system.

--- a/changelogs/internal/newsfragments/2045.clarification
+++ b/changelogs/internal/newsfragments/2045.clarification
@@ -1,0 +1,1 @@
+Clarify that v1.0 of Matrix was a symbolic release prior to the current global versionins system.

--- a/changelogs/internal/newsfragments/2045.clarification
+++ b/changelogs/internal/newsfragments/2045.clarification
@@ -1,1 +1,1 @@
-Clarify that v1.0 of Matrix was a symbolic release prior to the current global versioning system.
+Clarify that v1.0 of Matrix was a release prior to the current global versioning system.

--- a/content/_index.md
+++ b/content/_index.md
@@ -504,8 +504,8 @@ For historical reference, the APIs were versioned as `rX.Y.Z` where `X`
 roughly represents a breaking change, `Y` a backwards-compatible change, and
 `Z` a patch or insignificant alteration to the API.
 
-`v1.0` of Matrix was released on June 10th, 2019 with the following API
-versions:
+`v1.0` of Matrix was a symbolic version released on June 10th, 2019 with the
+following minimum API versions:
 
 | API/Specification       | Version |
 |-------------------------|---------|
@@ -516,6 +516,9 @@ versions:
 | Push Gateway API        | r0.1.0  |
 | Room Version            | v5      |
 
+It is not used in this specification and should not be returned by servers in
+the [`GET /_matrix/client/versions`](/client-server-api/#get_matrixclientversions)
+endpoint. The first version using the current global versioning system was `v1.1`.
 
 ## License
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -504,21 +504,23 @@ For historical reference, the APIs were versioned as `rX.Y.Z` where `X`
 roughly represents a breaking change, `Y` a backwards-compatible change, and
 `Z` a patch or insignificant alteration to the API.
 
-`v1.0` of Matrix was a symbolic version released on June 10th, 2019 with the
-following minimum API versions:
+The current global versioning system was introduced with `v1.1`.
+[Matrix 1.0][https://matrix.org/blog/2019/06/11/introducing-matrix-1-0-and-the-matrix-org-foundation/]
+did not correspond directly to a specification version; instead, it was based on
+the following versions for the individual APIs:
 
-| API/Specification       | Version |
-|-------------------------|---------|
-| Client-Server API       | r0.5.0  |
-| Server-Server API       | r0.1.2  |
-| Application Service API | r0.1.1  |
-| Identity Service API    | r0.1.1  |
-| Push Gateway API        | r0.1.0  |
-| Room Version            | v5      |
+| API/Specification        | Version       |
+|--------------------------|---------------|
+| Client-Server API        | r0.5.0        |
+| Server-Server API        | r0.1.2        |
+| Application Service API  | r0.1.1        |
+| Identity Service API     | r0.1.1        |
+| Push Gateway API         | r0.1.0        |
+| Room Versions            | 1, 2, 3, 4, 5 |
 
-It is not used in this specification and should not be returned by servers in
-the [`GET /_matrix/client/versions`](/client-server-api/#get_matrixclientversions)
-endpoint. The first version using the current global versioning system was `v1.1`.
+`v1.0` should **not** be returned by servers in the
+[`GET /_matrix/client/versions`](/client-server-api/#get_matrixclientversions)
+response.
 
 ## License
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -505,7 +505,7 @@ roughly represents a breaking change, `Y` a backwards-compatible change, and
 `Z` a patch or insignificant alteration to the API.
 
 The current global versioning system was introduced with `v1.1`.
-[Matrix 1.0][https://matrix.org/blog/2019/06/11/introducing-matrix-1-0-and-the-matrix-org-foundation/]
+[Matrix 1.0](https://matrix.org/blog/2019/06/11/introducing-matrix-1-0-and-the-matrix-org-foundation/)
 did not correspond directly to a specification version; instead, it was based on
 the following versions for the individual APIs:
 


### PR DESCRIPTION
Explain that it was a release prior to the current global versioning system and that it is not used in the APIs by clients/servers.

Closes #12.


### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)

















<!-- Replace -->
Preview: https://pr2045--matrix-spec-previews.netlify.app
<!-- Replace -->
