### PR TITLE
Fix `/sync` flow referencing incorrect parameter to use with `/messages`

### DIFF
--- a/changelogs/client_server/newsfragments/2195.clarification
+++ b/changelogs/client_server/newsfragments/2195.clarification
@@ -1,0 +1,1 @@
+Fix `/sync` flow referencing incorrect parameter to use with `/messages`.

--- a/content/client-server-api/_index.md
+++ b/content/client-server-api/_index.md
@@ -2837,7 +2837,7 @@ most recent message events for each room, as well as the state of the
 room at the start of the returned timeline. The response also includes a
 `next_batch` field, which should be used as the value of the `since`
 parameter in the next call to `/sync`. Finally, the response includes,
-for each room, a `prev_batch` field, which can be passed as a `start`
+for each room, a `prev_batch` field, which can be passed as a `from`/`to`
 parameter to the [`/rooms/<room_id>/messages`](/client-server-api/#get_matrixclientv3roomsroomidmessages) API to retrieve earlier
 messages.
 


### PR DESCRIPTION
Fix `/sync` flow referencing incorrect parameter to use with `/messages`

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)




Signed-off-by: Eric Eastwood <erice@element.io>


<!-- Replace -->
Preview: https://pr2195--matrix-spec-previews.netlify.app
<!-- Replace -->
