### PR TITLE
replace "Olm message" where not referring to the Olm message format

### DIFF
--- a/changelogs/client_server/newsfragments/2383.clarification
+++ b/changelogs/client_server/newsfragments/2383.clarification
@@ -1,0 +1,1 @@
+Replace "Olm message" with "event encrypted using Olm" where not referring to the Olm message format.

--- a/content/client-server-api/modules/end_to_end_encryption.md
+++ b/content/client-server-api/modules/end_to_end_encryption.md
@@ -1698,7 +1698,7 @@ Curve25519 key used to establish the Olm session does indeed belong
 to the claimed `sender`. This requires a signed "device keys" structure
 for that Curve25519 key, which can be obtained in one of two ways:
 
-1.  An Olm message may be received with a `sender_device_keys` property
+1.  An event encrypted using Olm may be received with a `sender_device_keys` property
     in the decrypted content.
 2.  The keys are returned via a [`/keys/query`](#post_matrixclientv3keysquery)
     request. Note that both the Curve25519 key **and** the Ed25519 key in

--- a/data/api/client-server/definitions/olm_payload.yaml
+++ b/data/api/client-server/definitions/olm_payload.yaml
@@ -16,7 +16,7 @@
 type: object
 title: OlmPayload
 description: |-
-  The plaintext payload of Olm message events.
+  The plaintext payload of an event encrypted using Olm.
 properties:
   type:
     type: string


### PR DESCRIPTION
### Pull Request Checklist
The term "Olm message" is used in the Olm specification, referring to the specific byte-encoded message format.
The term is also used in the Client-Server spec, but "event encrypted using Olm" (a wording also already used there) seems like a better fit in those places to avoid confusion.

Signed-off-by: Johanna Stuber <johannas@element.io>

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)





<!-- Replace -->
Preview: https://pr2383--matrix-spec-previews.netlify.app
<!-- Replace -->
