### PR TITLE
Clarify historical key sharing

### DIFF
--- a/changelogs/client_server/newsfragments/2410.clarification
+++ b/changelogs/client_server/newsfragments/2410.clarification
@@ -1,0 +1,1 @@
+Clarify history key sharing requirements. Contributed by @HarHarLinks and Matrix Stammtisch Aachen.

--- a/content/client-server-api/modules/end_to_end_encryption.md
+++ b/content/client-server-api/modules/end_to_end_encryption.md
@@ -1551,7 +1551,7 @@ objects described as follows:
 
 {{% added-in v="1.19" %}}
 
-When Alice invites Bob to an encrypted room, she might want Bob to have access
+When Alice invites Bob to an encrypted room, she likely wants Bob to have access
 to messages that were previously sent in that room, subject to the [history
 visibility](#room-history-visibility) setting of the room.
 

--- a/content/client-server-api/modules/end_to_end_encryption.md
+++ b/content/client-server-api/modules/end_to_end_encryption.md
@@ -1551,9 +1551,12 @@ objects described as follows:
 
 {{% added-in v="1.19" %}}
 
-When Alice invites Bob to an encrypted room, she might want Bob to have access
-to messages that were previously sent in that room, subject to the [history
-visibility](#room-history-visibility) setting of the room.
+When Alice invites Bob to an encrypted room, that room might be set up for
+Bob to have access to messages that were previously sent in that room,
+subject to the [history visibility](#room-history-visibility) setting of the room.
+Because the key material is not available on the server,
+Alice MUST share the decryption keys of messages visible according to
+the history visibility setting so Bob can read the message history.
 
 Alice does this by constructing an [encrypted key
 bundle](#construction-and-sharing-of-the-key-bundle) and sharing it with Bob

--- a/content/client-server-api/modules/end_to_end_encryption.md
+++ b/content/client-server-api/modules/end_to_end_encryption.md
@@ -1623,9 +1623,8 @@ In such cases where the current history visibility setting does not allow sharin
 MAY choose not to share *any* room history, even messages sent when the
 history visibility setting would allow sharing.
 
-In all other cases, Alice's client SHOULD share all available shareable keys.
-
-Before inviting Bob to a room, Alice's client constructs and sends a key bundle as follows:
+In all other cases, before inviting Bob to a room, Alice's client SHOULD share all available shareable keys.
+It does this by constructing and sending a key bundle as follows:
 
 1. Alice's client SHOULD ensure that it has downloaded all keys relevant to the room
    from [server-side key backup](#server-side-key-backups), if she is using it.

--- a/content/client-server-api/modules/end_to_end_encryption.md
+++ b/content/client-server-api/modules/end_to_end_encryption.md
@@ -1614,12 +1614,12 @@ Marking keys as [shareable](#shareable-encryption-sessions) essentially serves a
 precomputation of which keys Bob needs to decrypt all messages he can see, as
 defined by the room's history visibility.
 
-History visibility mechanics prevent changing the visibility of events in
-hindsight. It is thus possible for a room timeline to have "gappy" visibility,
-i.e. events sent during `shared` visibility in the past are visible, but events
-more recently sent during `joined` visibility and before joining are not visible.
+History visibility mechanics prevent changing the visibility of events
+retrospectively. It is thus possible for a room timeline to have "gappy" visibility.
+For example, events sent in the past during `shared` visibility are visible to new
+members, even though events sent more recently (during `joined` visibility) are not visible.
 In such cases where the current history visibility setting does not allow sharing
-(i.e. if `history_visibility` is set to `invited` or `joined`), Alice's client
+(i.e. if `history_visibility` is set to `invited` or `joined`), client implementations
 MAY choose not to share *any* room history, even messages sent when the
 history visibility setting would allow sharing.
 

--- a/content/client-server-api/modules/end_to_end_encryption.md
+++ b/content/client-server-api/modules/end_to_end_encryption.md
@@ -1623,7 +1623,7 @@ In such cases where the current history visibility setting does not allow sharin
 MAY choose not to share *any* room history, even messages sent when the
 history visibility setting would allow sharing.
 
-In all other cases, Alice's client MUST share all available shareable keys.
+In all other cases, Alice's client SHOULD share all available shareable keys.
 
 Before inviting Bob to a room, Alice's client constructs and sends a key bundle as follows:
 

--- a/content/client-server-api/modules/end_to_end_encryption.md
+++ b/content/client-server-api/modules/end_to_end_encryption.md
@@ -1551,12 +1551,9 @@ objects described as follows:
 
 {{% added-in v="1.19" %}}
 
-When Alice invites Bob to an encrypted room, that room might be set up for
-Bob to have access to messages that were previously sent in that room,
-subject to the [history visibility](#room-history-visibility) setting of the room.
-Because the key material is not available on the server,
-Alice MUST share the decryption keys of messages visible according to
-the history visibility setting so Bob can read the message history.
+When Alice invites Bob to an encrypted room, she might want Bob to have access
+to messages that were previously sent in that room, subject to the [history
+visibility](#room-history-visibility) setting of the room.
 
 Alice does this by constructing an [encrypted key
 bundle](#construction-and-sharing-of-the-key-bundle) and sharing it with Bob
@@ -1613,12 +1610,22 @@ room.
 
 ##### Construction and sharing of the key bundle
 
-Alice's client MAY choose not to share any room history (even messages sent when the
-history visibility setting would allow sharing) if the current history
-visibility setting does not allow sharing (i.e. if `history_visibility` is
-set to `invited` or `joined`).
+Marking keys as [shareable](#shareable-encryption-sessions) essentially serves as
+precomputation of which keys Bob needs to decrypt all messages he can see, as
+defined by the room's history visibility.
 
-Otherwise, before inviting Bob to a room, Alice's client constructs and sends a key bundle as follows:
+History visibility mechanics prevent changing the visibility of events in
+hindsight. It is thus possible for a room timeline to have "gappy" visibility,
+i.e. events sent during `shared` visibility in the past are visible, but events
+more recently sent during `joined` visibility and before joining are not visible.
+In such cases where the current history visibility setting does not allow sharing
+(i.e. if `history_visibility` is set to `invited` or `joined`), Alice's client
+MAY choose not to share *any* room history, even messages sent when the
+history visibility setting would allow sharing.
+
+In all other cases, Alice's client MUST share all available shareable keys.
+
+Before inviting Bob to a room, Alice's client constructs and sends a key bundle as follows:
 
 1. Alice's client SHOULD ensure that it has downloaded all keys relevant to the room
    from [server-side key backup](#server-side-key-backups), if she is using it.

--- a/content/client-server-api/modules/end_to_end_encryption.md
+++ b/content/client-server-api/modules/end_to_end_encryption.md
@@ -1614,7 +1614,7 @@ room.
 ##### Construction and sharing of the key bundle
 
 Alice's client MAY choose not to share any room history (even messages sent when the
-history visibity setting would allow sharing) if the current history
+history visibility setting would allow sharing) if the current history
 visibility setting does not allow sharing (i.e. if `history_visibility` is
 set to `invited` or `joined`).
 

--- a/data/event-schemas/schema/components/room_key_withheld_content.yaml
+++ b/data/event-schemas/schema/components/room_key_withheld_content.yaml
@@ -33,7 +33,9 @@ properties:
       - m.no_olm
       - m.history_not_shared
     description: |-
-      A machine-readable code for why the key was not sent. Codes beginning
+      A machine-readable code for why the key was not sent, as defined by
+      [Reporting that decryption keys are withheld](#reporting-that-decryption-keys-are-withheld).
+      Codes beginning
       with `m.` are reserved for codes defined in the Matrix
       specification. Custom codes must use the Java package naming
       convention.


### PR DESCRIPTION
See https://github.com/matrix-org/matrix-spec/pull/2399/files#r3560365639

We understand there is an introductory paragraph to the use case, but we think it is setting the rest of the section up for confusion given
- that there is no clear requirement level for historical key sharing in general stated (only different aspects about how to create the key bundles etc)
- how fuzzy the spec is in general towards proper RFC 2119 usage.

Our reading of the spec is that for some reason there is an exemption for rooms that are currently not using shareable history, but by default ("otherwise") shareable keys hence may not not [sic!] be shared, i.e. MUST be shared. We think stating that outright clarifies this requirement a lot.

Further the way the exemption was defined was hard to grasp for a group of us, hence an attempt of a slightly more verbose approach.

Finally the error codes for withholding keys were missing a reference to when to choose which one.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)













<!-- Replace -->
Preview: https://pr2410--matrix-spec-previews.netlify.app
<!-- Replace -->
