### PR TITLE
Restore legacy well-known URI anchor

### DIFF
--- a/changelogs/client_server/newsfragments/2429.clarification
+++ b/changelogs/client_server/newsfragments/2429.clarification
@@ -1,0 +1,1 @@
+Restore the legacy singular anchor for the well-known URI section.

--- a/content/client-server-api/_index.md
+++ b/content/client-server-api/_index.md
@@ -415,6 +415,8 @@ valid data was obtained, but no server is available to serve the client.
 No further guess should be attempted and the user should make a
 conscientious decision what to do next.
 
+<a id="well-known-uri"></a>
+
 ### Well-known URIs
 
 Matrix facilitates automatic discovery for the Client-Server API base URL and more via the

--- a/content/client-server-api/_index.md
+++ b/content/client-server-api/_index.md
@@ -415,9 +415,7 @@ valid data was obtained, but no server is available to serve the client.
 No further guess should be attempted and the user should make a
 conscientious decision what to do next.
 
-<a id="well-known-uri"></a>
-
-### Well-known URIs
+### Well-known URIs {#well-known-uri}
 
 Matrix facilitates automatic discovery for the Client-Server API base URL and more via the
 [RFC 8615](https://datatracker.ietf.org/doc/html/rfc8615) "Well-Known URI" method.


### PR DESCRIPTION
Fixes #2425.

Restores the singular `well-known-uri` anchor referenced by the IANA registration while preserving the current plural heading anchor.

### Pull Request Checklist

* [x] Pull request includes a changelog file
* [x] Pull request includes a sign off
* [x] Pull request is classified as "other changes"
