### PR TITLE
Clarify how to use state_after ahead of declaring full support for its spec version

### DIFF
--- a/changelogs/client_server/newsfragments/2240.clarification
+++ b/changelogs/client_server/newsfragments/2240.clarification
@@ -1,0 +1,1 @@
+Clarify how to use `state_after` ahead of declaring full support for its spec version.

--- a/data/api/client-server/sync.yaml
+++ b/data/api/client-server/sync.yaml
@@ -133,10 +133,15 @@ paths:
             sync and the **start** of the timeline in `state` and MUST omit
             `state_after`.
 
-            Even if this is set to `true`, clients MUST update their local state
-            with events in `state` and `timeline` if `state_after` is missing in
-            the response, for compatibility with servers that don't support this
-            parameter.
+            Servers MAY implement this parameter ahead of declaring support for
+            the version of the spec in which it was introduced. Consequently,
+            clients MAY set this parameter to `true` regardless of the
+            [`/versions`](/client-server-api/#get_matrixclientversions) response.
+            If they do, they can infer whether the server actually supports this
+            parameter from the presence of `state_after` in the response. If
+            `state_after` is missing, clients MUST behave as if they had not
+            specified the parameter and update their local state with events
+            in `state` and `timeline`.
 
             By default, this is `false`.
           example: false


### PR DESCRIPTION
The current text in the spec appears contradictory to me because it requires servers to support the feature but also requires clients to handle the server not supporting it. It was clarified in the [matrix-spec room](https://matrix.to/#/!NasysSDfxKxZBzJJoE:matrix.org/$44XjU62OkEtv8TonSbiTp7qXBSiNEGlDKtwMPBzbAkM?via=matrix.org&via=envs.net&via=element.io) that the intent was to allow usage of this feature without requiring the server to implement full support for Matrix 1.16.

What I think this means is that we want to allow clients to set `use_state_after=true` regardless of whether the server declares support for 1.16 in `/versions`. And only if a client does that, we want to require it handle the server not supporting the feature. This change tries to change the spec text accordingly.

It was also mentioned in the matrix-spec room that some servers declare support for a version without fully implementing it. The current spec for `use_state_after` would work in this case, too. I think we should not allow this, however, because it makes `/versions` somewhat useless and would require clients to infer what features the server actually supports _everywhere_.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [X] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [X] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)


<!-- Replace -->
Preview: https://pr2240--matrix-spec-previews.netlify.app
<!-- Replace -->
