### PR TITLE
Describe behaviour when the `topic` key is falsey in a `m.room.topic` event.

### DIFF
--- a/changelogs/client_server/newsfragments/2068.clarification
+++ b/changelogs/client_server/newsfragments/2068.clarification
@@ -1,0 +1,1 @@
+Clarify behaviour when the `topic` key of a `m.room.topic` event is absent, null, or empty.

--- a/data/event-schemas/schema/m.room.topic.yaml
+++ b/data/event-schemas/schema/m.room.topic.yaml
@@ -7,8 +7,8 @@ description: |-
     be suitable for the room name.
     The room topic can also be set when creating a room using `/createRoom` with the `topic` key.'
     
-    If a room has an `m.room.topic` event with an absent, null, or empty `topic`
-    field, it should be treated the same as a room with no `m.room.topic` event.
+    If the `topic` property is absent, null, or empty then the topic is unset. In other words,
+    an empty `topic` property effectively resets the room to having no topic.
 properties:
   content:
     properties:

--- a/data/event-schemas/schema/m.room.topic.yaml
+++ b/data/event-schemas/schema/m.room.topic.yaml
@@ -1,7 +1,14 @@
 ---
 allOf:
   - $ref: core-event-schema/state_event.yaml
-description: 'A topic is a short message detailing what is currently being discussed in the room.  It can also be used as a way to display extra information about the room, which may not be suitable for the room name. The room topic can also be set when creating a room using `/createRoom` with the `topic` key.'
+description: |- 
+    A topic is a short message detailing what is currently being discussed in the room.
+    It can also be used as a way to display extra information about the room, which may not
+    be suitable for the room name.
+    The room topic can also be set when creating a room using `/createRoom` with the `topic` key.'
+    
+    If a room has an `m.room.topic` event with an absent, null, or empty `topic`
+    field, it should be treated the same as a room with no `m.room.topic` event.
 properties:
   content:
     properties:


### PR DESCRIPTION
We seem to have [updated this for m.room.name](https://github.com/matrix-org/matrix-spec/pull/1639) some years back but omitted it for topic.

Signed-off-by: Half-Shot <signoff@half-shot.uk>

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [ ] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)








<!-- Replace -->
Preview: https://pr2068--matrix-spec-previews.netlify.app
<!-- Replace -->
