### PR TITLE
Add link to git commit for unstable changelog too

### DIFF
--- a/changelogs/internal/newsfragments/2078.clarification
+++ b/changelogs/internal/newsfragments/2078.clarification
@@ -1,0 +1,1 @@
+Add link to the git commit for the unstable changelog.

--- a/layouts/docs/changelog.html
+++ b/layouts/docs/changelog.html
@@ -31,9 +31,13 @@
     <h1>{{ .Title }}</h1>
 
     <table class="release-info">
-        {{ if ne $version "unstable" -}}
-            {{ $commitLink := printf "https://github.com/matrix-org/matrix-spec/tree/%s" $version -}}
+        {{ $rev := $version }}
+        {{ if eq $version "unstable" -}}
+            {{ $rev = .Params.commit -}}
+        {{ end -}}
+        {{ $commitLink := printf "https://github.com/matrix-org/matrix-spec/tree/%s" $rev -}}
         <tr><th>Git commit</th><td><a href="{{ $commitLink }}">{{ $commitLink }}</a></td>
+        {{ if ne $version "unstable" }}
         <tr><th>Release date</th><td>{{ .Date | time.Format ":date_long" }}</td>
         {{ end -}}
         {{ $checklist := .OutputFormats.Get "checklist" -}}

--- a/layouts/docs/changelog.html
+++ b/layouts/docs/changelog.html
@@ -33,6 +33,10 @@
     <table class="release-info">
         {{ $rev := $version }}
         {{ if eq $version "unstable" -}}
+            {{- /*
+                Extract the git SHA from the frontmatter of the changelog, where
+                it was stashed by `generate-changelog.sh`.
+            */ -}}
             {{ $rev = .Params.commit -}}
         {{ end -}}
         {{ $commitLink := printf "https://github.com/matrix-org/matrix-spec/tree/%s" $rev -}}

--- a/scripts/generate-changelog.sh
+++ b/scripts/generate-changelog.sh
@@ -44,8 +44,18 @@ outputs:
   - html
   - checklist
 date: $(date -Idate)
----
 EOF
+
+    # Add the commit hash for the unstable versions. It is used to generate a
+    # link to the commit on the repository.
+    if [ "$VERSION" == "vUNSTABLE" ]; then
+        echo "params:"
+        echo "  commit: $(git rev-parse --short HEAD)"
+    fi
+
+    # Close the frontmatter.
+    echo "---"
+
     # Remove trailing whitespace (such as our intentionally blank RST headings)
     sed -e "s/[ ]*$//" rendered.md
 } > ../content/changelog/$FILENAME


### PR DESCRIPTION
I am not sure if it closes #1612. It says "somewhere on the page", so on every page of the spec, but here we do it only on the unstable changelog page, which might be enough?

If we want to show it on every page, it will probably require to copy the commit hash in the config file or something like that.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)











<!-- Replace -->
Preview: https://pr2078--matrix-spec-previews.netlify.app
<!-- Replace -->
