### PR TITLE
Fix minor typo in content hash calculations

### DIFF
--- a/changelogs/server_server/newsfragments/2128.clarification
+++ b/changelogs/server_server/newsfragments/2128.clarification
@@ -1,0 +1,1 @@
+Fix various typos throughout the specification.

--- a/content/server-server-api.md
+++ b/content/server-server-api.md
@@ -1337,7 +1337,7 @@ calculated as follows.
 The *content hash* of an event covers the complete event including the
 *unredacted* contents. It is calculated as follows.
 
-First, any existing `unsigned`, `signature`, and `hashes` members are
+First, any existing `unsigned`, `signatures`, and `hashes` properties are
 removed. The resulting object is then encoded as [Canonical
 JSON](/appendices#canonical-json), and the JSON is hashed using
 SHA-256.


### PR DESCRIPTION
and members -> properties per [doc style](https://github.com/matrix-org/matrix-spec/blob/main/meta/documentation_style.rst)

<!-- Replace -->
Preview: https://pr2128--matrix-spec-previews.netlify.app
<!-- Replace -->
