### PR TITLE
Add links to url-safe unpadded base64

### DIFF
--- a/changelogs/identity_service/newsfragments/2401.clarification
+++ b/changelogs/identity_service/newsfragments/2401.clarification
@@ -1,0 +1,1 @@
+Fix various typos throughout the specification.

--- a/changelogs/room_versions/newsfragments/2401.clarification
+++ b/changelogs/room_versions/newsfragments/2401.clarification
@@ -1,0 +1,1 @@
+Fix various typos throughout the specification.

--- a/content/identity-service-api.md
+++ b/content/identity-service-api.md
@@ -276,9 +276,8 @@ internal state of the hash function.
 
 After formatting each query, the string is run through SHA-256 as
 defined by [RFC 4634](https://tools.ietf.org/html/rfc4634). The
-resulting bytes are then encoded using URL-Safe [Unpadded
-Base64](/appendices#unpadded-base64) (similar to [room version
-4's event ID format](/rooms/v4#event-ids)).
+resulting bytes are then encoded using [URL-Safe unpadded
+Base64](/appendices/#url-safe-unpadded-base64).
 
 An example set of queries when using the pepper `matrixrocks` would be:
 

--- a/content/rooms/fragments/v4-event-ids.md
+++ b/content/rooms/fragments/v4-event-ids.md
@@ -2,11 +2,8 @@
 ---
 {{% added-in v=4 %}} The event ID is the [reference
 hash](/server-server-api#calculating-the-reference-hash-for-an-event) of
-the event encoded using a variation of [Unpadded
-Base64](/appendices#unpadded-base64) which replaces the 62nd and
-63rd characters with `-` and `_` instead of using `+` and `/`. This
-matches [RFC4648's definition of URL-safe
-base64](https://tools.ietf.org/html/rfc4648#section-5).
+the event encoded using [URL-safe unpadded
+Base64](/appendices/#url-safe-unpadded-base64).
 
 Event IDs are still prefixed with `$` and might result in looking like
 `$Rqnc-F-dvnEYJTyHq_iKxU2bZ1CI92-kuZq3a5lr5Zg`.

--- a/data/api/identity/v2_store_invite.yaml
+++ b/data/api/identity/v2_store_invite.yaml
@@ -156,7 +156,7 @@ paths:
                         public_key:
                           type: string
                           description: |
-                            The public key, encoded using standard or URL-safe [unpadded Base64](/appendices/#unpadded-base64).
+                            The public key, encoded using [standard unpadded Base64](/appendices/#unpadded-base64) or [URL-safe unpadded Base64](/appendices/#url-safe-unpadded-base64).
                         key_validity_url:
                           type: string
                           description: |


### PR DESCRIPTION
Now that we have an appendix section describing url-safe unpadded base64, let's link to
it rather than describing it in multiple places.

<!-- Replace -->
Preview: https://pr2401--matrix-spec-previews.netlify.app
<!-- Replace -->
