### PR TITLE
Clarify that clients should replace events with the most recent replacement by origin_server_ts

### DIFF
--- a/changelogs/internal/newsfragments/2190.clarification
+++ b/changelogs/internal/newsfragments/2190.clarification
@@ -1,0 +1,1 @@
+Clarify that clients should replace events with the most recent replacement by origin_server_ts.

--- a/content/client-server-api/modules/event_replacements.md
+++ b/content/client-server-api/modules/event_replacements.md
@@ -268,7 +268,7 @@ Client authors are reminded to take note of the requirements for [Validity of
 replacement events](#validity-of-replacement-events), and to ignore any
 invalid replacement events that are received.
 
-Clients should render the content of the **most recent** replacement event. The
+Clients should render the content of the **most recent** valid replacement event. The
 most recent event is determined by comparing `origin_server_ts`; if two or more
 replacement events have identical `origin_server_ts`, the event with the
 lexicographically largest `event_id` is treated as more recent.

--- a/content/client-server-api/modules/event_replacements.md
+++ b/content/client-server-api/modules/event_replacements.md
@@ -268,6 +268,11 @@ Client authors are reminded to take note of the requirements for [Validity of
 replacement events](#validity-of-replacement-events), and to ignore any
 invalid replacement events that are received.
 
+Clients should render the content of the **most recent** replacement event. The
+most recent event is determined by comparing `origin_server_ts`; if two or more
+replacement events have identical `origin_server_ts`, the event with the
+lexicographically largest `event_id` is treated as more recent.
+
 ##### Permalinks
 
 When creating [links](/appendices/#uris) to events (also known as permalinks),

--- a/content/client-server-api/modules/event_replacements.md
+++ b/content/client-server-api/modules/event_replacements.md
@@ -195,7 +195,7 @@ given event (for example, if an event is edited multiple times). These should
 be [aggregated](#aggregations-of-child-events) by the homeserver.
 
 The aggregation format of `m.replace` relationships gives the **most recent**
-replacement event, formatted [as normal](#room-event-format).
+valid replacement event, formatted [as normal](#room-event-format).
 
 The most recent event is determined by comparing `origin_server_ts`; if two or
 more replacement events have identical `origin_server_ts`, the event with the


### PR DESCRIPTION
It seems clear that if the server aggregates in this order, then the client should do the same, so I argue that this change clarifies something that was already implied in the existing spec.

### Pull Request Checklist

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)








<!-- Replace -->
Preview: https://pr2190--matrix-spec-previews.netlify.app
<!-- Replace -->
