### PR TITLE
Fix generation of historical spec

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -265,7 +265,7 @@ jobs:
     name: "📖 Build the historical backup spec"
     runs-on: ubuntu-latest
     needs: [build-openapi]
-    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    # if: ${{ startsWith(github.ref, 'refs/tags/') }}
     steps:
       - name: "➕ Setup Node"
         uses: actions/setup-node@v4
@@ -283,10 +283,11 @@ jobs:
           npm i
           npm run get-proposals
       - name: "⚙️ hugo"
+        env:
+          HUGO_PARAMS_VERSION_STATUS: "historical"
         # Create a baseURL like `/v1.2` out of the `v1.2` tag
         run: |
-          echo -e '[params.version]\nstatus="historical"' > historical.toml
-          hugo --config config.toml,historical.toml --baseURL "/${GITHUB_REF/refs\/tags\//}" -d "spec"
+          hugo --baseURL "/${GITHUB_REF/refs\/tags\//}" -d "spec"
 
       - name: "📥 Spec definition download"
         uses: actions/download-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -265,7 +265,7 @@ jobs:
     name: "📖 Build the historical backup spec"
     runs-on: ubuntu-latest
     needs: [build-openapi]
-    # if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
     steps:
       - name: "➕ Setup Node"
         uses: actions/setup-node@v4

--- a/changelogs/internal/newsfragments/2123.clarification
+++ b/changelogs/internal/newsfragments/2123.clarification
@@ -1,0 +1,1 @@
+Fix the historical info box when generating the historical spec in CI.


### PR DESCRIPTION
With the move of the config file, the command in CI did not work as expected anymore.
I am unsure why Hugo didn't complain about the missing config file from the command…

To avoid this problem in the future and simplify the job, we use the default config and add an environment variable for the status which will always take precedence over the config.

This should take care of #2116 for future versions.

~~I enabled the historical job for every workflow temporarily to check that it builds as expected.~~ To see the fixed historical build, you need to get the artifact from one of the 2 first commits, not from the last one.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)





<!-- Replace -->
Preview: https://pr2123--matrix-spec-previews.netlify.app
<!-- Replace -->
