### PR TITLE
Append version number to 'latest' entry in the picker

### DIFF
--- a/assets/js/versions.template.js
+++ b/assets/js/versions.template.js
@@ -40,13 +40,13 @@ const currentSegment = segmentMatches ? segmentMatches[0] : undefined;
 // fall back to the version as defined in Hugo.
 const selected = currentSegment ?? currentVersion;
 
-function appendVersion(parent, name, url) {
+function appendVersion(parent, name, segment, url) {
     // The list item
     const li = document.createElement("li");
-    if (name === selected) {
+    if (segment === selected) {
         li.classList.add("selected");
     }
-    if (name === "latest") {
+    if (segment === "latest") {
         li.classList.add("latest");
     }
     parent.appendChild(li);
@@ -74,7 +74,7 @@ function appendVersion(parent, name, url) {
         // Otherwise, stop further event handling and replace the segment
         ev.preventDefault();
         ev.stopPropagation();
-        window.location.href = href.replace(`/${currentSegment}/`, `/${name}/`);
+        window.location.href = href.replace(`/${currentSegment}/`, `/${segment}/`);
     });
 
     // The link text
@@ -100,12 +100,13 @@ fetch(url)
         }
 
         // Add a entries for the unstable version and the "latest" shortcut
-        appendVersion(ul, "unstable", "https://spec.matrix.org/unstable");
-        appendVersion(ul, "latest", "https://spec.matrix.org/latest");
+        appendVersion(ul, "unstable", "unstable", "https://spec.matrix.org/unstable");
+        const latestName = versions?.length ? `latest (${versions[0].name})` : "latest";
+        appendVersion(ul, latestName, "latest", "https://spec.matrix.org/latest");
 
         // Add an entry for each proper version
         for (const version of versions) {
-            appendVersion(ul, version.name, `https://spec.matrix.org/${version.name}`);
+            appendVersion(ul, version.name, version.name, `https://spec.matrix.org/${version.name}`);
         }
 
         // For historical versions, simply link to the changelog

--- a/changelogs/internal/newsfragments/2261.clarification
+++ b/changelogs/internal/newsfragments/2261.clarification
@@ -1,0 +1,1 @@
+Add version picker in the navbar.


### PR DESCRIPTION
Hopefully the last fix on the version picker for a while. This appends the version number to the "latest" picker item.

<img width="236" height="201" alt="Screenshot 2025-12-05 at 15 05 43" src="https://github.com/user-attachments/assets/135c7b14-94d2-4892-9000-17988450a52b" />

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)





<!-- Replace -->
Preview: https://pr2261--matrix-spec-previews.netlify.app
<!-- Replace -->
