### PR TITLE
Clarify that join rules must be in auth events for knock events

### DIFF
--- a/changelogs/server_server/newsfragments/2063.clarification
+++ b/changelogs/server_server/newsfragments/2063.clarification
@@ -1,0 +1,1 @@
+Clarify that `m.join_rules` should be in the `auth_events` of an `m.room.member` event with a `membership` of `knock`.

--- a/content/server-server-api.md
+++ b/content/server-server-api.md
@@ -537,7 +537,7 @@ the following subset of the room state:
 - If type is `m.room.member`:
 
     - The target's current `m.room.member` event, if any.
-    - If `membership` is `join` or `invite`, the current
+    - If `membership` is `join`, `invite` or `knock`, the current
       `m.room.join_rules` event, if any.
     - If membership is `invite` and `content` contains a
       `third_party_invite` property, the current


### PR DESCRIPTION
Since it is necessary for passing the [authorization rules](https://spec.matrix.org/v1.13/rooms/v11/#authorization-rules) (step 4.7.1).

It must have been forgotten when knocking was introduced in v1.1.


### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)





<!-- Replace -->
Preview: https://pr2063--matrix-spec-previews.netlify.app
<!-- Replace -->
