### PR TITLE
Clarify that server ACLs are case-insensitive

### DIFF
--- a/changelogs/server_server/newsfragments/2334.clarification
+++ b/changelogs/server_server/newsfragments/2334.clarification
@@ -1,0 +1,1 @@
+Clarify that server ACLs are case-insensitive.

--- a/changelogs/server_server/newsfragments/2334.clarification
+++ b/changelogs/server_server/newsfragments/2334.clarification
@@ -1,1 +1,1 @@
-Clarify that server ACLs are case-insensitive.
+Clarify that server ACLs are case-insensitive, as per [MSC4436](https://github.com/matrix-org/matrix-spec-proposals/pull/4436).

--- a/data/event-schemas/schema/m.room.server_acl.yaml
+++ b/data/event-schemas/schema/m.room.server_acl.yaml
@@ -62,8 +62,9 @@ properties:
       allow:
         type: array
         description: |-
-          The case-insensitive server names to allow in the room, excluding any port information.
-          Each entry is interpreted as a [glob-style pattern](/appendices#glob-style-matching).
+          The case-insensitive [glob expressions](/appendices#glob-style-matching) that are
+          evaluated against server names excluding any port information to determine the servers
+          to allow in the room.
 
           **This defaults to an empty list when not provided, effectively disallowing
           every server.**
@@ -72,8 +73,9 @@ properties:
       deny:
         type: array
         description: |-
-          The case-insensitive server names to disallow in the room, excluding any port information.
-          Each entry is interpreted as a [glob-style pattern](/appendices#glob-style-matching).
+          The case-insensitive [glob expressions](/appendices#glob-style-matching) that are
+          evaluated against server names excluding any port information to determine the servers
+          to disallow in the room.
 
           This defaults to an empty list when not provided.
         items:

--- a/data/event-schemas/schema/m.room.server_acl.yaml
+++ b/data/event-schemas/schema/m.room.server_acl.yaml
@@ -62,7 +62,7 @@ properties:
       allow:
         type: array
         description: |-
-          The server names to allow in the room, excluding any port information.
+          The case-insensitive server names to allow in the room, excluding any port information.
           Each entry is interpreted as a [glob-style pattern](/appendices#glob-style-matching).
 
           **This defaults to an empty list when not provided, effectively disallowing
@@ -72,7 +72,7 @@ properties:
       deny:
         type: array
         description: |-
-          The server names to disallow in the room, excluding any port information.
+          The case-insensitive server names to disallow in the room, excluding any port information.
           Each entry is interpreted as a [glob-style pattern](/appendices#glob-style-matching).
 
           This defaults to an empty list when not provided.


### PR DESCRIPTION
### Pull Request Checklist

These were implemented case insensitively in Synapse when they were first added: https://github.com/element-hq/synapse/commit/3cf3e08a97f4617763ce10da4f127c0e21d7ff1d

Some implementations (notably Ruma) treated them case sensitively however.

* [X] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [X] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [X] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)

Signed-off-by: Helix K <vel@riseup.net>










<!-- Replace -->
Preview: https://pr2334--matrix-spec-previews.netlify.app
<!-- Replace -->
