### PR TITLE
fix: update twitter icon to x

### DIFF
--- a/changelogs/internal/newsfragments/2219.clarification
+++ b/changelogs/internal/newsfragments/2219.clarification
@@ -1,0 +1,1 @@
+Swapped icon for X (fka. twitter) to updated logo in footer.

--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -110,7 +110,7 @@ sidebar_menu_compact = true
 [[params.links.bottom]]
 	name = "Twitter"
 	url = "https://twitter.com/matrixdotorg"
-	icon = "fab fa-twitter"
+	icon = "fab fa-x-twitter"
   desc = "Matrix on Twitter"
 
 


### PR DESCRIPTION
### Pull Request Checklist
Fixes #2218 Twitter icon has been updated on https://spec.matrix.org/latest/

<img width="269" height="85" alt="Screenshot 2025-10-04 at 12 37 30 AM" src="https://github.com/user-attachments/assets/0bb129ea-17ad-4e4b-bd8a-94e68bac91e5" />

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)








<!-- Replace -->
Preview: https://pr2219--matrix-spec-previews.netlify.app
<!-- Replace -->
