### PR TITLE
Clients can choose which history visibility options they offer to users when creating rooms

### DIFF
--- a/changelogs/client_server/newsfragments/2072.clarification
+++ b/changelogs/client_server/newsfragments/2072.clarification
@@ -1,0 +1,1 @@
+Clients can choose which history visibility options they offer to users when creating rooms.

--- a/content/client-server-api/modules/history_visibility.md
+++ b/content/client-server-api/modules/history_visibility.md
@@ -43,11 +43,8 @@ setting at that time was more restrictive.
 
 #### Client behaviour
 
-Clients that implement this module MUST present to the user the possible
-options for setting history visibility when creating a room.
-
-Clients may want to display a notice that their events may be read by
-non-joined people if the value is set to `world_readable`.
+Clients may want to display a notice that events may be read by
+non-joined people if the history visibility is set to `world_readable`.
 
 #### Server behaviour
 


### PR DESCRIPTION
The current wording is ambiguous because it's not clear whether it means for clients to offer:

1. all history visibility options that the spec defines
2. only those that the client chose to support during room creation

Option 1 doesn't seem reasonable to me. Evidently Element X doesn't allow users to choose between all 4 visibility values when creating rooms. It appears perfectly reasonable for clients to decide that they don't want to support creating rooms with a certain history visibility.

Option 2 seems reasonable to me but I don't think it requires a notice in the spec. Clients are generally free to choose what subset of configuration options they expose in their UI (see e.g. push rules).

Therefore, I think we should drop this paragraph.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)





<!-- Replace -->
Preview: https://pr2072--matrix-spec-previews.netlify.app
<!-- Replace -->
