### PR TITLE
Don't advertise creator field in description of room creation

### DIFF
--- a/changelogs/client_server/newsfragments/2215.clarification
+++ b/changelogs/client_server/newsfragments/2215.clarification
@@ -1,0 +1,1 @@
+Don't advertise `creator` field in description of room creation.

--- a/content/client-server-api/_index.md
+++ b/content/client-server-api/_index.md
@@ -3386,10 +3386,10 @@ Unspecified room types are permitted through the use of
 ### Creation
 
 The homeserver will create an `m.room.create` event when a room is
-created, which serves as the root of the event graph for this room. This
-event also has a `creator` key which contains the user ID of the room
-creator. It will also generate several other events in order to manage
-permissions in this room. This includes:
+created, which serves as the root of the event graph for this room. The
+event `sender` is the user ID of the room creator. The server will also
+generate several other events in order to manage permissions in this room.
+This includes:
 
 -   `m.room.power_levels` : Sets the power levels of users and required power
     levels for various actions within the room such as sending events.


### PR DESCRIPTION
Fixes: #2161

I took a slightly different route than suggested in the issue to call out the `sender` field instead.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)





<!-- Replace -->
Preview: https://pr2215--matrix-spec-previews.netlify.app
<!-- Replace -->
