### PR TITLE
Fix schema for room forget call

### DIFF
--- a/data/api/client-server/leaving.yaml
+++ b/data/api/client-server/leaving.yaml
@@ -102,6 +102,13 @@ paths:
           example: "!au1ba7o:matrix.org"
           schema:
             type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example: {}
+        required: true
       responses:
         "200":
           description: The room has been forgotten.


### PR DESCRIPTION
https://spec.matrix.org/v1.16/client-server-api/#post_matrixclientv3roomsroomidforget fails to define a request body.

But it is not one of the four exceptions listed in https://spec.matrix.org/v1.16/client-server-api/#api-standards which deviate from the rule that 

> All POST and PUT endpoints, with the exception of those listed below, require the client to supply a request body containing a (potentially empty) JSON object.


### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [ ] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [ ] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [ ] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)


<!-- Replace -->
Preview: https://pr2229--matrix-spec-previews.netlify.app
<!-- Replace -->
