### PR TITLE
Fix new redocly lints

### DIFF
--- a/data/api/application-service/definitions/protocol.yaml
+++ b/data/api/application-service/definitions/protocol.yaml
@@ -23,3 +23,4 @@ allOf:
       type: array
       items:
         $ref: protocol_instance.yaml
+  required: ['instances']

--- a/data/api/application-service/definitions/protocol_base.yaml
+++ b/data/api/application-service/definitions/protocol_base.yaml
@@ -77,4 +77,4 @@ properties:
         "placeholder": "#foobar"
       }
     }
-required: ['user_fields', 'location_fields', 'icon', 'field_types', 'instances']
+required: ['user_fields', 'location_fields', 'icon', 'field_types']

--- a/data/api/client-server/definitions/protocol.yaml
+++ b/data/api/client-server/definitions/protocol.yaml
@@ -37,7 +37,8 @@ allOf:
                   A unique identifier for this instance on the homeserver. This field is added
                   to the response of [`GET /_matrix/app/v1/thirdparty/protocol/{protocol}`](/application-service-api/#get_matrixappv1thirdpartyprotocolprotocol)
                   by the homeserver.
-                  
+
                   This is the identifier to use as the `third_party_instance_id` in a request to
                   [`POST /_matrix/client/v3/publicRooms`](/client-server-api/#post_matrixclientv3publicrooms).
                 example: "irc-freenode"
+  required: ['instances']

--- a/data/api/client-server/definitions/room_summary.yaml
+++ b/data/api/client-server/definitions/room_summary.yaml
@@ -42,9 +42,3 @@ allOf:
       room_version:
         description: The version of the room.
         type: string
-
-required:
-  - room_id
-  - num_joined_members
-  - world_readable
-  - guest_can_join

--- a/data/api/client-server/room_summary.yaml
+++ b/data/api/client-server/room_summary.yaml
@@ -89,11 +89,6 @@ paths:
                           - leave
                           - ban
                         type: string
-                required:
-                  - guest_can_join
-                  - num_joined_members
-                  - room_id
-                  - world_readable
               examples:
                 response:
                   value: {

--- a/data/event-schemas/schema/core-event-schema/room_event.yaml
+++ b/data/event-schemas/schema/core-event-schema/room_event.yaml
@@ -1,13 +1,13 @@
+title: RoomEvent
+description: Room Events have the following fields.
 allOf:
 - $ref: sync_room_event.yaml
-description: Room Events have the following fields.
-properties:
-  room_id:
-    description: |-
-      The ID of the room associated with this event. Will not be present on events
-      that arrive through `/sync`, despite being required everywhere else.
-    type: string
-required:
-- room_id
-title: RoomEvent
-type: object
+- type: object
+  properties:
+    room_id:
+      description: |-
+        The ID of the room associated with this event. Will not be present on events
+        that arrive through `/sync`, despite being required everywhere else.
+      type: string
+  required:
+  - room_id

--- a/data/event-schemas/schema/core-event-schema/sync_room_event.yaml
+++ b/data/event-schemas/schema/core-event-schema/sync_room_event.yaml
@@ -17,27 +17,27 @@
 # be on events, so we give it a whole event structure as a base for room_event.
 # This base doesn't declare a room_id, which instead appears in the room_event.
 
-allOf:
-- $ref: event.yaml
+title: SyncRoomEvent
 description: In addition to the Event fields, Room Events have the following additional
   fields.
-properties:
-  event_id:
-    description: The globally unique event identifier.
-    type: string
-  sender:
-    description: Contains the fully-qualified ID of the user who sent this event.
-    type: string
-  origin_server_ts:
-    description: Timestamp in milliseconds on originating homeserver
-      when this event was sent.
-    type: integer
-    format: int64
-  unsigned:
-    $ref: unsigned_prop.yaml
-required:
-- event_id
-- sender
-- origin_server_ts
-title: SyncRoomEvent
-type: object
+allOf:
+- $ref: event.yaml
+- type: object
+  properties:
+    event_id:
+      description: The globally unique event identifier.
+      type: string
+    sender:
+      description: Contains the fully-qualified ID of the user who sent this event.
+      type: string
+    origin_server_ts:
+      description: Timestamp in milliseconds on originating homeserver
+        when this event was sent.
+      type: integer
+      format: int64
+    unsigned:
+      $ref: unsigned_prop.yaml
+  required:
+  - event_id
+  - sender
+  - origin_server_ts

--- a/data/event-schemas/schema/core-event-schema/sync_state_event.yaml
+++ b/data/event-schemas/schema/core-event-schema/sync_state_event.yaml
@@ -14,21 +14,21 @@
 
 # See sync_room_event.yaml for why this file is here.
 
-allOf:
-- $ref: sync_room_event.yaml
+title: SyncStateEvent
 description: In addition to the Room Event fields, State Events have the following
   additional fields.
-properties:
-  state_key:
-    description: A unique key which defines the overwriting semantics for this piece
-      of room state. This value is often a zero-length string. The presence of this
-      key makes this event a State Event.
+allOf:
+- $ref: sync_room_event.yaml
+- type: object
+  properties:
+    state_key:
+      description: A unique key which defines the overwriting semantics for this piece
+        of room state. This value is often a zero-length string. The presence of this
+        key makes this event a State Event.
 
-      State keys starting with an `@` are reserved for referencing user IDs, such
-      as room members. With the exception of a few events, state events set with a
-      given user's ID as the state key MUST only be set by that user.
-    type: string
-required:
-- state_key
-title: SyncStateEvent
-type: object
+        State keys starting with an `@` are reserved for referencing user IDs, such
+        as room members. With the exception of a few events, state events set with a
+        given user's ID as the state key MUST only be set by that user.
+      type: string
+  required:
+  - state_key


### PR DESCRIPTION
Redocly had a new major release and it seems that a new lint was triggered in CI.

The definitions or `Protocol` triggered a new lint because the `instances` field is not defined in `protocol_base.yaml`, so it cannot be in the `required` array in that file. That condition must be moved to where this field is defined.

The other changes were required because the definitions provoked a crash in the new version of Redocly (https://github.com/Redocly/redocly-cli/issues/2224). While the crash should not happen in the first place, we can avoid it in our case by cleaning up the definitions:
  - For the room summary endpoint, the `required` array was duplicated at each level of nesting. Keeping it only on the base definition gets rid of the crash.
  - For the `SyncStateEvent` definition, we use `allOf` only for `$ref` and add other fields at the top level. It actually makes more sense to declare the added field in a schema that is also an item of `allOf`, which is what this does.

This doesn't change anything in the rendered spec.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)
