### PR TITLE
disambiguate placeholder descriptions in OlmPayload example

### DIFF
--- a/changelogs/client_server/newsfragments/2382.clarification
+++ b/changelogs/client_server/newsfragments/2382.clarification
@@ -1,0 +1,1 @@
+Disambiguate placeholder descriptions in OlmPayload example.

--- a/data/api/client-server/definitions/olm_payload.yaml
+++ b/data/api/client-server/definitions/olm_payload.yaml
@@ -65,15 +65,15 @@ example: {
   "sender": "<sender_user_id>",
   "recipient": "<recipient_user_id>",
   "recipient_keys": {
-    "ed25519": "<our_ed25519_key>"
+    "ed25519": "<recipient_ed25519_key>"
   },
   "keys": {
     "ed25519": "<sender_ed25519_key>"
   },
   "sender_device_keys": {
     "algorithms": ["<supported>", "<algorithms>"],
-    "user_id": "<user_id>",
-    "device_id": "<device_id>",
+    "user_id": "<sender_user_id>",
+    "device_id": "<sender_device_id>",
     "keys": {
       "ed25519:<device_id>": "<sender_ed25519_key>",
       "curve25519:<device_id>": "<sender_curve25519_key>"


### PR DESCRIPTION
### Pull Request Checklist

Some of the current placeholder descriptions in the `OlmPayload` example do not include `sender` or `recipient`  like others do, which helps to disambiguate what they are supposed to be.

Signed-off-by: Johanna Stuber <johannas@element.io>

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)





<!-- Replace -->
Preview: https://pr2382--matrix-spec-previews.netlify.app
<!-- Replace -->
