### PR TITLE
Add zecakeh as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @matrix-org/spec-core-team
+*       @matrix-org/spec-core-team @zecakeh

--- a/changelogs/internal/newsfragments/2400.clarification
+++ b/changelogs/internal/newsfragments/2400.clarification
@@ -1,0 +1,1 @@
+Update CODEOWNERS file.


### PR DESCRIPTION
Now that @zecakeh has write access to matrix-spec, they should be able to
approve PRs for merging. Currently this isn't working, because they aren't
listed in the CODEOWNERS file.

<!-- Replace -->
Preview: https://pr2400--matrix-spec-previews.netlify.app
<!-- Replace -->
