### PR TITLE
Clarify that additional OpenGraph properties can be present in URL previews

### DIFF
--- a/changelogs/client_server/newsfragments/2225.clarification
+++ b/changelogs/client_server/newsfragments/2225.clarification
@@ -1,0 +1,1 @@
+Additional OpenGraph properties can be present in URL previews.

--- a/data/api/client-server/authed-content-repo.yaml
+++ b/data/api/client-server/authed-content-repo.yaml
@@ -379,7 +379,8 @@ paths:
           description: |-
             The OpenGraph data for the URL, which may be empty. Some values are
             replaced with matrix equivalents if they are provided in the response.
-            The differences from the OpenGraph protocol are described here.
+            The differences from the [OpenGraph protocol](https://ogp.me/) are
+            described here.
           content:
             application/json:
               schema:
@@ -394,6 +395,9 @@ paths:
                     format: uri
                     description: An [`mxc://` URI](/client-server-api/#matrix-content-mxc-uris) to
                       the image. Omitted if there is no image.
+                additionalProperties:
+                    description: |-
+                      Additional properties as per the [OpenGraph](https://ogp.me/) protocol.
               examples:
                 response:
                   value: {

--- a/data/api/client-server/content-repo.yaml
+++ b/data/api/client-server/content-repo.yaml
@@ -605,7 +605,8 @@ paths:
           description: |-
             The OpenGraph data for the URL, which may be empty. Some values are
             replaced with matrix equivalents if they are provided in the response.
-            The differences from the OpenGraph protocol are described here.
+            The differences from the [OpenGraph](https://ogp.me/) protocol are
+            described here.
           content:
             application/json:
               schema:
@@ -620,6 +621,9 @@ paths:
                     format: uri
                     description: An [`mxc://` URI](/client-server-api/#matrix-content-mxc-uris) to
                       the image. Omitted if there is no image.
+                additionalProperties:
+                    description: |-
+                      Additional properties as per the [OpenGraph](https://ogp.me/) protocol.
               examples:
                 response:
                   value: {


### PR DESCRIPTION
Fixes: #1753

Rather than enumerate all the other possible properties (and their interplay), I used `additionalProperties` to link to the OpenGraph spec.

<img width="761" height="350" alt="Screenshot 2025-10-07 at 10 24 04" src="https://github.com/user-attachments/assets/6b6a5275-ed20-4fe2-a4d6-d6474f6c5600" />

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)





<!-- Replace -->
Preview: https://pr2225--matrix-spec-previews.netlify.app
<!-- Replace -->
