### PR TITLE
Clarify wording around public room directory

### DIFF
--- a/changelogs/client_server/newsfragments/2133.clarification
+++ b/changelogs/client_server/newsfragments/2133.clarification
@@ -1,0 +1,1 @@
+Clarify wording around public room directory. Contributed by @HarHarLinks.

--- a/changelogs/server_server/newsfragments/2133.clarification
+++ b/changelogs/server_server/newsfragments/2133.clarification
@@ -1,0 +1,1 @@
+Clarify wording around public room directory. Contributed by @HarHarLinks.

--- a/data/api/client-server/list_public_rooms.yaml
+++ b/data/api/client-server/list_public_rooms.yaml
@@ -129,9 +129,9 @@ paths:
         - Room discovery
   /publicRooms:
     get:
-      summary: Lists the public rooms on the server.
+      summary: Lists the published rooms on the server.
       description: |-
-        Lists the public rooms on the server.
+        Lists the rooms published to the room directory on the server.
 
         This API returns paginated responses. The rooms are ordered by the number
         of joined members, with the largest rooms first.
@@ -154,7 +154,7 @@ paths:
         - in: query
           name: server
           description: |-
-            The server to fetch the public room lists from. Defaults to the
+            The server to fetch the published rooms list from. Defaults to the
             local server. Case sensitive.
           schema:
             type: string
@@ -168,9 +168,9 @@ paths:
       tags:
         - Room discovery
     post:
-      summary: Lists the public rooms on the server with optional filter.
+      summary: Lists the published rooms on the server with optional filter.
       description: |-
-        Lists the public rooms on the server, with optional filter.
+        Lists the rooms published to the room directory on the server, with optional filter.
 
         This API returns paginated responses. The rooms are ordered by the number
         of joined members, with the largest rooms first.
@@ -182,7 +182,7 @@ paths:
         - in: query
           name: server
           description: |-
-            The server to fetch the public room lists from. Defaults to the
+            The server to fetch the published rooms list from. Defaults to the
             local server. Case sensitive.
           schema:
             type: string

--- a/data/api/server-server/public_rooms.yaml
+++ b/data/api/server-server/public_rooms.yaml
@@ -18,11 +18,11 @@ info:
 paths:
   /publicRooms:
     get:
-      summary: Get all the public rooms for a homeserver
+      summary: Get all the published rooms for a homeserver
       description: |-
-        Gets all the public rooms for the homeserver. This should not return
-        rooms that are listed on another homeserver's directory, just those
-        listed on the receiving homeserver's directory.
+        Gets all the rooms published to the room directory of the homeserver.
+        This should not return rooms that are listed on another homeserver's directory,
+        just those listed on the receiving homeserver's directory.
       operationId: getPublicRooms
       security:
         - signedRequest: []
@@ -62,15 +62,15 @@ paths:
             type: string
       responses:
         "200":
-          description: The public room list for the homeserver.
+          description: The published rooms list for the homeserver.
           content:
             application/json:
               schema:
                 $ref: ../client-server/definitions/public_rooms_response.yaml
     post:
-      summary: Gets the public rooms on the server with optional filter.
+      summary: Gets the published rooms on the server with optional filter.
       description: |-
-        Lists the public rooms on the server, with optional filter.
+        Gets all the rooms published to the room directory of the homeserver, with optional filter.
 
         This API returns paginated responses. The rooms are ordered by the number
         of joined members, with the largest rooms first.
@@ -147,19 +147,19 @@ paths:
         required: true
       responses:
         "200":
-          description: A list of the rooms on the server.
+          description: A list of the published rooms on the server.
           content:
             application/json:
               schema:
                 type: object
-                description: A list of the rooms on the server.
+                description: A list of the published rooms on the server.
                 required:
                   - chunk
                 properties:
                   chunk:
                     title: PublicRoomsChunks
                     type: array
-                    description: A paginated chunk of public rooms.
+                    description: A paginated chunk of published rooms.
                     items:
                       allOf:
                         - $ref: ../client-server/definitions/public_rooms_chunk.yaml
@@ -188,8 +188,8 @@ paths:
                   total_room_count_estimate:
                     type: integer
                     description: |-
-                      An estimate on the total number of public rooms, if the
-                      server has an estimate.
+                      An estimate on the total number of rooms published in the room directory,
+                      if the server has an estimate.
               examples:
                 response:
                   value: {


### PR DESCRIPTION
This PR suggest a switch to clearer wording in the API descriptions of what is commonly known as "(public) room directory", which contains "published rooms" (namely, published to the directory), to differentiate it more clearly from what is commonly known as "public rooms" (a room with the join rule = public).

Sadly, the name "publicRooms" is baked into the api; ideally it would be named similar to the user directory, however a migration path to that would be rough and certainly take an MSC.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)


<!-- Replace -->
Preview: https://pr2133--matrix-spec-previews.netlify.app
<!-- Replace -->
