### PR TITLE
Clarify that `join_authorised_via_users_server` auth event is only necessary for `join`s

### DIFF
--- a/changelogs/server_server/newsfragments/2100.clarification
+++ b/changelogs/server_server/newsfragments/2100.clarification
@@ -1,0 +1,1 @@
+Clarify that auth event of `content.join_authorised_via_users_server` is only necessary for `m.room.member` with a `membership` of `join`.

--- a/content/server-server-api.md
+++ b/content/server-server-api.md
@@ -543,8 +543,8 @@ the following subset of the room state:
       `third_party_invite` property, the current
       `m.room.third_party_invite` event with `state_key` matching
       `content.third_party_invite.signed.token`, if any.
-    - If `content.join_authorised_via_users_server` is present,
-      and the [room version supports restricted rooms](/rooms/#feature-matrix),
+    - If `membership` is `join`, `content.join_authorised_via_users_server`
+      is present, and the [room version supports restricted rooms](/rooms/#feature-matrix),
       then the `m.room.member` event with `state_key` matching
       `content.join_authorised_via_users_server`.
 


### PR DESCRIPTION
Since the field is only checked in the authorization rules when the `membership` is `join`: 4.3.5 in [room v11](https://spec.matrix.org/v1.13/rooms/v11/#authorization-rules).

This matches the behavior of Synapse: https://github.com/element-hq/synapse/blob/51df675c054369576ed9bde8d1865c904fa6056c/synapse/event_auth.py#L1176

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)





<!-- Replace -->
Preview: https://pr2100--matrix-spec-previews.netlify.app
<!-- Replace -->
