### PR TITLE
Update link from whispersystems to signal.org

### DIFF
--- a/changelogs/olm_megolm/newsfragments/2387.clarification
+++ b/changelogs/olm_megolm/newsfragments/2387.clarification
@@ -1,0 +1,1 @@
+Update link from whispersystems.org to signal.org in the olm documentation

--- a/content/olm-megolm/olm.md
+++ b/content/olm-megolm/olm.md
@@ -5,7 +5,7 @@ type: docs
 ---
 
 An implementation of the double cryptographic ratchet described by
-https://whispersystems.org/docs/specifications/doubleratchet/.
+https://signal.org/docs/specifications/doubleratchet/.
 
 ## Notation
 

--- a/content/olm-megolm/olm.md
+++ b/content/olm-megolm/olm.md
@@ -320,11 +320,11 @@ Can be sent to olm at matrix.org.
 ## Acknowledgements
 
 The ratchet that Olm implements was designed by Trevor Perrin and Moxie
-Marlinspike - details at https://whispersystems.org/docs/specifications/doubleratchet/. Olm is
+Marlinspike - details at https://signal.org/docs/specifications/doubleratchet/. Olm is
 an entirely new implementation written by the Matrix.org team.
 
 [Curve25519]: http://cr.yp.to/ecdh.html
-[Triple Diffie-Hellman]: https://whispersystems.org/blog/simplifying-otr-deniability/
+[Triple Diffie-Hellman]: https://signal.org/blog/simplifying-otr-deniability/
 [HMAC-based key derivation function]: https://tools.ietf.org/html/rfc5869
 [HKDF-SHA-256]: https://tools.ietf.org/html/rfc5869
 [HMAC-SHA-256]: https://tools.ietf.org/html/rfc2104


### PR DESCRIPTION
This pull request makes a minor documentation update to the `content/olm-megolm/olm.md` file, correcting a URL to point to the current location of the double ratchet specification (`whispersystems.org` -> `signal.org`). 

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)


<!-- Replace -->
Preview: https://pr2387--matrix-spec-previews.netlify.app
<!-- Replace -->
