### PR TITLE
Load versions.json as a resource if we're in the unstable spec

### DIFF
--- a/assets/js/versions.template.js
+++ b/assets/js/versions.template.js
@@ -82,7 +82,14 @@ function appendVersion(parent, name, url) {
     a.appendChild(text);
 }
 
-fetch("/latest/versions.json")
+// If we're in the unstable version, we're the latest thing and can just load
+// versions.json from our own resources. Otherwise, we fall back to loading it
+// from /unstable/versions.json, assuming we are on the spec.matrix.org deployment.
+const url = currentVersion === "unstable"
+    ? '{{ "/" | relURL }}versions.json'
+    : "/unstable/versions.json";
+
+fetch(url)
     .then(r => r.json())
     .then(versions => {
         // Find the surrounding list element

--- a/changelogs/internal/newsfragments/2258.clarification
+++ b/changelogs/internal/newsfragments/2258.clarification
@@ -1,0 +1,1 @@
+Add version picker in the navbar.


### PR DESCRIPTION
This is a follow-up on https://github.com/matrix-org/matrix-spec/pull/2256 and https://github.com/matrix-org/matrix-spec/pull/2257. It switches to loading `versions.json` as a resource of the local site if we're in the unstable spec. This should make the version picker on https://spec.matrix.org/unstable/ work ahead of the next spec release.

I noticed that the CSS styles in the picker don't seem to work in the netlify deployment. I'm not sure why. They do work locally. 🤔 

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)











<!-- Replace -->
Preview: https://pr2258--matrix-spec-previews.netlify.app
<!-- Replace -->
