### PR TITLE
Clarify the meaning of "public rooms" for profile look-ups

### DIFF
--- a/changelogs/client_server/newsfragments/2101.clarification
+++ b/changelogs/client_server/newsfragments/2101.clarification
@@ -1,0 +1,1 @@
+"Public" rooms in profile look-ups are defined through their join rule and history visibility.

--- a/content/client-server-api/_index.md
+++ b/content/client-server-api/_index.md
@@ -2847,10 +2847,15 @@ re-invited.
 
 #### Server behaviour
 
-Homeservers MUST at a minimum allow profile look-up for:
+Homeservers MUST at a minimum allow profile look-up for users who are
+visible to the requester based on their membership in rooms known to the
+homeserver. This means:
 
 -   users that share a room with the requesting user
--   users that reside in public rooms known to the homeserver
+-   users who are joined to rooms known to the homeserver that have a
+    `public` [join rule](#mroomjoin_rules)
+-   users who are joined to rooms known to the homeserver that have a
+    `world_readable` [history visibility](#room-history-visibility)
 
 In all other cases, homeservers MAY deny profile look-up by responding with
 403 and an error code of `M_FORBIDDEN`.


### PR DESCRIPTION
Relates to: #633

This is merely a clarification of what the spec says today. It's debatable whether members of "public rooms" should be included in profile queries or not. Changing this, would require an MSC, however.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)





<!-- Replace -->
Preview: https://pr2101--matrix-spec-previews.netlify.app
<!-- Replace -->
