### PR TITLE
improve event format description of m.room.encrypted events

### DIFF
--- a/changelogs/client_server/newsfragments/2413.clarification
+++ b/changelogs/client_server/newsfragments/2413.clarification
@@ -1,0 +1,1 @@
+Improve the format description of `m.room.encrypted` (Olm/Megolm) events.

--- a/content/client-server-api/modules/end_to_end_encryption.md
+++ b/content/client-server-api/modules/end_to_end_encryption.md
@@ -1742,11 +1742,11 @@ The content of an event encrypted using Olm has the following format:
 Note that when the event is received from the server, it will have a `type`
 (with a value of `m.room.encrypted`) and `sender` property alongside the
 `content` property. In `content`, `ciphertext` is a mapping from a device
-Curve25519 key to an object with a `type` and a `body`. Here, `type` is an
-integer indicating the type of the message body:
+Curve25519 key to an object with a `type` and a `body`. Here, `body` is a
+Base64-encoded [Olm message](/olm-megolm/olm/#the-olm-message-format), and
+`type` is an integer indicating the type of the message:
 0 for the initial [pre-key message](/olm-megolm/olm/#pre-key-messages),
-1 for [normal messages](/olm-megolm/olm/#normal-messages);
-`body` is a Base64-encoded [Olm message body](/olm-megolm/olm/#the-olm-message-format).
+1 for [normal messages](/olm-megolm/olm/#normal-messages).
 
 Olm sessions will generate messages with a type of 0 until they receive
 a message. Once a session has decrypted a message it will produce

--- a/content/client-server-api/modules/end_to_end_encryption.md
+++ b/content/client-server-api/modules/end_to_end_encryption.md
@@ -1911,7 +1911,9 @@ The content of an [`m.room.encrypted`](#mroomencrypted) event using Megolm has t
 ```
 Note that when the event is received from the server, it will have additional
 properties alongside the `content` property, including a `type` (with a value
-of `m.room.encrypted`) and a `sender` property. In `content`, `ciphertext`
+of `m.room.encrypted`) and a `sender` property. (See [Room event format](#room-event-format).)
+
+Within `content`, `ciphertext`
 is a Base64-encoded [Megolm message](/olm-megolm/megolm/#message-format),
 whose plaintext body is of the form:
 

--- a/content/client-server-api/modules/end_to_end_encryption.md
+++ b/content/client-server-api/modules/end_to_end_encryption.md
@@ -1745,7 +1745,7 @@ Note that when the event is received from the server, it will have a `type`
 Curve25519 key to an object with a `type` and a `body`. Here, `body` is a
 Base64-encoded [Olm message](/olm-megolm/olm/#the-olm-message-format), and
 `type` is an integer indicating the type of the message:
-0 for the initial [pre-key message](/olm-megolm/olm/#pre-key-messages),
+0 for the initial [pre-key messages](/olm-megolm/olm/#pre-key-messages),
 1 for [normal messages](/olm-megolm/olm/#normal-messages).
 
 Olm sessions will generate messages with a type of 0 until they receive

--- a/content/client-server-api/modules/end_to_end_encryption.md
+++ b/content/client-server-api/modules/end_to_end_encryption.md
@@ -1723,28 +1723,30 @@ Devices that support Olm must include "m.olm.v1.curve25519-aes-sha2" in
 their list of supported messaging algorithms, must list a Curve25519
 device key, and must publish Curve25519 one-time keys.
 
-An event encrypted using Olm has the following format:
+The content of an event encrypted using Olm has the following format:
 
 ```json
 {
-  "type": "m.room.encrypted",
   "content": {
     "algorithm": "m.olm.v1.curve25519-aes-sha2",
     "sender_key": "<sender_curve25519_key>",
     "ciphertext": {
       "<device_curve25519_key>": {
         "type": 0,
-        "body": "<encrypted_payload_base_64>"
+        "body": "<base64_encoded_olm_message>"
       }
     }
   }
 }
 ```
-
-`ciphertext` is a mapping from device Curve25519 key to an encrypted
-payload for that device. `body` is a Base64-encoded [Olm message body](/olm-megolm/olm/#the-olm-message-format).
-`type` is an integer indicating the type of the message body: 0 for the
-initial [pre-key message](/olm-megolm/olm/#pre-key-messages), 1 for [normal messages](/olm-megolm/olm/#normal-messages).
+Note that when the event is received from the server, it will have a `type`
+(with a value of `m.room.encrypted`) and `sender` property alongside the
+`content` property. In `content`, `ciphertext` is a mapping from a device
+Curve25519 key to an object with a `type` and a `body`. Here, `type` is an
+integer indicating the type of the message body:
+0 for the initial [pre-key message](/olm-megolm/olm/#pre-key-messages),
+1 for [normal messages](/olm-megolm/olm/#normal-messages);
+`body` is a Base64-encoded [Olm message body](/olm-megolm/olm/#the-olm-message-format).
 
 Olm sessions will generate messages with a type of 0 until they receive
 a message. Once a session has decrypted a message it will produce
@@ -1894,23 +1896,24 @@ This uses:
 Devices that support Megolm must support Olm, and include
 "m.megolm.v1.aes-sha2" in their list of supported messaging algorithms.
 
-An event encrypted using Megolm has the following format:
+The content of an event encrypted using Megolm has the following format:
 
 ```json
 {
-  "type": "m.room.encrypted",
   "content": {
     "algorithm": "m.megolm.v1.aes-sha2",
     "sender_key": "<sender_curve25519_key>",
     "device_id": "<sender_device_id>",
     "session_id": "<outbound_group_session_id>",
-    "ciphertext": "<encrypted_payload_base_64>"
+    "ciphertext": "<base64_encoded_megolm_message>"
   }
 }
 ```
-
-The encrypted payload can contain any message event. The plaintext is of
-the form:
+Note that when the event is received from the server, it will have additional
+properties alongside the `content` property, including a `type` (with a value
+of `m.room.encrypted`) and a `sender` property. In `content`, `ciphertext`
+is a Base64-encoded [Megolm message body](/olm-megolm/megolm/#message-format),
+whose plaintext body is of the form:
 
 ```json
 {
@@ -1920,7 +1923,7 @@ the form:
 }
 ```
 
-We include the room ID in the payload, because otherwise the homeserver
+We include the room ID in the encrypted message, because otherwise the homeserver
 would be able to change the room a message was sent in.
 
 Clients must guard against replay attacks by keeping track of the

--- a/content/client-server-api/modules/end_to_end_encryption.md
+++ b/content/client-server-api/modules/end_to_end_encryption.md
@@ -1912,7 +1912,7 @@ The content of an event encrypted using Megolm has the following format:
 Note that when the event is received from the server, it will have additional
 properties alongside the `content` property, including a `type` (with a value
 of `m.room.encrypted`) and a `sender` property. In `content`, `ciphertext`
-is a Base64-encoded [Megolm message body](/olm-megolm/megolm/#message-format),
+is a Base64-encoded [Megolm message](/olm-megolm/megolm/#message-format),
 whose plaintext body is of the form:
 
 ```json

--- a/content/client-server-api/modules/end_to_end_encryption.md
+++ b/content/client-server-api/modules/end_to_end_encryption.md
@@ -1723,7 +1723,7 @@ Devices that support Olm must include "m.olm.v1.curve25519-aes-sha2" in
 their list of supported messaging algorithms, must list a Curve25519
 device key, and must publish Curve25519 one-time keys.
 
-The content of an event encrypted using Olm has the following format:
+The content of an [`m.room.encrypted`](#mroomencrypted) event using Olm has the following format:
 
 ```json
 {
@@ -1896,7 +1896,7 @@ This uses:
 Devices that support Megolm must support Olm, and include
 "m.megolm.v1.aes-sha2" in their list of supported messaging algorithms.
 
-The content of an event encrypted using Megolm has the following format:
+The content of an [`m.room.encrypted`](#mroomencrypted) event using Megolm has the following format:
 
 ```json
 {

--- a/content/client-server-api/modules/event_replacements.md
+++ b/content/client-server-api/modules/event_replacements.md
@@ -91,13 +91,13 @@ For example, a replacement for an encrypted event might look like this:
         "sender_key": "<sender_curve25519_key>",
         "device_id": "<sender_device_id>",
         "session_id": "<outbound_group_session_id>",
-        "ciphertext": "<encrypted_payload_base_64>"
+        "ciphertext": "<base64_encoded_megolm_message>"
     }
     // irrelevant fields not shown
 }
 ```
 
-... and, once decrypted, the payload might look like this:
+... and, once decrypted, the event might look like this:
 
 ```json
 {

--- a/content/client-server-api/modules/event_replacements.md
+++ b/content/client-server-api/modules/event_replacements.md
@@ -97,7 +97,7 @@ For example, a replacement for an encrypted event might look like this:
 }
 ```
 
-... and, once decrypted, the event might look like this:
+... and the plaintext body of the Megolm message might look like this:
 
 ```json
 {


### PR DESCRIPTION
The current description for the format of the content of `m.room.encrypted` Olm/Megolm events (see https://spec.matrix.org/v1.19/client-server-api/#molmv1curve25519-aes-sha2 and https://spec.matrix.org/v1.19/client-server-api/#mmegolmv1aes-sha2) is rather confusing, which I'm trying to improve by fixing the following issues (as discussed with @richvdh and @andybalaam):
- we can only really define the format of `content`, any properties like `type` alongside `content` are already fixed by how events look like (which is why they are now mentioned in the accompanying text)
- importantly, events also have a `sender` property alongside `content`, which wasn't present in the JSON snippet before, but is referenced further below
- the old placeholders for `body` contained "payload", which is a very overloaded term
- the description of `ciphertext` wasn't really correct
- for Megolm, a reference to the message format was missing

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)


























<!-- Replace -->
Preview: https://pr2413--matrix-spec-previews.netlify.app
<!-- Replace -->
