### PR TITLE
Try to prevent PostCSS from stripping comments that are meant to prevent PurgeCSS from stripping our version picker CSS

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -59,8 +59,10 @@ Custom SCSS for the Matrix spec
 
   /* As these styles are only applied by JavaScript, PurgeCSS doesn't see them
    * in the source code and removes them unless we explicitly tell it not to.
+   * We use /*! so that PostCSS doesn't strip the comments before PurgeCSS can
+   * see them.
    */
-  /* purgecss start ignore */
+  /*! purgecss start ignore */
   ul#version-selector li.selected a {
     font-weight: bold;
   }
@@ -68,7 +70,7 @@ Custom SCSS for the Matrix spec
   ul#version-selector li.latest a {
     color: $secondary;
   }
-  /* purgecss end ignore */
+  /*! purgecss end ignore */
 }
 
 /* Styles for the sidebar nav */

--- a/changelogs/internal/newsfragments/2263.clarification
+++ b/changelogs/internal/newsfragments/2263.clarification
@@ -1,0 +1,1 @@
+Add version picker in the navbar.


### PR DESCRIPTION
I haven't tested this (because I don't really know how) but the [PurgeCSS](https://purgecss.com/safelisting.html#gotchas) docs listed this as a potential gotcha.

CC @anoadragon453 

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)





<!-- Replace -->
Preview: https://pr2263--matrix-spec-previews.netlify.app
<!-- Replace -->
