### PR TITLE
Fix broken link to katex CSS

### DIFF
--- a/changelogs/internal/newsfragments/2241.clarification
+++ b/changelogs/internal/newsfragments/2241.clarification
@@ -1,0 +1,1 @@
+Inline Olm & Megolm specifications.

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -13,8 +13,8 @@
   <head>
     {{ partial "head.html" . }}
     {{ if .Page.Store.Get "hasMath" }}
-      <link href="/css/katex.min.css" rel="preload" as="style">
-      <link href="/css/katex.min.css" rel="stylesheet">
+      <link href="{{ relURL "css/katex.min.css" }}" rel="preload" as="style">
+      <link href="{{ relURL "css/katex.min.css" }}" rel="stylesheet">
     {{ end }}
   </head>
   <body class="td-{{ .Kind }}{{ with .Page.Params.body_class }} {{ . }}{{ end }}">


### PR DESCRIPTION
Followup to https://github.com/matrix-org/matrix-spec/pull/2226, which broke the build. These links to the static CSS are broken in the case that the spec is built for a subdirectory (such as `unstable`).




<!-- Replace -->
Preview: https://pr2241--matrix-spec-previews.netlify.app
<!-- Replace -->
