### PR TITLE
Remind servers that they shouldn't overwrite signatures with those from a policy server

### DIFF
--- a/changelogs/server_server/newsfragments/2385.clarification
+++ b/changelogs/server_server/newsfragments/2385.clarification
@@ -1,0 +1,1 @@
+Clarify that policy servers might share a name with event origins, and that servers should avoid overwriting/discarding signatures for the event origin when getting a policy server signature.

--- a/data/api/server-server/room_policy.yaml
+++ b/data/api/server-server/room_policy.yaml
@@ -41,6 +41,12 @@ paths:
 
         What the Policy Server checks for when calling this endpoint is left as an
         implementation detail.
+
+        {{% boxes/warning %}}
+        The policy server name might be the same as the event's origin, and therefore the event might
+        have existing signatures. Those existing signatures might not be returned by the policy server,
+        but should be retained to validate the event.
+        {{% /boxes/warning %}}
       operationId: askPolicyServerToSign
       security:
         - signedRequest: []


### PR DESCRIPTION
To maybe help avoid it happening a 5th time. https://github.com/element-hq/synapse/pull/19797


### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [ ] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)


<!-- Replace -->
Preview: https://pr2385--matrix-spec-previews.netlify.app
<!-- Replace -->
