### PR TITLE
Clarify matrix.to RFC 3986 percent encoding requirements

### DIFF
--- a/changelogs/appendices/newsfragments/2395.clarification
+++ b/changelogs/appendices/newsfragments/2395.clarification
@@ -1,0 +1,1 @@
+Clarify matrix.to RFC 3986 percent encoding requirements. Contributed by @HarHarLinks.

--- a/content/appendices.md
+++ b/content/appendices.md
@@ -894,14 +894,22 @@ room alias, the client may open a view for the user to participate in
 the room.
 
 The components of the matrix.to URI (`<identifier>` and
-`<extra parameter>`) are to be percent-encoded as per RFC 3986.
+`<extra parameter>`) MUST be percent-encoded as per RFC 3986.
 
 Examples of matrix.to URIs are:
 
 <!-- Author's note: These examples should be consistent with the matrix scheme counterparts. -->
+* Link to `#somewhere:example.org`: `https://matrix.to/#/%23somewhere:example.org`
+* Link to `!somewhere:example.org`: `https://matrix.to/#/!somewhere:example.org?via=elsewhere.ca`
+* Link to `$event` in `!somewhere:example.org`: `https://matrix.to/#/!somewhere:example.org/$event:example.org?via=elsewhere.ca`
+* Link to `@alice:example.org`: `https://matrix.to/#/@alice:example.org`
+
+Note that encoding of characters is REQUIRED by RFC 3986 when they could otherwise be misinterpreted, and OPTIONAL for any other character.
+Hence the following encoding is also valid:
+
 * Link to `#somewhere:example.org`: `https://matrix.to/#/%23somewhere%3Aexample.org`
-* Link to `!somewhere:example.org`: `https://matrix.to/#/!somewhere%3Aexample.org?via=elsewhere.ca`
-* Link to `$event` in `!somewhere:example.org`: `https://matrix.to/#/!somewhere%3Aexample.org/%24event%3Aexample.org?via=elsewhere.ca`
+* Link to `!somewhere:example.org`: `https://matrix.to/#/%21somewhere%3Aexample.org?via=elsewhere.ca`
+* Link to `$event` in `!somewhere:example.org`: `https://matrix.to/#/%21somewhere%3Aexample.org/%24event%3Aexample.org?via=elsewhere.ca`
 * Link to `@alice:example.org`: `https://matrix.to/#/%40alice%3Aexample.org`
 
 {{% boxes/note %}}


### PR DESCRIPTION
The matrix.to URL components take the place of a URI [fragment](https://www.rfc-editor.org/info/rfc3986/#section-3.5).

```
fragment    = *( pchar / "/" / "?" )
```

where [`pchar`](https://www.rfc-editor.org/info/rfc3986/#section-3.3) resolves to 

```
pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
```

where [`unreserved`](https://www.rfc-editor.org/info/rfc3986/#section-2.3) resolves to

```
unreserved  = ALPHA / DIGIT / "-" / "." / "_" / "~"
```

and [`sub-delims`](https://www.rfc-editor.org/info/rfc3986/#section-2.2) to

```
sub-delims  = "!" / "$" / "&" / "'" / "(" / ")"
                  / "*" / "+" / "," / ";" / "="
```

for a complete definition of

```
pchar         = ALPHA / DIGIT / "-" / "." / "_" / "~" / pct-encoded / "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "=" / ":" / "@"
```

Notably, out of the Matrix sigils `#!$@`, historical sigil `+`, and server name delimiter `:`, only `#` is in the set of characters REQUIRED to encode.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)





<!-- Replace -->
Preview: https://pr2395--matrix-spec-previews.netlify.app
<!-- Replace -->
