### PR TITLE
Add further normative language in mutual rooms server behaviour

### DIFF
--- a/changelogs/client_server/newsfragments/2407.clarification
+++ b/changelogs/client_server/newsfragments/2407.clarification
@@ -1,0 +1,1 @@
+Add further normative language in mutual rooms server behaviour.

--- a/content/client-server-api/modules/mutual_rooms.md
+++ b/content/client-server-api/modules/mutual_rooms.md
@@ -7,7 +7,7 @@
 #### Server behaviour
 
 The server MAY decide that the response to this endpoint is too large, and only return a
-subset of the results. In this case, the server MUST populate the optional field `next_batch`
+subset of the results. In this case, the server populates the optional field `next_batch`
 with an [opaque identifier](/appendices/#opaque-identifiers). The client can then supply
 the identifier as the `from` query parameter in a subsequent request, along with the original
 `user_id`, to fetch the next batch of responses. This will continue until the server no longer

--- a/content/client-server-api/modules/mutual_rooms.md
+++ b/content/client-server-api/modules/mutual_rooms.md
@@ -6,9 +6,9 @@
 
 #### Server behaviour
 
-The server may decide that the response to this endpoint is too large, and only return a
-subset of the results. In this case, the server should populate the optional field `next_batch`
-with an [opaque identifier](/appendices/#opaque-identifiers). The client may then supply
+The server MAY decide that the response to this endpoint is too large, and only return a
+subset of the results. In this case, the server MUST populate the optional field `next_batch`
+with an [opaque identifier](/appendices/#opaque-identifiers). The client can then supply
 the identifier as the `from` query parameter in a subsequent request, along with the original
 `user_id`, to fetch the next batch of responses. This will continue until the server no longer
 inserts `next_batch`, meaning there are no further results.


### PR DESCRIPTION
This adds further RFC2119 language to the server behaviour section of the mutual rooms endpoint. The "should" in the current wording struck me as ambiguous.

Either it is a requirement to include the pagination token, then we should use "MUST". Or it is recommended but not required (meaning the server can just truncate). Then we should use "SHOULD".

I assume we want a MUST but https://github.com/matrix-org/matrix-spec-proposals/pull/2666 doesn't seem to make this explicit (maybe @Half-Shot could clarify the intention as the author).

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)








<!-- Replace -->
Preview: https://pr2407--matrix-spec-previews.netlify.app
<!-- Replace -->
