### PR TITLE
Spec for MSC3784: Using room type of m.policy for policy rooms

### DIFF
--- a/changelogs/client_server/newsfragments/2411.feature
+++ b/changelogs/client_server/newsfragments/2411.feature
@@ -1,0 +1,1 @@
+Introduce room type `m.policy` to indicate rooms likely to contain policy lists.

--- a/changelogs/client_server/newsfragments/2411.feature
+++ b/changelogs/client_server/newsfragments/2411.feature
@@ -1,2 +1,1 @@
-Introduce room type `m.policy` to indicate rooms likely to contain policy lists, as per
-[MSC3784](https://github.com/matrix-org/matrix-spec-proposals/pull/3784).
+Introduce room type `m.policy` to indicate rooms likely to contain policy lists, as per [MSC3784](https://github.com/matrix-org/matrix-spec-proposals/pull/3784).

--- a/changelogs/client_server/newsfragments/2411.feature
+++ b/changelogs/client_server/newsfragments/2411.feature
@@ -1,1 +1,2 @@
-Introduce room type `m.policy` to indicate rooms likely to contain policy lists.
+Introduce room type `m.policy` to indicate rooms likely to contain policy lists, as per
+[MSC3784](https://github.com/matrix-org/matrix-spec-proposals/pull/3784).

--- a/content/client-server-api/_index.md
+++ b/content/client-server-api/_index.md
@@ -3818,6 +3818,7 @@ the create room request.
 In this specification the following room types are specified:
 
 * [`m.space`](#spaces)
+* [`m.policy`](#moderation-policy-lists)
 
 Unspecified room types are permitted through the use of
 [Namespaced Identifiers](/appendices/#common-namespaced-identifier-grammar).

--- a/content/client-server-api/_index.md
+++ b/content/client-server-api/_index.md
@@ -3818,7 +3818,7 @@ the create room request.
 In this specification the following room types are specified:
 
 * [`m.space`](#spaces)
-* [`m.policy`](#moderation-policy-lists)
+* [`m.policy`](#moderation-policy-lists) {{% added-in v="1.20" %}}
 
 Unspecified room types are permitted through the use of
 [Namespaced Identifiers](/appendices/#common-namespaced-identifier-grammar).

--- a/content/client-server-api/modules/moderation_policies.md
+++ b/content/client-server-api/modules/moderation_policies.md
@@ -22,6 +22,10 @@ restrictions on how the rooms can be configured in terms of
 [join rules](#mroomjoin_rules), [history visibility](#room-history-visibility),
 encryption, etc.
 
+A moderation policy list may be designated by the [`m.policy` room type](#types),
+however, policy events may still be sent in rooms without this room type. Sending
+messages in rooms with the `m.policy` room type is discouraged, but not forbidden.
+
 There are currently 3 kinds of entities which can be affected by rules:
 `user`, `server`, and `room`. All 3 are described with
 `m.policy.rule.<kind>` state events. The `state_key` for a policy rule

--- a/content/client-server-api/modules/moderation_policies.md
+++ b/content/client-server-api/modules/moderation_policies.md
@@ -22,9 +22,15 @@ restrictions on how the rooms can be configured in terms of
 [join rules](#mroomjoin_rules), [history visibility](#room-history-visibility),
 encryption, etc.
 
-A moderation policy list may be designated by the [`m.policy` room type](#types),
-however, policy events may still be sent in rooms without this room type. Sending
-messages in rooms with the `m.policy` room type is discouraged, but not forbidden.
+Dedicated moderation policy rooms SHOULD use the [`m.policy` room type](#types).
+However, use of the room type is not required. Policy events MAY be sent in any
+room.
+
+Like [spaces](#spaces), sending normal [`m.room.message`](#mroommessage) events
+within a policy room is discouraged. Policy rooms should be created with
+[`m.room.power_levels`](#mroompower_levels) which prohibit normal events by
+setting `events_default` to a suitably high number. In the default power level
+structure, this would be `100`.
 
 There are currently 3 kinds of entities which can be affected by rules:
 `user`, `server`, and `room`. All 3 are described with

--- a/content/client-server-api/modules/moderation_policies.md
+++ b/content/client-server-api/modules/moderation_policies.md
@@ -22,6 +22,7 @@ restrictions on how the rooms can be configured in terms of
 [join rules](#mroomjoin_rules), [history visibility](#room-history-visibility),
 encryption, etc.
 
+{{% added-in v="1.20" %}}
 Dedicated moderation policy rooms SHOULD use the [`m.policy` room type](#types).
 However, use of the room type is not required. Policy events MAY be sent in any
 room.


### PR DESCRIPTION
### Pull Request Checklist

[MSC3784](https://github.com/matrix-org/matrix-spec-proposals/pull/3784) ([rendered](https://github.com/FSG-Cat/matrix-spec-proposals/blob/FSG-Cat-Policy-List-Room-Type/proposals/3784-using-room-type-of-m.policy-for-policy-rooms.md))

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [ ] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)











<!-- Replace -->
Preview: https://pr2411--matrix-spec-previews.netlify.app
<!-- Replace -->
