### PR TITLE
Add page search widget (Docsy / Lunr)

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -661,3 +661,7 @@ dd {
     margin: 0;
   }
 }
+
+.td-offline-search-results {
+  max-width: 460px;
+}

--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -66,6 +66,9 @@ description = "Home of the Matrix specification for decentralised communication"
 
 [params]
 copyright = "The Matrix.org Foundation C.I.C."
+offlineSearch = true
+offlineSearchSummaryLength = 200
+offlineSearchMaxResults = 25
 
 [params.version]
 # must be one of "unstable", "current", "historical"


### PR DESCRIPTION
This is an alternative to https://github.com/matrix-org/matrix-spec/pull/2331 that uses [Docsy's built-in page search support](https://www.docsy.dev/docs/content/search/) based on Lunr.

The search input will display on the right side of the navbar. You'll need to hit enter to trigger the search which will make results display in a popup below the input.

<img width="541" height="925" alt="Screenshot 2026-03-10 at 14 19 48" src="https://github.com/user-attachments/assets/e0703c2a-b6e9-4abe-9136-24f6d07c328c" />

It looks like one major drawback of this is that the search results will only list entire pages. So you will get e.g. `/client-server-api/` in the results but not different matches of the search term on that page.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [ ] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)
