### PR TITLE
rename payload -> body in Olm and Megolm specification

### DIFF
--- a/changelogs/client_server/newsfragments/2414.clarification
+++ b/changelogs/client_server/newsfragments/2414.clarification
@@ -1,0 +1,1 @@
+Rename `Payload` in the Olm/Megolm specification to `Body` to avoid confusion with the distict `OlmPayload`.

--- a/changelogs/client_server/newsfragments/2414.clarification
+++ b/changelogs/client_server/newsfragments/2414.clarification
@@ -1,1 +1,1 @@
-Rename `Payload` in the Olm/Megolm specification to `Body` to avoid confusion with the distict `OlmPayload`.
+Rename `Payload` in the Olm/Megolm specification to `Body` to avoid confusion with the distinct `OlmPayload`.

--- a/content/olm-megolm/megolm.md
+++ b/content/olm-megolm/megolm.md
@@ -147,7 +147,7 @@ and the IV \(\mathit{AES\_IV}_{i}\) to give the cipher-text, \(X_{i}\).
 
 The ratchet index \(i\), and the cipher-text \(X_{i}\), are then packed
 into a message as described in [Message format](#message-format). Then the entire message
-(including the version bytes and all payload bytes) are passed through
+(including the version byte and all body bytes) are passed through
 HMAC-SHA-256. The first 8 bytes of the MAC are appended to the message.
 
 Finally, the authenticated message is signed using the Ed25519 keypair; the 64
@@ -240,19 +240,19 @@ part of the Ed25519 keypair \(K\).
 ### Message format
 
 Megolm messages consist of a one byte version, followed by a variable length
-payload, a fixed length message authentication code, and a fixed length
+body, a fixed length message authentication code, and a fixed length
 signature.
 
 ```nohighlight
 +---+------------------------------------+-----------+------------------+
-| V | Payload Bytes                      | MAC Bytes | Signature Bytes  |
+| V | Body Bytes                         | MAC Bytes | Signature Bytes  |
 +---+------------------------------------+-----------+------------------+
 0   1                                    N          N+8                N+72   bytes
 ```
 
 The version byte, ``V``, is ``"\x03"``.
 
-The payload uses a format based on the [Protocol Buffers encoding][]. It
+The body uses a format based on the [Protocol Buffers encoding][]. It
 consists of the following key-value pairs:
 
 **Name**|**Tag**|**Type**|**Meaning**
@@ -260,7 +260,7 @@ consists of the following key-value pairs:
 Message-Index|0x08|Integer|The index of the ratchet, i
 Cipher-Text|0x12|String|The cipher-text, Xi, of the message
 
-Within the payload, integers are encoded using a variable length encoding. Each
+Within the body, integers are encoded using a variable length encoding. Each
 integer is encoded as a sequence of bytes with the high bit set followed by a
 byte with the high bit clear. The seven low bits of each byte store the bits of
 the integer. The least significant bits are stored in the first byte.
@@ -270,7 +270,7 @@ Strings are encoded as a variable-length integer followed by the string itself.
 Each key-value pair is encoded as a variable-length integer giving the tag,
 followed by a string or variable-length integer giving the value.
 
-The payload is followed by the MAC. The length of the MAC is determined by the
+The body is followed by the MAC. The length of the MAC is determined by the
 authenticated encryption algorithm being used (8 bytes in this version of the
 protocol). The MAC protects all of the bytes preceding the MAC.
 

--- a/content/olm-megolm/olm.md
+++ b/content/olm-megolm/olm.md
@@ -201,17 +201,17 @@ a means for recipients to distinguish between them.
 ### Normal Messages
 
 Olm messages start with a one byte version followed by a variable length
-payload followed by a fixed length message authentication code.
+body followed by a fixed length message authentication code.
 
 ```nohighlight
  +--------------+------------------------------------+-----------+
- | Version Byte | Payload Bytes                      | MAC Bytes |
+ | Version Byte | Body Bytes                         | MAC Bytes |
  +--------------+------------------------------------+-----------+
 ```
 
 The version byte is ``"\x03"``.
 
-The payload consists of key-value pairs where the keys are integers and the
+The body consists of key-value pairs where the keys are integers and the
 values are integers and strings. The keys are encoded as a variable length
 integer tag where the 3 lowest bits indicates the type of the value:
 0 for integers, 2 for strings. If the value is an integer then the tag is
@@ -237,17 +237,17 @@ MAC protects all of the bytes preceding the MAC.
 ### Pre-Key Messages
 
 Olm pre-key messages start with a one byte version followed by a variable
-length payload.
+length body.
 
 ```nohighlight
  +--------------+------------------------------------+
- | Version Byte | Payload Bytes                      |
+ | Version Byte | Body Bytes                         |
  +--------------+------------------------------------+
 ```
 
 The version byte is ``"\x03"``.
 
-The payload uses the same key-value format as for normal messages.
+The body uses the same key-value format as for normal messages.
 
 **Name**|**Tag**|**Type**|**Meaning**
 :-----:|:-----:|:-----:|:-----:
@@ -276,7 +276,7 @@ message key using [HKDF-SHA-256][] using the default salt and an info of
 The plain-text is encrypted with AES-256, using the key \(AES\_KEY_{i,j}\)
 and the IV \(AES\_IV_{i,j}\) to give the cipher-text, \(X_{i,j}\).
 
-Then the entire message (including the Version Byte and all Payload Bytes) are
+Then the entire message (including the version byte and all body bytes) are
 passed through [HMAC-SHA-256][]. The first 8 bytes of the MAC are appended to the message.
 
 ## Message authentication concerns


### PR DESCRIPTION
The term "payload" is (very confusingly) used for two different things in regards to Olm/Megolm:
1. The [`OlmPayload`](https://spec.matrix.org/v1.19/client-server-api/#molmv1curve25519-aes-sha2) struct in the Client-Server API – which is the plaintext corresponding to the "Cipher-Text" that is part of ...
2. the [`Payload Bytes`](https://spec.matrix.org/v1.19/olm-megolm/olm/#normal-messages) in the Olm specification.

To reduce confusion, I suggest renaming the `Payload` in the Olm and Megolm specification to `Body`.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)








<!-- Replace -->
Preview: https://pr2414--matrix-spec-previews.netlify.app
<!-- Replace -->
