### PR TITLE
Clarify the requiredness of `event_id` in `predecessor`

### DIFF
--- a/changelogs/client_server/newsfragments/2304.clarification
+++ b/changelogs/client_server/newsfragments/2304.clarification
@@ -1,0 +1,1 @@
+Clarify the requiredness of `event_id` in `predecessor`.

--- a/content/client-server-api/modules/room_upgrades.md
+++ b/content/client-server-api/modules/room_upgrades.md
@@ -43,8 +43,8 @@ They must be explicitly set during the `/upgrade` call.
 {{% /boxes/note %}}
 
 {{% boxes/note %}}
-{{% added-in v="1.16" %}} When upgrading to room version 12 or later, the `predecessor` field MAY NOT contain
-an `event_id`.
+{{% added-in v="1.16" %}} When upgrading to room version 12 or later, the `event_id` property inside
+`predecessor` MAY be omitted.
 {{% /boxes/note %}}
 
 3.  Replicates transferable state events to the new room. The exact


### PR DESCRIPTION
[RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119) does not define MAY NOT. It does define SHALL NOT to mean the same as MUST NOT though.

Grammatically "may not" implies "forbidden" to me (though I'm not a native speaker, admittedly). IIUC the intent is simply to make the field optional though. Therefore, I think the current wording is potentially confusing.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)








<!-- Replace -->
Preview: https://pr2304--matrix-spec-previews.netlify.app
<!-- Replace -->
