### PR TITLE
Define where to find `via` for following tombstone/predecessor

### DIFF
--- a/changelogs/client_server/newsfragments/2352.clarification
+++ b/changelogs/client_server/newsfragments/2352.clarification
@@ -1,0 +1,1 @@
+Clarify how to find `via` parameter when following room upgrades.

--- a/content/client-server-api/modules/room_upgrades.md
+++ b/content/client-server-api/modules/room_upgrades.md
@@ -20,6 +20,10 @@ old room. Another approach may be to virtually merge the rooms such that
 the old room's timeline seamlessly continues into the new timeline
 without the user having to jump between the rooms.
 
+When joining a room using the room ID in an `m.room.tombstone` event or
+`predecessor` field on `m.room.create`, clients SHOULD parse the event
+sender and use the resulting server name as a `via` parameter.
+
 {{% http-api spec="client-server" api="room_upgrades" %}}
 
 #### Server behaviour

--- a/content/client-server-api/modules/room_upgrades.md
+++ b/content/client-server-api/modules/room_upgrades.md
@@ -22,7 +22,7 @@ without the user having to jump between the rooms.
 
 When joining a room using the room ID in an `m.room.tombstone` event or
 `predecessor` field on `m.room.create`, clients SHOULD parse the event
-sender and use the resulting server name as a `via` parameter.
+`sender` and use the resulting server name as a `via` parameter.
 
 {{% http-api spec="client-server" api="room_upgrades" %}}
 


### PR DESCRIPTION
### Pull Request Checklist

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)


<!-- Replace -->
Preview: https://pr2352--matrix-spec-previews.netlify.app
<!-- Replace -->
