### PR TITLE
Fix conflicting information on requirement of fragment response mode

### DIFF
--- a/changelogs/client_server/newsfragments/2430.clarification
+++ b/changelogs/client_server/newsfragments/2430.clarification
@@ -1,0 +1,1 @@
+Fixed conflicting information on whether clients using the authorisation code grant are required to use the `fragment` response mode.

--- a/content/client-server-api/_index.md
+++ b/content/client-server-api/_index.md
@@ -2409,9 +2409,9 @@ To use this grant, homeservers and clients MUST:
 - Support the [refresh token grant](#refresh-token-grant).
 - Support PKCE using the `S256` code challenge method as per [RFC 7636](https://datatracker.ietf.org/doc/html/rfc7636).
 - Use [pre-registered](#client-registration), strict redirect URIs.
-- Use the `fragment` response mode as per [OAuth 2.0 Multiple Response Type
-  Encoding Practices](https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html)
-  for clients with an HTTPS redirect URI.
+
+Clients with an HTTPS redirect URI SHOULD use the `fragment` response mode as per
+[OAuth 2.0 Multiple Response Type Encoding Practices](https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html).
 
 ##### Device authorisation grant
 


### PR DESCRIPTION
https://spec.matrix.org/v1.19/client-server-api/#authorisation-code-flow currently states that

> To avoid disclosing the parameters to the web server hosting the `redirect_uri`, clients SHOULD use the `fragment` response mode if the `redirect_uri` is an HTTPS URI with a remote host.

https://spec.matrix.org/v1.19/client-server-api/#authorisation-code-grant has conflicting information, it says

> To use this grant, homeservers and clients MUST:
> * ...
> * Use the fragment response mode as per [OAuth 2.0 Multiple Response Type Encoding Practices](https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html) for clients with an HTTPS redirect URI.

I think `SHOULD` makes more sense, because the client may be running on the server rather than in the browser, in which case disclosing the parameters to the web server is the goal. All `MUST` would do is force the web server to serve an unnecessary interstitial page that uploads the parameters with javascript.

Both MAS and continuwuity appear to already allow the `query` response mode with https redirect URIs, neither of them implemented the `MUST` half of the spec.

### Pull Request Checklist

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)


<!-- Replace -->
Preview: https://pr2430--matrix-spec-previews.netlify.app
<!-- Replace -->
