### PR TITLE
Clarify the special casing of membership events and redactions in power levels

### DIFF
--- a/changelogs/client_server/newsfragments/2231.clarification
+++ b/changelogs/client_server/newsfragments/2231.clarification
@@ -1,0 +1,1 @@
+Clarify the special casing of membership events and redactions in power levels.

--- a/data/api/client-server/redaction.yaml
+++ b/data/api/client-server/redaction.yaml
@@ -26,9 +26,9 @@ paths:
         This cannot be undone.
 
         Any user with a power level greater than or equal to the `m.room.redaction`
-        event power level may send redaction events in the room. If the user's power
-        level is also greater than or equal to the `redact` power level of the room,
-        the user may redact events sent by other users.
+        event power level may send redactions for their own events in the room. If
+        the user's power level is also greater than or equal to the `redact` power
+        level of the room, the user may redact events sent by other users.
 
         Server administrators may redact events sent by users on their server.
       operationId: redactEvent

--- a/data/event-schemas/schema/m.room.power_levels.yaml
+++ b/data/event-schemas/schema/m.room.power_levels.yaml
@@ -13,24 +13,34 @@ description: |-
   0. If the room contains no `m.room.power_levels` event, the room's creator has
   a power level of 100, and all other users have a power level of 0.
 
-  The level required to send a certain event is governed by `events`,
-  `state_default` and `events_default`. If an event type is specified in
-  `events`, then the user must have at least the level specified in order to
-  send that event. If the event type is not supplied, it defaults to
-  `events_default` for Message Events and `state_default` for State
-  Events.
+  Except for membership events and redactions, the level required to
+  send a certain event is governed purely by `events`, `state_default`
+  and `events_default`. If an event type is specified in `events`, then
+  the user must have at least the level specified in order to send that
+  event. If the event type is not supplied, it defaults to `events_default`
+  for message events and `state_default` for state events.
 
   If there is no `state_default` in the `m.room.power_levels` event, or
   there is no `m.room.power_levels` event, the `state_default` is 50.
   If there is no `events_default` in the `m.room.power_levels` event,
   or there is no `m.room.power_levels` event, the `events_default` is 0.
 
-  The power level required to invite a user to the room, kick a user from the
-  room, ban a user from the room, or redact an event sent by another user, is
-  defined by `invite`, `kick`, `ban`, and `redact`, respectively.  The levels
-  for `kick`, `ban` and `redact` default to 50 if they are not specified in the
-  `m.room.power_levels` event, or if the room contains no `m.room.power_levels`
-  event. `invite` defaults to 0 in either case.
+  Membership events are not subject to `events`, `events_default`, or
+  `state_default`. Instead, the power level required to invite a user
+  to the room, kick a user from the room, or ban a user from the room
+  is defined by `invite`, `kick`, and `ban`, respectively. The levels
+  for `kick` and `ban` default to 50 if they are not specified in the
+  `m.room.power_levels` event, or if the room contains no
+  `m.room.power_levels` event. `invite` defaults to 0 in either case.
+  Other membership values are handled during event authorization. See
+  the authorization rules in [room versions](/rooms) for further details.
+
+  For redactions of a user's own events, the required power level is
+  determined by the `m.room.redaction` event power level, as per `events`
+  and `events_default`. The power level required to redact an event sent
+  by another user is _additionally_ governed by `redact`. The level for
+  `redact` defaults to 50 if it is not specified in the `m.room.power_levels`
+  event, or if the room contains no `m.room.power_levels` event.
 
   **Note:**
 


### PR DESCRIPTION
Fixes: #1020

The breakout of redactions in the description doesn't relate to #1020 but it seemed easier to comprehend to me this way.

Hopefully I've pieced everything together correctly. 🤞 

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)





<!-- Replace -->
Preview: https://pr2231--matrix-spec-previews.netlify.app
<!-- Replace -->
