### PR TITLE
Link to OAuth RFCs for error response definitions

### DIFF
--- a/changelogs/client_server/newsfragments/2432.clarification
+++ b/changelogs/client_server/newsfragments/2432.clarification
@@ -1,0 +1,1 @@
+Link to the relevant OAuth 2.0 RFCs for the structure of error responses on the OAuth 2.0 API endpoints.

--- a/content/client-server-api/_index.md
+++ b/content/client-server-api/_index.md
@@ -56,8 +56,9 @@ requirements for server responses.
 
 ### Standard error response
 
-Any errors which occur at the Matrix API level MUST return a "standard
-error response". This is a JSON object which looks like:
+Any errors which occur at the Matrix API level (for requests that are within
+scope of these [API Standards](#api-standards)) MUST return a "standard error
+response". This is a JSON object which looks like:
 
 ```json
 {
@@ -1860,7 +1861,8 @@ A successful authorisation will have a `code` value, for example:
 https://app.example.com/oauth2-callback#state=ewubooN9weezeewah9fol4oothohroh3&code=iuB7Eiz9heengah1joh2ioy9ahChuP6R
 ```
 
-A failed authorisation will have the following values:
+A failed authorisation will have the following values as defined by
+[RFC 6749 section 4.1.2.1](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1):
 
 - `error`: the error code
 - `error_description`: the error description (optional)
@@ -1890,6 +1892,12 @@ parameters, encoded as `application/x-www-form-urlencoded` in the body:
 
 The server replies with a JSON object containing the access token, the token
 type, the expiration time, and the refresh token.
+
+{{% boxes/note %}}
+Error responses to this request do not follow the Matrix [standard error
+response](#standard-error-response) structure and are instead defined by
+[RFC 6749 section 5.2](https://datatracker.ietf.org/doc/html/rfc6749#section-5.2).
+{{% /boxes/note %}}
 
 Sample token request:
 
@@ -1978,6 +1986,12 @@ containing:
 
 It is RECOMMENDED that the server provides a `verification_uri_complete` such
 that the user does not need to type in the `user_code`.
+
+{{% boxes/note %}}
+Error responses do not follow the Matrix [standard error response](#standard-error-response)
+structure and are instead defined by [RFC 6749 section 5.2](https://datatracker.ietf.org/doc/html/rfc6749#section-5.2),
+as required by [RFC 8628 section 3.2](https://datatracker.ietf.org/doc/html/rfc8628#section-3.2).
+{{% /boxes/note %}}
 
 Sample response:
 
@@ -2076,6 +2090,12 @@ request to the `token_endpoint` with the following parameters, encoded as
 The server replies with a JSON object containing the new access token, the token
 type, the expiration time, and a new refresh token, like in the authorisation
 flow.
+
+{{% boxes/note %}}
+Error responses to this request do not follow the Matrix [standard error
+response](#standard-error-response) structure and are instead defined by
+[RFC 6749 section 5.2](https://datatracker.ietf.org/doc/html/rfc6749#section-5.2).
+{{% /boxes/note %}}
 
 #### Server metadata discovery
 
@@ -2238,6 +2258,12 @@ Server: auth.example.com
 Upon successful registration, the server replies with an `HTTP 201 Created`
 response, with a JSON object containing the allocated `client_id` and all the
 registered metadata values.
+
+{{% boxes/note %}}
+Error responses to this request do not follow the Matrix [standard error
+response](#standard-error-response) structure and are instead defined by
+[RFC 7591 section 3.2.2](https://datatracker.ietf.org/doc/html/rfc7591#section-3.2.2).
+{{% /boxes/note %}}
 
 With the registration request above, the server might reply with:
 
@@ -2546,6 +2572,12 @@ The server SHOULD return one of the following responses:
   `401 Unauthorized` response
 - For other errors, the server returns a `400 Bad Request` response with error
   details
+
+{{% boxes/note %}}
+Error responses to this request do not follow the Matrix [standard error
+response](#standard-error-response) structure and are instead defined by
+[RFC 7009 section 2.2.1](https://datatracker.ietf.org/doc/html/rfc7009#section-2.2.1).
+{{% /boxes/note %}}
 
 #### User registration
 


### PR DESCRIPTION
The Client-Server [API standards](https://spec.matrix.org/v1.19/client-server-api/#api-standards) says at that they don't apply to OAuth 2.0 (and other unspecified) endpoints:

> These standards only apply to the APIs defined in the Matrix specification. APIs used by this specification but defined in other specifications, like the [OAuth 2.0 API](https://spec.matrix.org/v1.19/client-server-api/#oauth-20-api), use their own rules.

But this detail can be lost when you are reading about the OAuth 2.0 flows lower down on the page. Particularly in the case of errors where we don't always given examples of the error responses.

In this PR I have attempt to make the situation better by:

- adding explicit notes next to where OAuth 2.0 API responses are documented and link to where the error responses are actually defined
- clarifying within the "standard error responses" section that it doesn't apply to OAuth 2.0

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#adding-to-the-changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#sign-off)
* [x] Pull request is classified as ['other changes'](https://github.com/matrix-org/matrix-spec/blob/master/CONTRIBUTING.rst#other-changes)

Signed-off-by: Hugh Nimmo-Smith <hughns@element.io>


<!-- Replace -->
Preview: https://pr2432--matrix-spec-previews.netlify.app
<!-- Replace -->
