### PR TITLE
Fix the version of the Identity Service API at Matrix 1.0

### DIFF
--- a/changelogs/internal/newsfragments/2061.clarification
+++ b/changelogs/internal/newsfragments/2061.clarification
@@ -1,0 +1,1 @@
+Fix the version of the Identity Service API when Matrix 1.0 was introduced.

--- a/content/_index.md
+++ b/content/_index.md
@@ -514,7 +514,7 @@ the following versions for the individual APIs:
 | Client-Server API        | r0.5.0        |
 | Server-Server API        | r0.1.2        |
 | Application Service API  | r0.1.1        |
-| Identity Service API     | r0.1.1        |
+| Identity Service API     | r0.2.0        |
 | Push Gateway API         | r0.1.0        |
 | Room Versions            | 1, 2, 3, 4, 5 |
 


### PR DESCRIPTION
There is no version r0.1.1 of the Identity Service API, as can be seen in [the historical changelogs list](https://spec.matrix.org/v1.13/changelog/historical/#identity-service-api).

According to the [commit history at the time](https://github.com/matrix-org/matrix-spec/commits/main?since=2019-06-10&until=2019-06-11), r0.2.0 is the version that was released at that time.


### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)





<!-- Replace -->
Preview: https://pr2061--matrix-spec-previews.netlify.app
<!-- Replace -->
