### PR TITLE
Remove the `origin` field in `PUT /send_join` responses

### DIFF
--- a/changelogs/server_server/newsfragments/2050.clarification
+++ b/changelogs/server_server/newsfragments/2050.clarification
@@ -1,0 +1,1 @@
+Remove the `origin` field in `PUT /send_join` responses, because it was never sent in the first place.

--- a/data/api/server-server/joins-v1.yaml
+++ b/data/api/server-server/joins-v1.yaml
@@ -339,9 +339,6 @@ paths:
                       title: Room State
                       description: The state for the room.
                       properties:
-                        origin:
-                          type: string
-                          description: The resident server's [server name](/appendices/#server-name).
                         auth_chain:
                           type: array
                           description: |-
@@ -371,13 +368,11 @@ paths:
                       required:
                         - auth_chain
                         - state
-                        - origin
               examples:
                 response:
                   value: [
                     200,
                     {
-                      "origin": "matrix.org",
                       "auth_chain": [
                         {
                           "$ref": "examples/minimal_pdu.json"

--- a/data/api/server-server/joins-v2.yaml
+++ b/data/api/server-server/joins-v2.yaml
@@ -160,9 +160,6 @@ paths:
               schema:
                 type: object
                 properties:
-                  origin:
-                    type: string
-                    description: The resident server's [server name](/appendices/#server-name).
                   members_omitted:
                     type: boolean
                     description: "`true` if `m.room.member` events have been omitted from `state`."
@@ -222,11 +219,9 @@ paths:
                 required:
                   - auth_chain
                   - state
-                  - origin
               examples:
                 response:
                   value: {
-                    "origin": "matrix.org",
                     "auth_chain": [
                       {
                         "$ref": "examples/minimal_pdu.json"


### PR DESCRIPTION
Although other removals of `origin` in the spec might require a MSC, this case is a spec bug as it has actually never been sent by Synapse, going back to 2014:

- Commit in 2014 where `auth_chain` was added: https://github.com/element-hq/synapse/commit/3b4dec442da51c6c999dd946db6ea6ce5f07ff0c
- Same state at Synapse 0.99.0 matching more or less the release date of r0.1.0 of the SS API in February of 2019: https://github.com/element-hq/synapse/blob/v0.99.0/synapse/federation/federation_server.py#L396-L401

The current state is that it is not sent and ignored when received by Synapse, Conduit, Conduwuit, and it is sent by Dendrite but ignored when received.

Part of https://github.com/matrix-org/matrix-spec/issues/374.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)





<!-- Replace -->
Preview: https://pr2050--matrix-spec-previews.netlify.app
<!-- Replace -->
