### PR TITLE
Clarify how multiple signatures should be handled during verification

### DIFF
--- a/changelogs/server_server/newsfragments/2341.clarification
+++ b/changelogs/server_server/newsfragments/2341.clarification
@@ -1,0 +1,1 @@
+Clarify how multiple signatures should be handled during signature verification. Contributed by @nexy7574.

--- a/content/server-server-api.md
+++ b/content/server-server-api.md
@@ -1508,7 +1508,7 @@ expected to be published and therefore should be skipped at this stage.
 Additionally, any keys that are known to have expired prior to the event's
 `origin_server_ts` are ignored.
 
-If all signatures from known keys are found to be valid, the expected content hash is
+If all signatures from known unexpired keys from the originating server(s) are found to be valid, the expected content hash is
 calculated as described below. The content hash in the `hashes` property
 of the received event is base64-decoded, and the two are compared for
 equality.

--- a/content/server-server-api.md
+++ b/content/server-server-api.md
@@ -1492,37 +1492,35 @@ signature](/appendices#checking-for-a-signature). Note that this
 step should succeed whether we have been sent the full event or a
 redacted copy.
 
-The signatures expected on an event are:
+Unless the event is a 3rd party invite, only the signature(s) from the
+originating server (the server the `sender` belongs to) are required for
+verification. If a signature is from an unknown or expired key, it is skipped.
 
--   The `sender`'s server, unless the invite was created as a result of
-    3rd party invite. The sender must already match the 3rd party
-    invite, and the server which actually sends the event may be a
-    different server.
--   For room versions 1 and 2, the server which created the `event_id`.
-    Other room versions do not track the `event_id` over federation and
-    therefore do not need a signature from those servers.
+If the event is a 3rd party invite, the sender must already match the 3rd party
+invite, and the server which actually sends the event may be a different
+server.
 
-Only signatures from known server keys are validated here, any unknown keys are ignored.
+Only signatures from known server keys are validated here. Any unknown keys are ignored.
 In particular, the [policy server key](#validating-policy-server-signatures) is not
 expected to be published and therefore should be skipped at this stage.
 Additionally, any keys that are known to have expired prior to the event's
 `origin_server_ts` are ignored.
-
-If all signatures from known unexpired keys from the originating server(s) are found to be valid, the expected content hash is
-calculated as described below. The content hash in the `hashes` property
-of the received event is base64-decoded, and the two are compared for
-equality.
-
-If the hash check fails, then it is assumed that this is because we have
-only been given a redacted version of the event. To enforce this, the
-receiving server should use the redacted copy it calculated rather than
-the full copy it received.
 
 {{% boxes/note %}}
 {{% added-in v="1.18" %}}
 Events sent in rooms with [Policy Servers](#policy-servers) have [additional](#validating-policy-server-signatures)
 signature validation requirements.
 {{% /boxes/note %}}
+
+If all signatures from known unexpired keys from the originating server(s) are
+found to be valid, the expected content hash is calculated as described below.
+The content hash in the `hashes` property of the received event is base64-decoded,
+and the two are compared for equality.
+
+If the hash check fails, then it is assumed that this is because we have
+only been given a redacted version of the event. To enforce this, the
+receiving server should use the redacted copy it calculated rather than
+the full copy it received.
 
 ### Calculating the reference hash for an event
 

--- a/content/server-server-api.md
+++ b/content/server-server-api.md
@@ -1502,6 +1502,12 @@ The signatures expected on an event are:
     Other room versions do not track the `event_id` over federation and
     therefore do not need a signature from those servers.
 
+Only signatures from known server keys are validated here, any unknown keys are ignored.
+In particular, the [policy server key](#validating-policy-server-signatures) is not
+expected to be published and therefore should be skipped at this stage.
+Additionally, any keys that are known to have expired prior to the event's
+`origin_server_ts` are ignored.
+
 If all signatures from known keys are found to be valid, the expected content hash is
 calculated as described below. The content hash in the `hashes` property
 of the received event is base64-decoded, and the two are compared for

--- a/content/server-server-api.md
+++ b/content/server-server-api.md
@@ -1484,10 +1484,9 @@ the Policy Server for a signature too.
 When a server receives an event over federation from another server, the
 receiving server should check the hashes and signatures on that event.
 
-First the signature is checked. The event is redacted following the
-[redaction
-algorithm](/client-server-api#redactions), and
-the resultant object is checked for a signature from the originating
+First the signatures are checked. The event is redacted following the
+[redaction algorithm](/client-server-api#redactions), and
+the resultant object is checked for signatures from the originating
 server, following the algorithm described in [Checking for a
 signature](/appendices#checking-for-a-signature). Note that this
 step should succeed whether we have been sent the full event or a
@@ -1503,7 +1502,7 @@ The signatures expected on an event are:
     Other room versions do not track the `event_id` over federation and
     therefore do not need a signature from those servers.
 
-If the signature is found to be valid, the expected content hash is
+If all signatures from known keys are found to be valid, the expected content hash is
 calculated as described below. The content hash in the `hashes` property
 of the received event is base64-decoded, and the two are compared for
 equality.

--- a/content/server-server-api.md
+++ b/content/server-server-api.md
@@ -1492,9 +1492,12 @@ signature](/appendices#checking-for-a-signature). Note that this
 step should succeed whether we have been sent the full event or a
 redacted copy.
 
-Unless the event is a 3rd party invite, only the signature(s) from the
-originating server (the server the `sender` belongs to) are required for
-verification. If a signature is from an unknown or expired key, it is skipped.
+For room versions 3 and later, unless the event is a 3rd party invite, only the
+signature(s) from the originating server (the server the `sender` belongs to)
+are required for verification. Room versions 1 and 2 also require that a
+signature is present from the domain in the `event_id`, if it differs from the
+originating server. If a signature is from an unknown or expired key, it is
+skipped.
 
 If the event is a 3rd party invite, the sender must already match the 3rd party
 invite, and the server which actually sends the event may be a different


### PR DESCRIPTION
Clarifies the "[Validating hashes and signatures on received events](https://spec.matrix.org/unstable/server-server-api/#validating-hashes-and-signatures-on-received-events)" section of the server-to-server specification to clarify that signatures from unknown keys are skipped. This clarifies behaviour that is seen in [Synapse](https://github.com/element-hq/synapse/blob/40d699b1d4d7855ffb892723eac90cd34f22aa6f/synapse/crypto/keyring.py#L351-L357) and [ruwuma](https://forgejo.ellis.link/continuwuation/ruwuma/pulls/51), and will become necessary as policy servers are adopted, as noted in https://github.com/matrix-org/matrix-spec/issues/1471#issuecomment-4103659286.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)














<!-- Replace -->
Preview: https://pr2341--matrix-spec-previews.netlify.app
<!-- Replace -->
