### PR TITLE
Clarify that restricted joins require the referenced user to be joined

### DIFF
--- a/changelogs/room_versions/newsfragments/2220.clarification
+++ b/changelogs/room_versions/newsfragments/2220.clarification
@@ -1,0 +1,1 @@
+In room versions 8 through 12, clarify that "sufficient permission to invite users" on restricted joins also includes being a joined member of the room.

--- a/content/rooms/fragments/v8-auth-rules.md
+++ b/content/rooms/fragments/v8-auth-rules.md
@@ -74,7 +74,7 @@ The rules are as follows:
             1.  If membership state is `join` or `invite`, allow.
             2.  If the `join_authorised_via_users_server` key in `content`
                 is not a user with sufficient permission to invite other
-                users, reject.
+                users or is not a joined member of the room, reject.
             3.  Otherwise, allow.
         6.  If the `join_rule` is `public`, allow.
         7.  Otherwise, reject.

--- a/content/rooms/v10.md
+++ b/content/rooms/v10.md
@@ -150,7 +150,7 @@ The rules are as follows:
             1.  If membership state is `join` or `invite`, allow.
             2.  If the `join_authorised_via_users_server` key in `content`
                 is not a user with sufficient permission to invite other
-                users, reject.
+                users or is not a joined member of the room, reject.
             3.  Otherwise, allow.
         6.  If the `join_rule` is `public`, allow.
         7.  Otherwise, reject.

--- a/content/rooms/v11.md
+++ b/content/rooms/v11.md
@@ -157,7 +157,7 @@ The rules are as follows:
             1.  If membership state is `join` or `invite`, allow.
             2.  If the `join_authorised_via_users_server` key in `content`
                 is not a user with sufficient permission to invite other
-                users, reject.
+                users or is not a joined member of the room, reject.
             3.  Otherwise, allow.
         6.  If the `join_rule` is `public`, allow.
         7.  Otherwise, reject.

--- a/content/rooms/v12.md
+++ b/content/rooms/v12.md
@@ -141,7 +141,7 @@ The rules are as follows:
             1.  If membership state is `join` or `invite`, allow.
             2.  If the `join_authorised_via_users_server` key in `content`
                 is not a user with sufficient permission to invite other
-                users, reject.
+                users or is not a joined member of the room, reject.
             3.  Otherwise, allow.
         6.  If the `join_rule` is `public`, allow.
         7.  Otherwise, reject.


### PR DESCRIPTION
See https://github.com/element-hq/synapse/blob/develop/synapse/event_auth.py#L698-L701
See https://matrix.to/#/!NasysSDfxKxZBzJJoE:matrix.org/$AG6DYMtZftTiWYFLrQqd_9OqfOazxhVNm5HJ6jECETs?via=matrix.org&via=envs.net&via=element.io

<!-- Replace -->
Preview: https://pr2220--matrix-spec-previews.netlify.app
<!-- Replace -->
