### PR TITLE
Rename OlmPayload -> OlmPlaintext to avoid confusion with Olm message Payload Bytes

### DIFF
--- a/changelogs/client_server/newsfragments/2418.clarification
+++ b/changelogs/client_server/newsfragments/2418.clarification
@@ -1,0 +1,1 @@
+Rename OlmPayload to OlmPlaintext to avoid confusion with Olm message Payload Bytes.

--- a/content/client-server-api/modules/end_to_end_encryption.md
+++ b/content/client-server-api/modules/end_to_end_encryption.md
@@ -1762,12 +1762,9 @@ Messages with type 1 can only be decrypted with an existing session. If
 there is no matching session, the client must treat this as an invalid
 message.
 
-The plaintext payload is of the form:
+The plaintext corresponding to the "Cipher-Text" in an an [Olm message](/olm-megolm/olm/#normal-messages) is of the form:
 
-{{% definition path="api/client-server/definitions/olm_payload" %}}
-
-The type and content of the plaintext message event are given in the
-payload.
+{{% definition path="api/client-server/definitions/olm_plaintext" %}}
 
 If a client has multiple sessions established with another device, it
 should use the session from which it last received and successfully

--- a/data/api/client-server/definitions/olm_plaintext.yaml
+++ b/data/api/client-server/definitions/olm_plaintext.yaml
@@ -14,9 +14,9 @@
 
 
 type: object
-title: OlmPayload
+title: OlmPlaintext
 description: |-
-  The plaintext payload of an event encrypted using Olm.
+  The plaintext of an event encrypted using Olm.
 properties:
   type:
     type: string

--- a/data/event-schemas/schema/m.room_key_bundle.yaml
+++ b/data/event-schemas/schema/m.room_key_bundle.yaml
@@ -13,7 +13,7 @@ description: |-
   [Olm](/client-server-api/#molmv1curve25519-aes-sha2).
 
   The `sender_device_keys` property in the [Olm
-  plaintext](/client-server-api/#definition-olmpayload) MUST be
+  plaintext](/client-server-api/#definition-olmplaintext) MUST be
   populated. Recipients SHOULD ignore `m.room_key_bundle` messages which omit
   them.
 properties:


### PR DESCRIPTION
Alternative to https://github.com/matrix-org/matrix-spec/pull/2414. As explained there:

The term "payload" is (very confusingly) used for two different things in regards to Olm/Megolm:
1. The [`OlmPayload`](https://spec.matrix.org/v1.19/client-server-api/#definition-olmpayload) struct in the Client-Server API – which is the plaintext corresponding to the "Cipher-Text" that is part of ...
2. the [`Payload Bytes`](https://spec.matrix.org/v1.19/olm-megolm/olm/#normal-messages) in the Olm specification.

To reduce confusion, I suggest renaming the `OlmPayload` to `OlmPlaintext`.

I tried to catch any references to the term "payload" in this context, but note that there's also https://github.com/matrix-org/matrix-spec/pull/2413 which already removes some occurrences.

I also renamed the `olm_payload.yaml` file to `olm_plaintext.yaml`, is that okay/desired, or might that break something (which I might not have seen when searching for "payload" throughout the spec)?


### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)





<!-- Replace -->
Preview: https://pr2418--matrix-spec-previews.netlify.app
<!-- Replace -->
