### PR TITLE
Upgrade docsy to v0.14.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: "Spec"
 
 env:
-  HUGO_VERSION: 0.153.3
+  HUGO_VERSION: 0.155.3
   PYTHON_VERSION: 3.13
   NODE_VERSION: 24
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ place after an MSC has been accepted, not as part of a proposal itself.
 
 1. Install the extended version (often the OS default) of Hugo:
    <https://gohugo.io/getting-started/installing>. Note that at least Hugo
-   v0.146.0 is required.
+   v0.155.0 is required.
 
    Alternatively, use the Docker image at
    https://hub.docker.com/r/klakegg/hugo/. (The "extended edition" is required

--- a/changelogs/internal/newsfragments/2346.clarification
+++ b/changelogs/internal/newsfragments/2346.clarification
@@ -1,0 +1,1 @@
+Upgrade Docsy theme to v0.14.3.

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,4 @@ module github.com/matrix-org/matrix-spec
 
 go 1.12
 
-require github.com/matrix-org/docsy v0.0.0-20260106184755-71d103ebb20a // indirect
-
-replace github.com/matrix-org/docsy v0.0.0-20260106184755-71d103ebb20a => github.com/zecakeh/matrix-org-docsy v0.0.0-20260330090302-c8561ffa244e
+require github.com/matrix-org/docsy v0.0.0-20260331222549-f318855c7886 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/matrix-org/matrix-spec
 go 1.12
 
 require github.com/matrix-org/docsy v0.0.0-20260106184755-71d103ebb20a // indirect
+
+replace github.com/matrix-org/docsy v0.0.0-20260106184755-71d103ebb20a => github.com/zecakeh/matrix-org-docsy v0.0.0-20260330090302-c8561ffa244e

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,5 @@ github.com/FortAwesome/Font-Awesome v0.0.0-20241216213156-af620534bfc3/go.mod h1
 github.com/matrix-org/docsy v0.0.0-20260106184755-71d103ebb20a h1:WB3unuZJy7ewAf33sxbtEwYnC+i+Jt1sJpAR3BtzvEo=
 github.com/matrix-org/docsy v0.0.0-20260106184755-71d103ebb20a/go.mod h1:mdn1m5HJug6ZddQgrOyCrXNegbtdl5evHiqqbEQLzdI=
 github.com/twbs/bootstrap v5.3.8+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
+github.com/zecakeh/matrix-org-docsy v0.0.0-20260330090302-c8561ffa244e h1:6fDwyGJlfkiuxC4NERnqasxv77+26zA0yL9TAD79MrY=
+github.com/zecakeh/matrix-org-docsy v0.0.0-20260330090302-c8561ffa244e/go.mod h1:mdn1m5HJug6ZddQgrOyCrXNegbtdl5evHiqqbEQLzdI=

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,4 @@
 github.com/FortAwesome/Font-Awesome v0.0.0-20241216213156-af620534bfc3/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
-github.com/matrix-org/docsy v0.0.0-20260106184755-71d103ebb20a h1:WB3unuZJy7ewAf33sxbtEwYnC+i+Jt1sJpAR3BtzvEo=
-github.com/matrix-org/docsy v0.0.0-20260106184755-71d103ebb20a/go.mod h1:mdn1m5HJug6ZddQgrOyCrXNegbtdl5evHiqqbEQLzdI=
+github.com/matrix-org/docsy v0.0.0-20260331222549-f318855c7886 h1:+Qowx/XQ8sQGTeVyoyIpcwOcdlB+Ft6x+QJkJEPDIpg=
+github.com/matrix-org/docsy v0.0.0-20260331222549-f318855c7886/go.mod h1:mdn1m5HJug6ZddQgrOyCrXNegbtdl5evHiqqbEQLzdI=
 github.com/twbs/bootstrap v5.3.8+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
-github.com/zecakeh/matrix-org-docsy v0.0.0-20260330090302-c8561ffa244e h1:6fDwyGJlfkiuxC4NERnqasxv77+26zA0yL9TAD79MrY=
-github.com/zecakeh/matrix-org-docsy v0.0.0-20260330090302-c8561ffa244e/go.mod h1:mdn1m5HJug6ZddQgrOyCrXNegbtdl5evHiqqbEQLzdI=

