### PR TITLE
[schema] Correct null value handling for the AS Registration’s `url` property

### DIFF
--- a/changelogs/application_service/newsfragments/2130.feature
+++ b/changelogs/application_service/newsfragments/2130.feature
@@ -1,1 +1,1 @@
-Correct null value handling for the AS Registration’s `url` property.
+Correct null value handling for the AS Registration's `url` property.

--- a/changelogs/application_service/newsfragments/2130.feature
+++ b/changelogs/application_service/newsfragments/2130.feature
@@ -1,0 +1,1 @@
+Correct null value handling for the AS Registration’s `url` property.

--- a/data/api/application-service/definitions/registration.yaml
+++ b/data/api/application-service/definitions/registration.yaml
@@ -19,7 +19,7 @@ properties:
     type: string
     description: A unique, user-defined ID of the application service which will never change.
   url:
-    type: string
+    type: ["null", "string"]
     description: The URL for the application service. May include a path after the domain name. Optionally set to null if no traffic is required.
   as_token:
     type: string


### PR DESCRIPTION
Fixes the `url` property’s nullability of the Application Service Registration schema.

The Spec [states](https://spec.matrix.org/v1.14/application-service-api/#definition-registration_registration) that the Registration’s `url` property can be “optionally set to null if no traffic is required”, but the corresponding schema does not allow this:

https://github.com/matrix-org/matrix-spec/blob/23ff7f1343ef00c61d148e84b3a26ec7826810b2/data/api/application-service/definitions/registration.yaml#L21-L23

This PR fixes the problem by making the `url` property nullable, i.e., give it `type: ["null", "string"]`.

I find this change to be between a clarification and a backwards-compatible change. Still I want to note the possibility of a Registration consumer breaking for new setups, because they didn’t expect null values for the `url` property to be present and will now have to handle them.

In a [previous iteration](https://github.com/V02460/matrix-spec/commit/990629dc0675d961a53a9ffd0f0819a1b3fe3649) of this PR I additionally removed `url` from the list of required properties and made `null` its default value. I did this to get consistent meaning for the `url` property being unset and the property being set to `null`; but I removed it, because the Synapse source code seems to consider it not a bug, but a feature:

> 'url' must either be a string or explicitly null, not missing to avoid accidentally turning off push for ASes.

From [synapse/config/appservice.py#L115-L116
](https://github.com/element-hq/synapse/blob/081f6ad50fa0ea87c348778e8be40517da25c698/synapse/config/appservice.py#L115-L116)


### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)


<!-- Replace -->
Preview: https://pr2130--matrix-spec-previews.netlify.app
<!-- Replace -->
