### PR TITLE
Add m.login.terms to enumeration of authentication types

### DIFF
--- a/changelogs/client_server/newsfragments/2233.clarification
+++ b/changelogs/client_server/newsfragments/2233.clarification
@@ -1,0 +1,1 @@
+Add `m.login.terms` to enumeration of authentication types.

--- a/content/client-server-api/_index.md
+++ b/content/client-server-api/_index.md
@@ -906,6 +906,7 @@ This specification defines the following auth types:
 -   `m.login.msisdn`
 -   `m.login.dummy`
 -   `m.login.registration_token`
+-   {{% added-in v="1.11" %}} `m.login.terms`
 
 ###### Password-based
 


### PR DESCRIPTION
I'm not sure if this was intentionally omitted in https://github.com/matrix-org/matrix-spec/pull/1812 but I couldn't think of a reason why it should be the only type missing from the list.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)





<!-- Replace -->
Preview: https://pr2233--matrix-spec-previews.netlify.app
<!-- Replace -->
