### PR TITLE
Fix versions.json URL in unstable and local environment

### DIFF
--- a/assets/js/versions.template.js
+++ b/assets/js/versions.template.js
@@ -86,7 +86,7 @@ function appendVersion(parent, name, url) {
 // versions.json from our own resources. Otherwise, we fall back to loading it
 // from /unstable/versions.json, assuming we are on the spec.matrix.org deployment.
 const url = currentVersion === "unstable"
-    ? '{{ "/" | relURL }}versions.json'
+    ? '{{ .Site.Home.Permalink }}versions.json'
     : "/unstable/versions.json";
 
 fetch(url)

--- a/changelogs/internal/newsfragments/2259.clarification
+++ b/changelogs/internal/newsfragments/2259.clarification
@@ -1,0 +1,1 @@
+Add version picker in the navbar.


### PR DESCRIPTION
This is another follow-up on #2258 which has left the version picker broken on https://spec.matrix.org/unstable. I switched to `.Site.Home.Permalink` for the base URL. This works locally and I hope it'll work in the deployment, too, because a similar pattern is used in the navbar.

If this doesn't work either, we can switch to `/unstable/versions.json` which, however, has the downside of leaving the picker empty on local builds.

CC @anoadragon453 

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)





<!-- Replace -->
Preview: https://pr2259--matrix-spec-previews.netlify.app
<!-- Replace -->