--- a/layouts/_markup/render-heading.html
+++ b/layouts/_markup/render-heading.html
@@ -1,7 +1,7 @@
 {{- /*
 
     This is a heading render hook (https://gohugo.io/render-hooks/headings/)
-    using Docsy's heading self-links hook (https://www.docsy.dev/docs/adding-content/navigation/#heading-self-links).
+    using Docsy's heading self-links hook (https://www.docsy.dev/docs/content/navigation/#heading-self-links).
 
     This is used when a heading is encountered in markdown content to generate
     the HTML for that heading. A self-link anchor is added at the end of the

--- a/layouts/_partials/navbar.html
+++ b/layouts/_partials/navbar.html
@@ -2,7 +2,6 @@
 
   A copy of the navbar.html partial in Docsy, modified to:
 
-  * remove `data-bs-theme` at L20, otherwise the title disappears on hover.
   * replace the site title with "specification" at L31.
   * include the spec version from the config at L34-35, which is calculated
     using an inline `version-string` partial.
@@ -16,7 +15,8 @@
 {{ $baseURL := urls.Parse $.Site.Params.Baseurl -}}
 
 <nav class="td-navbar js-navbar-scroll
-            {{- if $cover }} td-navbar-cover {{- end }}">
+      {{- if $cover }} td-navbar-cover td-navbar-transparent {{- end }}"
+      {{- if eq (.Param "ui.navbar_theme") "dark" }} data-bs-theme="dark" {{- end }}>
 <div class="td-navbar-container container-fluid flex-column flex-md-row">
   <a class="navbar-brand" href="{{ .Site.Home.RelPermalink }}">
     {{- /**/ -}}
@@ -35,7 +35,7 @@
 	  <span class="navbar-version"> &mdash; {{ partial "version-string" . }}</span>
     {{- /**/ -}}
   </a>
-  <div class="td-navbar-nav-scroll td-navbar-nav-scroll--indicator" id="main_navbar">
+  <div class="td-navbar__main td-navbar-nav-scroll td-navbar-nav-scroll--indicator" id="main_navbar">
     <div class="scroll-indicator scroll-left"></div>
     <ul class="navbar-nav">
       {{ $p := . -}}
@@ -80,7 +80,7 @@
     </ul>
     <div class="scroll-indicator scroll-right"></div>
   </div>
-  <div class="d-none d-lg-block td-navbar__search">
+  <div class="td-navbar__search d-none d-lg-block">
     {{ partial "search-input.html" . }}
   </div>
 </div>

--- a/layouts/_partials/sidebar-tree.html
+++ b/layouts/_partials/sidebar-tree.html
@@ -14,6 +14,7 @@
 {{ $cacheSidebar := .cacheSidebar -}}
 
 {{ with $context -}}
+
 {{/* When the sidebar is cached, "active" class is set client side. */ -}}
 {{ $shouldDelayActive := $cacheSidebar -}}
 
@@ -174,7 +175,7 @@
       {{- end -}}
       <span class="
         {{- if $active }}td-sidebar-nav-active-item{{ end -}}
-        {{- if and $s.Params.sidebar_root_for site.Params.ui.sidebar_root_enabled }} td-sidebar-root-up-icon{{ end -}}
+        {{- if and $treeRoot $s.Params.sidebar_root_for site.Params.ui.sidebar_root_enabled }} td-sidebar-root-up-icon{{ end -}}
       ">
         {{- $s.LinkTitle -}}
       </span></a>
@@ -190,4 +191,4 @@
     </ul>
     {{- end }}
   </li>
-{{- end }}
+{{- end -}}


### PR DESCRIPTION
~~Requires https://github.com/matrix-org/docsy/pull/8.~~

I didn't notice any visual change after the upgrade.

The minimum required hugo version bump is a requirement from upstream: https://www.docsy.dev/blog/2026/0.14.0/#hugo.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)








<!-- Replace -->
Preview: https://pr2346--matrix-spec-previews.netlify.app
<!-- Replace -->
