### PR TITLE
Add a note to the federation invite endpoints that invites can be sent twice

### DIFF
--- a/changelogs/server_server/newsfragments/2067.clarification
+++ b/changelogs/server_server/newsfragments/2067.clarification
@@ -1,0 +1,1 @@
+Add a note to the invite endpoints that invites to local users may be received twice over federation if the homeserver is already in the room.

--- a/data/api/server-server/invites-v1.yaml
+++ b/data/api/server-server/invites-v1.yaml
@@ -35,7 +35,7 @@ paths:
 
         Also note that if the remote homeserver is already in the room, it will receive the
         invite event twice; once through this endpoint, and again through a [federation
-        transaction](https://spec.matrix.org/v1.13/server-server-api/#transactions).
+        transaction](/server-server-api/#transactions).
       operationId: sendInviteV1
       security:
         - signedRequest: []

--- a/data/api/server-server/invites-v1.yaml
+++ b/data/api/server-server/invites-v1.yaml
@@ -20,7 +20,7 @@ paths:
     put:
       summary: Invites a remote user to a room
       description: |-
-        Invites a remote user to a room. Once the event has been  signed by both the inviting
+        Invites a remote user to a room. Once the event has been signed by both the inviting
         homeserver and the invited homeserver, it can be sent to all of the servers in the
         room by the inviting homeserver.
 
@@ -32,6 +32,10 @@ paths:
         [room version specification](/rooms) for precise event formats. **The request and response
         bodies here describe the common event fields in more detail and may be missing other
         required fields for a PDU.**
+
+        Also note that if the remote homeserver is already in the room, it will receive the
+        invite event twice; once through this endpoint, and again through a [federation
+        transaction](https://spec.matrix.org/v1.13/server-server-api/#transactions).
       operationId: sendInviteV1
       security:
         - signedRequest: []

--- a/data/api/server-server/invites-v2.yaml
+++ b/data/api/server-server/invites-v2.yaml
@@ -24,7 +24,7 @@ paths:
         This API is nearly identical to the v1 API with the exception of the request
         body being different, and the response format fixed.
 
-        Invites a remote user to a room. Once the event has been  signed by both the inviting
+        Invites a remote user to a room. Once the event has been signed by both the inviting
         homeserver and the invited homeserver, it can be sent to all of the servers in the
         room by the inviting homeserver.
 
@@ -36,6 +36,10 @@ paths:
         [room version specification](/rooms) for precise event formats. **The request and response
         bodies here describe the common event fields in more detail and may be missing other
         required fields for a PDU.**
+
+        Also note that if the remote homeserver is already in the room, it will receive the
+        invite event twice; once through this endpoint, and again through a [federation
+        transaction](https://spec.matrix.org/v1.13/server-server-api/#transactions).
       operationId: sendInviteV2
       security:
         - signedRequest: []

--- a/data/api/server-server/invites-v2.yaml
+++ b/data/api/server-server/invites-v2.yaml
@@ -39,7 +39,7 @@ paths:
 
         Also note that if the remote homeserver is already in the room, it will receive the
         invite event twice; once through this endpoint, and again through a [federation
-        transaction](https://spec.matrix.org/v1.13/server-server-api/#transactions).
+        transaction](/server-server-api/#transactions).
       operationId: sendInviteV2
       security:
         - signedRequest: []


### PR DESCRIPTION
As this may be non-obvious when implementing behaviour that is triggered by an incoming invite event.

See https://github.com/matrix-org/matrix-spec/issues/2062 for more context. Closes https://github.com/matrix-org/matrix-spec/issues/2062.







<!-- Replace -->
Preview: https://pr2067--matrix-spec-previews.netlify.app
<!-- Replace -->
