### PR TITLE
Clarify user `avatar_url`s to always use MXC URIs

### DIFF
--- a/changelogs/client_server/newsfragments/2422.clarification
+++ b/changelogs/client_server/newsfragments/2422.clarification
@@ -1,0 +1,1 @@
+Use MXC URI type for all user `avatar_url` fields. Contributed by @networkException.

--- a/data/api/client-server/definitions/public_rooms_chunk.yaml
+++ b/data/api/client-server/definitions/public_rooms_chunk.yaml
@@ -54,7 +54,8 @@ properties:
     example: true
   avatar_url:
     type: string
-    format: uri
+    format: mx-mxc-uri
+    pattern: "^mxc:\\/\\/"
     description: The URL for the room's avatar, if one is set.
     example: "mxc://example.org/abcdef"
   join_rule:

--- a/data/api/client-server/rooms.yaml
+++ b/data/api/client-server/rooms.yaml
@@ -340,7 +340,8 @@ paths:
                             description: The display name of the user this object is representing.
                           avatar_url:
                             type: string
-                            format: uri
+                            format: mx-mxc-uri
+                            pattern: "^mxc:\\/\\/"
                             description: The avatar of the user this object is representing, as an [`mxc://`
                               URI](/client-server-api/#matrix-content-mxc-uris).
                     description: A map from user ID to a RoomMember object.

--- a/data/api/client-server/search.yaml
+++ b/data/api/client-server/search.yaml
@@ -238,7 +238,8 @@ paths:
                                               title: Display name
                                             avatar_url:
                                               type: string
-                                              format: uri
+                                              format: mx-mxc-uri
+                                              pattern: "^mxc:\\/\\/"
                                               title: Avatar Url
                                     events_before:
                                       type: array

--- a/data/api/client-server/users.yaml
+++ b/data/api/client-server/users.yaml
@@ -90,7 +90,8 @@ paths:
                           description: The display name of the user, if one exists.
                         avatar_url:
                           type: string
-                          format: uri
+                          format: mx-mxc-uri
+                          pattern: "^mxc:\\/\\/"
                           example: mxc://bar.com/foo
                           description: The avatar url, as an [`mxc://`
                             URI](/client-server-api/#matrix-content-mxc-uris),

--- a/data/api/server-server/query.yaml
+++ b/data/api/server-server/query.yaml
@@ -172,6 +172,8 @@ paths:
                     example: John Doe
                   avatar_url:
                     type: string
+                    format: mx-mxc-uri
+                    pattern: "^mxc:\\/\\/"
                     description: |-
                       The avatar URL for the user's avatar. MUST either be omitted or set to
                       `null` if the user does not have an avatar set.

--- a/data/event-schemas/schema/m.presence.yaml
+++ b/data/event-schemas/schema/m.presence.yaml
@@ -12,6 +12,8 @@
             "properties": {
                 "avatar_url": {
                     "type": "string",
+                    "format": "mx-mxc-uri",
+                    "pattern": "^mxc:\\/\\/",
                     "description": "The current avatar URL for this user, if any."
                 },
                 "displayname": {

--- a/data/event-schemas/schema/m.room.member.yaml
+++ b/data/event-schemas/schema/m.room.member.yaml
@@ -53,7 +53,8 @@ properties:
       avatar_url:
         description: 'The avatar URL for this user, if any.'
         type: string
-        format: uri
+        format: mx-mxc-uri
+        pattern: "^mxc:\\/\\/"
       displayname:
         description: 'The display name for this user, if any.'
         type:


### PR DESCRIPTION
Previously the spec would use a mix of `string`, `URI` and `MXC URI` for values of a user's `avatar_url` in different apis (like `m.room.member`, `m.presence`, CS profile endpoints).

This clarification updates all occurances to be MXC URIs, prompted by https URIs `m.room.member#avatar_url` events in the wild.

### Pull Request Checklist

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [ ] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)


<!-- Replace -->
Preview: https://pr2422--matrix-spec-previews.netlify.app
<!-- Replace -->
