### PR TITLE
Clarify string format of `replaces_state`

### DIFF
--- a/changelogs/client_server/newsfragments/2403.feature
+++ b/changelogs/client_server/newsfragments/2403.feature
@@ -1,0 +1,1 @@
+Specify `unsigned.replaces_state` in client-formatted events. Contributed by @nexy7574.

--- a/data/api/client-server/definitions/client_event_without_room_id.yaml
+++ b/data/api/client-server/definitions/client_event_without_room_id.yaml
@@ -124,6 +124,8 @@ properties:
           by the local homeserver, and is only returned if the event is a state event.
           Unlike `prev_content`, this field is included regardless of history visibility.
         type: string
+        format: mx-event-id
+        pattern: "^\\$"
         x-addedInMatrixVersion: "1.19"
       membership:
         description: |


### PR DESCRIPTION
This clarifies the string format of the field added in #2345.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)





<!-- Replace -->
Preview: https://pr2403--matrix-spec-previews.netlify.app
<!-- Replace -->
