### PR TITLE
Clarify allowed characters in `mxc://` URIs

### DIFF
--- a/changelogs/client_server/newsfragments/2377.clarification
+++ b/changelogs/client_server/newsfragments/2377.clarification
@@ -1,0 +1,1 @@
+Clarify allowed characters in `mxc://` URIs.

--- a/content/client-server-api/modules/content_repo.md
+++ b/content/client-server-api/modules/content_repo.md
@@ -40,6 +40,10 @@ mxc://<server-name>/<media-id>
 <media-id> : An opaque ID which identifies the content.
 ```
 
+The `media-id` segment MUST consist of only alphanumeric (`A-Za-z0-9`), `_` and
+`-` characters. See the [security considerations](#content-repo-security-considerations)
+section below for more details.
+
 #### Client behaviour {id="content-repo-client-behaviour"}
 
 Clients can access the content repository using the following endpoints.
@@ -125,7 +129,7 @@ Servers MUST NOT upscale thumbnails under any circumstance. Servers MUST
 NOT return a smaller thumbnail than requested, unless the original
 content makes that impossible.
 
-#### Security considerations
+#### Security considerations {id="content-repo-security-considerations"}
 
 The HTTP GET endpoint does not require any authentication. Knowing the
 URL of the content is sufficient to retrieve the content, even if the


### PR DESCRIPTION
The security considerations section already has this MUST, but people often don't look that far. There are already both clients and servers that enforce this requirement (e.g. anything based on ruma)

### Pull Request Checklist

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)


<!-- Replace -->
Preview: https://pr2377--matrix-spec-previews.netlify.app
<!-- Replace -->
