### PR TITLE
Add changelog directory for olm & megolm spec

### DIFF
--- a/changelogs/internal/newsfragments/2364.clarification
+++ b/changelogs/internal/newsfragments/2364.clarification
@@ -1,0 +1,1 @@
+Configure a new changelog section for the Olm & Megolm specs.

--- a/changelogs/olm_megolm/newsfragments/.gitignore
+++ b/changelogs/olm_megolm/newsfragments/.gitignore
@@ -1,0 +1,1 @@
+!.gitignore

--- a/changelogs/pyproject.toml
+++ b/changelogs/pyproject.toml
@@ -56,6 +56,10 @@
     [[tool.towncrier.section]]
         name = "Room Versions"
         path = "room_versions"
+
+    [[tool.towncrier.section]]
+        name = "Olm & Megolm"
+        path = "olm_megolm"
     
     [[tool.towncrier.section]]
         name = "Appendices"


### PR DESCRIPTION
It was noted in https://github.com/matrix-org/matrix-spec/pull/2361 that such a directory did not yet exist.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)

Signed-off-by: Andrew Morgan andrewm@element.io




<!-- Replace -->
Preview: https://pr2364--matrix-spec-previews.netlify.app
<!-- Replace -->
