### PR TITLE
Fix parsing of nested slices in resolve-refs and resolve-allof partials

### DIFF
--- a/changelogs/internal/newsfragments/2069.clarification
+++ b/changelogs/internal/newsfragments/2069.clarification
@@ -1,0 +1,1 @@
+Fix parsing of nested slices in `resolve-refs` and `resolve-allof` partials.

--- a/layouts/partials/json-schema/resolve-allof.html
+++ b/layouts/partials/json-schema/resolve-allof.html
@@ -24,6 +24,14 @@
 
     {{ range $original }}
         {{ $resolved := partial "json-schema/resolve-allof" . }}
+        {{ if reflect.IsSlice $resolved }}
+          {{/*
+              If $resolved is a slice, `append` will add the items of $resolved to
+              $ret, but we want to add $resolved itself to $ret, so we always wrap
+              it into another slice.
+          */}}
+          {{ $resolved = slice $resolved }}
+        {{ end }}
         {{ $ret = $ret | append $resolved }}
     {{ end }}
 {{ else if reflect.IsMap $original }}

--- a/layouts/partials/json-schema/resolve-refs.html
+++ b/layouts/partials/json-schema/resolve-refs.html
@@ -69,6 +69,14 @@
 
     {{ range $schema }}
         {{ $resolved := partial "json-schema/resolve-refs" (dict "schema" . "path" $path) }}
+        {{ if reflect.IsSlice $resolved }}
+            {{/*
+                If $resolved is a slice, `append` will add the items of $resolved to
+                $result_slice, but we want to add $resolved itself to $result_slice,
+                so we wrap it into another slice.
+            */}}
+            {{ $resolved = slice $resolved }}
+        {{ end }}
         {{ $result_slice = $result_slice | append $resolved }}
     {{ end }}
 


### PR DESCRIPTION
Since `append` treats a slice as a list of items to add rather than an item itself, we need to wrap a slice into another slice to add it as an item.

Fixes #1033.
Fixes #1820.

e.g. for [room version 1](https://pr2069--matrix-spec-previews.netlify.app/rooms/v1/#event-format):

![image](https://github.com/user-attachments/assets/e6abfb06-edcc-4e9e-b059-32fa7c26f41a)


### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)





<!-- Replace -->
Preview: https://pr2069--matrix-spec-previews.netlify.app
<!-- Replace -->
